### PR TITLE
refactor: generate-enums 스크립트 동작 방식 변경

### DIFF
--- a/scripts/copyJavaEnums/.gitignore
+++ b/scripts/copyJavaEnums/.gitignore
@@ -1,1 +1,1 @@
-/enums
+/api

--- a/scripts/copyJavaEnums/index.js
+++ b/scripts/copyJavaEnums/index.js
@@ -1,36 +1,22 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
+const { glob } = require('glob');
 
-const ROOT = `${__dirname}/../../`;
-const JAVA_ENUMS_DIRNAME = `${__dirname}/enums`; // 백엔드 common/enums 디렉터리를 임시로 카피해오세요
+const ROOT = `${__dirname}/../..`;
+const BACKEND_DIRNAME = `${__dirname}/api`; // 백엔드의 소스 디렉터리(main/java/com/pfplaybackend/api)를 카피해오세요
 const ENUMS_DIRNAME = `${ROOT}/src/api/@types`;
 const ENUMS_FILENAME = `${ENUMS_DIRNAME}/@enums.ts`;
-const exceptionEnumNames = new Set(['ExceptionEnum']);
+const exceptionEnumNames = new Set(['ExceptionEnum', 'ApiHeader', 'Domain']);
 
 main();
 
 function main() {
-  const enums = fs.readdirSync(JAVA_ENUMS_DIRNAME).reduce((acc, fileName) => {
-    const content = fs.readFileSync(`${JAVA_ENUMS_DIRNAME}/${fileName}`, { encoding: 'utf8' });
+  const allBackendFiles = glob.sync(`${BACKEND_DIRNAME}/**/*.java`);
 
-    const enumNameRegex = /(?<=public enum )([A-Z]\w+)/;
-    const enumName = enumNameRegex.exec(content)[1];
-
-    if (exceptionEnumNames.has(enumName)) {
-      return acc;
-    }
-
-    const enumFieldsRegex = /(?<enumValue>[A-Z_]+)(?:\("(?<enumLabel>.+)"\)|,)/g;
-    const enumFields = [...content.matchAll(enumFieldsRegex)].map((v) => v.groups);
-
-    const enumStr = `
-export enum ${enumName} {
-${enumFields.map(({ enumValue }) => `${enumValue} = '${enumValue}'`).join(',\n')}
-}`.trim();
-
-    acc.push(enumStr);
-    return acc;
-  }, []);
+  const enums = allBackendFiles.flatMap((file) => {
+    const content = fs.readFileSync(file, { encoding: 'utf-8' });
+    return extractEnums(content);
+  });
 
   mkdir(ENUMS_DIRNAME);
 
@@ -39,6 +25,41 @@ ${enumFields.map(({ enumValue }) => `${enumValue} = '${enumValue}'`).join(',\n')
   execSync(`eslint ${ENUMS_FILENAME} --fix --quiet`);
 
   console.log('🛠️Enums generated.');
+}
+
+function extractEnums(content) {
+  const enums = [];
+  const enumRegex = /public enum (?<enumName>\w+)\s*{(?<enumBody>[^}]*)}/g;
+  let match;
+
+  while ((match = enumRegex.exec(content)) !== null) {
+    const { enumName, enumBody } = match.groups;
+
+    if (exceptionEnumNames.has(enumName)) continue;
+
+    const enumValues = enumBody
+      .split(',')
+      .reduce((acc, v) => {
+        const trimmedValue = v.trim();
+        if (!trimmedValue) return acc;
+
+        const additionalDataMatch = trimmedValue.match(/(?<key>\w+)\s*\("(?<value>[^"]+)"\)/);
+        const result = additionalDataMatch
+          ? `${additionalDataMatch.groups.key} = "${additionalDataMatch.groups.value}"` // "KEY("VALUE")" 형태의 enum 항목을 처리
+          : /^\w+$/.test(trimmedValue) // "KEY" 형태의 enum 항목을 처리
+          ? `${trimmedValue} = "${trimmedValue}"`
+          : trimmedValue; // 그 외의 형태(주로 주석이나 공백)는 그대로 유지
+
+        acc.push(result);
+        return acc;
+      }, [])
+      .join(', ');
+
+    const tsEnum = `export enum ${enumName} { ${enumValues} }`;
+    enums.push(tsEnum);
+  }
+
+  return enums;
 }
 
 function mkdir(dirname) {

--- a/src/api/@types/@enums.ts
+++ b/src/api/@types/@enums.ts
@@ -1,6 +1,19 @@
-export enum ApiHeader {
-  AUTHORIZATION = 'AUTHORIZATION',
-  BEARER = 'BEARER',
+export enum PartyRoomType {
+  PARTY = 'PARTY',
+  MAIN = 'MAIN',
+}
+
+export enum PartyRoomStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+}
+
+export enum PartyPermissionRole {
+  ADMIN = 'ADMIN',
+  COMMUNITY_MANAGER = 'COMMUNITY_MANAGER',
+  MODERATOR = 'MODERATOR',
+  CLUBBER = 'CLUBBER',
+  LISTENER = 'LISTENER',
 }
 
 export enum Authority {
@@ -14,24 +27,4 @@ export enum AvatarType {
   DJ = 'DJ',
   REF = 'REF',
   ROOM = 'ROOM',
-}
-
-export enum Domain {
-  CLIENT = 'CLIENT',
-}
-
-export enum PartyPermissionRole {
-  ADMIN = 'ADMIN',
-  COMMUNITY_MANAGER = 'COMMUNITY_MANAGER',
-  MODERATOR = 'MODERATOR',
-  CLUBBER = 'CLUBBER',
-}
-
-export enum PartyRoomStatus {
-  ACTIVE = 'ACTIVE',
-}
-
-export enum PartyRoomType {
-  PARTY = 'PARTY',
-  MAIN = 'MAIN',
 }


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
#78 에서 작업한 generate-enums 스크립트의 동작방식이 기존에는 enum 이 들어있는 java 파일을 백엔드 레포를 뒤져서 전부 찾아 삽입해야 하는 방식이였는데, 이는 불편함이 심해 자바 소스 전체를 긁어다 넣으면 알아서 찾아주는 방식으로 변경합니다.

### Reference

<!--
  개발하시면서 도움이 되었던 참고자료들을 이곳에 적어주세요.
  다른 팀원들에게 큰 도움이 됩니다. :)
-->
정규식은 역시 ChatGPT

<img width="500" alt="image" src="https://github.com/pfplay/pfplay-web/assets/57123802/802b6f66-4c9f-4d48-a0bf-c596d64e8340">

