### PR TITLE
fix: 🐛 로그인 response 수정

### DIFF
--- a/src/api/@types/User.ts
+++ b/src/api/@types/User.ts
@@ -9,6 +9,7 @@ export interface UserLoginResponse {
   name: string;
   registered: boolean;
   authority: Authority;
+  accessToken: string;
 }
 
 export interface UserClient {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -32,7 +32,7 @@ const authOptions: NextAuthOptions = {
         const response = await UserService.login({
           accessToken: account.access_token,
         });
-        user.accessToken = account.access_token;
+        user.accessToken = response.accessToken;
         user.registered = response.registered;
         user.authority = response.authority;
         user.id = response.id;
@@ -44,7 +44,8 @@ const authOptions: NextAuthOptions = {
       }
     },
     // 구글 로그인 성공 후 callback
-    jwt: async ({ token, user }) => {
+    jwt: ({ token, user }) => {
+      if (!user) return token;
       token.accessToken = user.accessToken;
       token.registered = user.registered;
       token.authority = user.authority;


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

- 로그인 response 수정
  - axios response interceptor에서 response data 만 unwrap 해서 반환
  - 기존 `v1/user/info` API response가 header의 Authorization에 JWT 값을 set 해서 전달하기 때문에 body의 accessToken 필드에 담아 전달하는 것으로 수정
- next/auth jwt callback 실행 시 early return 추가
  - jwt callback이 useSession 훅 호출 시에도 실행되는데 이 때 user param이 `undefined` 이므로 user param의 속성에 접근하면서 에러 발생 (Reference 참고)
  - user param을 체크해서 early return을 하도록 수정
  - 참고로 signout 처리 시에는 next auth의 signOut 훅을 사용하면 session을 삭제해주기 때문에 jwt callback의 early return에 의한 영향은 없음

### Todo

- N/A

### Issue

- N/A

### Reference

- [next-auth jwt callback](https://next-auth.js.org/configuration/callbacks#jwt-callback)
- [next-auth signout](https://next-auth.js.org/getting-started/client#signout)
