### PR TITLE
fix: FormItem vertical 트리거를 반응형 에서 prop 으로 변경

### DIFF
--- a/src/components/@shared/FormItem.tsx
+++ b/src/components/@shared/FormItem.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn';
 
 export interface FormItemProps {
   label: ReactNode;
+  layout?: 'vertical' | 'horizontal';
   required?: boolean;
   error?: string | boolean;
   fit?: boolean;
@@ -19,6 +20,7 @@ export interface FormItemProps {
 const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
   children,
   label,
+  layout = 'horizontal',
   required,
   error,
   fit,
@@ -27,11 +29,10 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
   return (
     <label
       className={cn([
-        'grid gap-x-[16px] gap-y-[12px] items-center grid-rows-max auto-rows-max',
-        'tablet:gap-y-[6px]',
-        {
-          'tablet:grid-cols-[max-content_1fr]': !fit,
-          'tablet:grid-cols-[max-content_max-content]': fit,
+        'grid gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
+        layout === 'horizontal' && {
+          'grid-cols-[max-content_1fr]': !fit,
+          'grid-cols-[max-content_max-content]': fit,
         },
         classNames?.container,
       ])}
@@ -46,11 +47,15 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
       }}
     >
       <Typography
-        type='body2'
+        type={layout === 'horizontal' ? 'body2' : 'detail2'}
         data-custom-role='form-item-title'
         overflow='break-keep'
         className={cn([
-          'relative text-start tablet:text-right',
+          'relative pr-[12px]',
+          {
+            'text-start text-gray-300': layout === 'vertical',
+            'text-right': layout === 'horizontal',
+          },
           required && "after:ml-[0.2em] after:text-red-300 after:content-['*']",
           classNames?.label,
         ])}
@@ -59,7 +64,6 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
       </Typography>
 
       <div
-        data-custom-role='form-item-label'
         className={cn([
           'leading-none' /* FIXME: 이 속성이 들어간 이유 스레드 내용 참고 - https://pfplay.slack.com/files/U05CVKV905U/F05RGLGFE14/image.png */,
           fit && 'w-max',
@@ -72,7 +76,12 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
 
       {typeof error === 'string' && (
         <>
-          <div className='hidden tablet:block' />
+          <div
+            className={cn({
+              hidden: layout === 'vertical',
+              block: layout === 'horizontal',
+            })}
+          />
 
           <Typography
             type='caption1'

--- a/src/stories/FormItem.stories.tsx
+++ b/src/stories/FormItem.stories.tsx
@@ -50,6 +50,22 @@ export const Align = {
   ),
 };
 
+export const Vertical = {
+  render: () => (
+    <form className='flex flex-col gap-[20px]'>
+      <FormItem label='Label' layout='vertical' required>
+        <input className={TEMP_INPUT_STYLES} />
+      </FormItem>
+      <FormItem label='LabelAAAAA' layout='vertical'>
+        <input className={TEMP_INPUT_STYLES} />
+      </FormItem>
+      <FormItem label='LabelBBB' layout='vertical' error='Error'>
+        <input className={TEMP_INPUT_STYLES} />
+      </FormItem>
+    </form>
+  ),
+};
+
 export const Fit: Story = {
   args: {
     label: 'Label',
@@ -96,7 +112,7 @@ export const ProcessError = (args: Omit<FormItemProps, 'label' | 'error'>) => {
         onSubmit={handleSubmit((data) => {
           alert(JSON.stringify(data, null, 2));
         })}
-        className='flex flex-col gap-[20px] child-form-labels:w-[100px]'
+        className='flex flex-col gap-[20px] child-form-labels:w-[120px]'
       >
         <FormItem label='Checkbox' error={errors.myBool?.message} required fit {...args}>
           <input type='checkbox' className='w-[20px] h-[20px]' {...register('myBool')} />


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
FormItem 컴포넌트의 라벨 레이아웃이 좁은화면 수직 + 넓은 화면 수평으로 반응형으로 구성되어 있었으나,
디자인 시스템에 따라 prop 에 따라 수직 수평을 구분할 수 있도록 변경합니다.
 
![image](https://github.com/pfplay/pfplay-web/assets/57123802/7bd189d4-e6eb-4211-8c80-c52296bf2665)

<img width="1064" alt="image" src="https://github.com/pfplay/pfplay-web/assets/57123802/86734c1b-da77-4395-b873-884ec656fc8f">
