### PR TITLE
feat: Typography "as" prop

### DIFF
--- a/src/components/@shared/@atoms/Typography.tsx
+++ b/src/components/@shared/@atoms/Typography.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { forwardRef, ReactNode } from 'react';
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 
 export type TypographyType =
@@ -14,11 +14,11 @@ export type TypographyType =
   | 'caption2';
 type TypographyOverflow = 'ellipsis' | 'break-words' | 'break-all' | 'break-normal' | 'break-keep';
 
-export interface TypographyProps extends React.ComponentProps<'p'> {
+export interface TypographyProps extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
   type?: TypographyType;
   overflow?: TypographyOverflow;
-  inline?: boolean;
+  as?: keyof Pick<JSX.IntrinsicElements, 'h1' | 'h2' | 'p' | 'span'>;
 }
 
 const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
@@ -29,24 +29,16 @@ const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
       type = 'detail1',
       overflow = titleTypes.includes(type) ? 'ellipsis' : undefined,
       title = overflow === 'ellipsis' && typeof children === 'string' ? children : undefined,
-      inline,
+      as: El = defaultElDict[type],
       ...rest
     },
     ref
   ) => {
-    const El = elDict[type];
-
     return (
       <El
         ref={ref}
         title={title}
-        className={cn([
-          typoStyleDict[type],
-          overflow && overflowDict[overflow],
-          inline && 'inline-block',
-
-          className,
-        ])}
+        className={cn([typoStyleDict[type], overflow && overflowDict[overflow], className])}
         {...rest}
       >
         {children}
@@ -55,17 +47,18 @@ const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
   }
 );
 
-const elDict: Record<TypographyType, keyof Pick<JSX.IntrinsicElements, 'h1' | 'h2' | 'p'>> = {
-  title1: 'h1',
-  title2: 'h2',
-  body1: 'p',
-  body2: 'p',
-  body3: 'p',
-  detail1: 'p',
-  detail2: 'p',
-  caption1: 'p',
-  caption2: 'p',
-};
+const defaultElDict: Record<TypographyType, keyof Pick<JSX.IntrinsicElements, 'h1' | 'h2' | 'p'>> =
+  {
+    title1: 'h1',
+    title2: 'h2',
+    body1: 'p',
+    body2: 'p',
+    body3: 'p',
+    detail1: 'p',
+    detail2: 'p',
+    caption1: 'p',
+    caption2: 'p',
+  };
 const titleTypes: TypographyType[] = ['title1', 'title2'];
 
 const typoStyleDict: Record<TypographyType, string> = {

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -79,20 +79,20 @@ export const Overflow = () => {
   );
 };
 
-export const Inline = () => {
+export const As = () => {
   return (
     <section className='flexCol w-[400px] gap-[10px]'>
-      <PropDesc tag='inline: false'>
+      <PropDesc tag='as=undefined'>
         <section>
-          <Typography inline={false}>Content 1</Typography>
-          <Typography inline={false}>Content 2</Typography>
+          <Typography>Content 1</Typography>
+          <Typography>Content 2</Typography>
         </section>
       </PropDesc>
 
-      <PropDesc tag='inline: true'>
+      <PropDesc tag='as="span"'>
         <section>
-          <Typography inline={true}>Content 1</Typography>
-          <Typography inline={true}>Content 2</Typography>
+          <Typography as='span'>Content 1</Typography>
+          <Typography as='span'>Content 2</Typography>
         </section>
       </PropDesc>
     </section>


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
<img width="461" alt="image" src="https://github.com/pfplay/pfplay-web/assets/57123802/8fb1d552-8180-403a-9fd0-46be94b40769">

Typography 에 as prop 을 추가합니다.

기존 as="span" 이 가능해지면서 기존 inline prop 은 불필요하다 여겨져 제거합니다.
 
