### PR TITLE
refactor: playlistAction

### DIFF
--- a/src/entities/playlist/index.ts
+++ b/src/entities/playlist/index.ts
@@ -3,3 +3,4 @@ export {
   type FormProps as PlaylistFormProps,
 } from './ui/playlist-form.component';
 export type { Model as PlaylistFormValues } from './model/playlist-form.model';
+export { PlaylistActionContext, usePlaylistAction } from './lib/playlist-action.context';

--- a/src/entities/playlist/lib/playlist-action.context.tsx
+++ b/src/entities/playlist/lib/playlist-action.context.tsx
@@ -1,0 +1,49 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { AddPlaylistMusicRequestBody, Playlist, PlaylistMusic } from '@/shared/api/types/playlist';
+
+export type PlaylistActionrOptions = {
+  onSuccess?: () => void;
+};
+
+type PlaylistAction = {
+  list: Playlist[];
+
+  add: () => void;
+  edit: (targetId: Playlist['id']) => void;
+  remove: (targetIds: Playlist['id'][], options?: PlaylistActionrOptions) => void;
+
+  addMusic: (targetId: Playlist['id'], music: AddPlaylistMusicRequestBody) => void;
+  /**
+   * TODO: API 측에 명세 문의 필요 - https://pfplay.slack.com/archives/C051N8A0ZSB/p1718969303410129
+   */
+  removeMusics: (/* targetId: Playlist['id'], */ musicIds: PlaylistMusic['musicId'][]) => void;
+  /**
+   * TODO: API 안나옴
+   */
+  // moveMusic: (from: Playlist['id'], to: Playlist['id'], musicId: PlaylistMusic['musicId']) => void;
+};
+
+export const PlaylistActionContext = createContext<PlaylistAction | null>(null);
+
+/**
+ * portal 내부(ex-dialog body)로 context value를 bypass할 때 사용
+ */
+export const PlaylistActionBypassProvider = ({
+  children,
+  action,
+}: {
+  children: ReactNode;
+  action: PlaylistAction;
+}) => {
+  return <PlaylistActionContext.Provider value={action}>{children}</PlaylistActionContext.Provider>;
+};
+
+export const usePlaylistAction = () => {
+  const context = useContext(PlaylistActionContext);
+
+  if (!context) {
+    throw new Error('usePlaylistAction must be used within a PlaylistActionProvider');
+  }
+
+  return context;
+};

--- a/src/entities/playlist/ui/playlist-form.component.tsx
+++ b/src/entities/playlist/ui/playlist-form.component.tsx
@@ -25,6 +25,7 @@ const Form = ({ defaultValues, onCancel, onSubmit }: FormProps) => {
           {...register('name')}
           placeholder='한/영 구분없이 띄어쓰기 포함 20자 제한'
           maxLength={20}
+          autoComplete='off'
         />
       </FormItem>
       <Dialog.ButtonGroup>

--- a/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
@@ -1,5 +1,5 @@
 import { AvatarService } from '@/shared/api/services/avatar';
-import AvatarListItem from 'features/edit-profile-avatar/ui/avatar-list-item.component';
+import AvatarListItem from './avatar-list-item.component';
 
 const AvatarBodyList = async () => {
   const bodyList = await AvatarService.getBodyList();

--- a/src/features/playlist/add-musics/index.ts
+++ b/src/features/playlist/add-musics/index.ts
@@ -1,1 +1,2 @@
 export { default as AddMusicsToPlaylistButton } from './ui/entry-button.component';
+export { useAddPlaylistMusic } from './api/use-add-playlist-music.mutation';

--- a/src/features/playlist/add-musics/ui/entry-button.component.tsx
+++ b/src/features/playlist/add-musics/ui/entry-button.component.tsx
@@ -1,3 +1,5 @@
+import { usePlaylistAction } from '@/entities/playlist';
+import { PlaylistActionBypassProvider } from '@/entities/playlist/lib/playlist-action.context';
 import { Button } from '@/shared/ui/components/button';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { PFAdd, PFClose } from '@/shared/ui/icons';
@@ -5,6 +7,7 @@ import YoutubeMusicSearch from './youtube-music-search.component';
 
 const EntryButton = () => {
   const { openDialog } = useDialog();
+  const playlistAction = usePlaylistAction();
 
   const handleAddMusic = () => {
     openDialog((_, onClose) => ({
@@ -12,13 +15,15 @@ const EntryButton = () => {
         container: '!p-[unset] w-[800px] bg-black border border-gray-700',
       },
       Body: (
-        <YoutubeMusicSearch
-          extraAction={
-            <button onClick={onClose}>
-              <PFClose width={24} height={24} />
-            </button>
-          }
-        />
+        <PlaylistActionBypassProvider action={playlistAction}>
+          <YoutubeMusicSearch
+            extraAction={
+              <button onClick={onClose}>
+                <PFClose width={24} height={24} />
+              </button>
+            }
+          />
+        </PlaylistActionBypassProvider>
       ),
       hideDim: true,
     }));

--- a/src/features/playlist/add-musics/ui/search-list-item.component.tsx
+++ b/src/features/playlist/add-musics/ui/search-list-item.component.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
-import { Playlist, YoutubeMusic } from '@/shared/api/types/playlist';
+import { usePlaylistAction } from '@/entities/playlist';
+import { YoutubeMusic } from '@/shared/api/types/playlist';
 import { IconMenu } from '@/shared/ui/components/icon-menu';
 import { MenuItem } from '@/shared/ui/components/menu';
 import { Typography } from '@/shared/ui/components/typography';
@@ -8,26 +9,28 @@ import { PFAddCircle, PFAddPlaylist } from '@/shared/ui/icons';
 
 type SearchListItemProps = {
   music: YoutubeMusic;
-  playlists?: Playlist[];
   onSelectPlaylist?: (id: number) => void;
-  onAddPlaylist?: () => void;
 };
 
 const SearchListItem = ({
   music: { title, duration, thumbnailMedium },
-  playlists = [],
   onSelectPlaylist,
-  onAddPlaylist,
 }: SearchListItemProps) => {
+  const playlistAction = usePlaylistAction();
+
   const menuItemConfig: MenuItem[] = useMemo(
-    () =>
-      playlists.map(({ name: label, id }) => ({
+    () => [
+      ...playlistAction.list.map(({ name: label, id }) => ({
         label,
-        onClickItem: () => {
-          onSelectPlaylist?.(id);
-        },
+        onClickItem: () => onSelectPlaylist?.(id),
       })),
-    [playlists, onSelectPlaylist]
+      {
+        label: '플레이리스트 추가',
+        Icon: <PFAddCircle />,
+        onClickItem: playlistAction.add,
+      },
+    ],
+    [playlistAction.list, playlistAction.add, onSelectPlaylist]
   );
 
   return (
@@ -41,16 +44,7 @@ const SearchListItem = ({
       <IconMenu
         MenuButtonIcon={<PFAddPlaylist />}
         menuItemPanel={{ className: 'm-w-[300px] border border-gray-500' }}
-        menuItemConfig={[
-          ...menuItemConfig,
-          {
-            label: '플레이리스트 추가',
-            Icon: <PFAddCircle />,
-            onClickItem: () => {
-              onAddPlaylist?.();
-            },
-          },
-        ]}
+        menuItemConfig={menuItemConfig}
       />
     </div>
   );

--- a/src/features/playlist/add-musics/ui/youtube-music-search.component.tsx
+++ b/src/features/playlist/add-musics/ui/youtube-music-search.component.tsx
@@ -1,13 +1,10 @@
 import { ReactNode, useState } from 'react';
-import PlaylistCreateForm from '@/features/playlist/add/ui/form.component';
-import { useFetchPlaylists } from '@/features/playlist/list/api/use-fetch-playlist.query';
+import { usePlaylistAction } from '@/entities/playlist';
 import { YoutubeMusic } from '@/shared/api/types/playlist';
-import { useDialog } from '@/shared/ui/components/dialog';
 import { InfiniteScroll } from '@/shared/ui/components/infinite-scroll';
 import { Typography } from '@/shared/ui/components/typography';
 import SearchInput from './search-input.component';
 import SearchListItem from './search-list-item.component';
-import { useAddPlaylistMusic } from '../api/use-add-playlist-music.mutation';
 import { useInfiniteFetchYoutubeMusics } from '../api/use-infinite-fetch-youtube-musics.query';
 
 type YoutubeMusicSearchProps = {
@@ -21,22 +18,10 @@ const YoutubeMusicSearch = ({ extraAction }: YoutubeMusicSearchProps) => {
     isFetchedAfterMount: isFetchedYoutubeMusicsAfterMount,
     hasNextPage: hasNextYoutubeMusicsPage,
   } = useInfiniteFetchYoutubeMusics(search);
-  const { data: playlists } = useFetchPlaylists();
-  const { mutate: addMusicToPlaylist } = useAddPlaylistMusic();
-  const { openDialog } = useDialog();
+  const playlistAction = usePlaylistAction();
 
-  const handleChangeSearch = (search: string) => {
-    setSearch(search);
-  };
-  const handleAddPlaylist = () => {
-    openDialog((_, onCancel) => ({
-      title: '플레이리스트 이름을 입력해주세요',
-      Body: <PlaylistCreateForm onCancel={onCancel} />,
-    }));
-  };
   const handleSelectPlaylist = (listId: number, music: YoutubeMusic) => {
-    addMusicToPlaylist({
-      listId,
+    playlistAction.addMusic(listId, {
       uid: music.id,
       thumbnailImage: music.thumbnailMedium,
       duration: music.duration,
@@ -48,7 +33,7 @@ const YoutubeMusicSearch = ({ extraAction }: YoutubeMusicSearchProps) => {
     <div className='pt-[36px] pb-[12px] pl-[40px] pr-[12px]'>
       <div className='flex items-center gap-7 mb-11 pr-[28px]'>
         <Typography type='title2'>곡 추가</Typography>
-        <SearchInput onSearch={handleChangeSearch} />
+        <SearchInput onSearch={setSearch} />
         {extraAction}
       </div>
 
@@ -71,8 +56,6 @@ const YoutubeMusicSearch = ({ extraAction }: YoutubeMusicSearchProps) => {
               <div key={music.id} className='py-3'>
                 <SearchListItem
                   music={music}
-                  playlists={playlists}
-                  onAddPlaylist={handleAddPlaylist}
                   onSelectPlaylist={(listId) => handleSelectPlaylist(listId, music)}
                 />
               </div>

--- a/src/features/playlist/add/index.ts
+++ b/src/features/playlist/add/index.ts
@@ -1,1 +1,2 @@
 export { default as AddPlaylistButton } from './ui/entry-button.component';
+export { default as useAddPlaylistDialog } from './ui/form.component';

--- a/src/features/playlist/add/ui/entry-button.component.tsx
+++ b/src/features/playlist/add/ui/entry-button.component.tsx
@@ -1,20 +1,12 @@
 import { Button } from '@/shared/ui/components/button';
-import { useDialog } from '@/shared/ui/components/dialog';
 import { PFAdd } from '@/shared/ui/icons';
-import Form from './form.component';
+import useAddPlaylistDialog from './form.component';
 
 const EntryButton = () => {
-  const { openDialog } = useDialog();
-
-  const handleAddList = () => {
-    openDialog((_, onCancel) => ({
-      title: '플레이리스트 이름을 입력해주세요',
-      Body: <Form onCancel={onCancel} />,
-    }));
-  };
+  const openAddDialog = useAddPlaylistDialog();
 
   return (
-    <Button size='sm' variant='outline' color='secondary' Icon={<PFAdd />} onClick={handleAddList}>
+    <Button size='sm' variant='outline' color='secondary' Icon={<PFAdd />} onClick={openAddDialog}>
       리스트 추가
     </Button>
   );

--- a/src/features/playlist/add/ui/form.component.tsx
+++ b/src/features/playlist/add/ui/form.component.tsx
@@ -1,13 +1,24 @@
+import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
 import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
-import { useCreatePlaylist } from '@/features/playlist/add/api/use-create-playlist.mutation';
 import { ErrorCode } from '@/shared/api/types/@shared';
 import { Dialog } from '@/shared/ui/components/dialog';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
+import { useCreatePlaylist } from '../api/use-create-playlist.mutation';
+
+export default function useAddPlaylistDialog() {
+  const { openDialog } = useDialog();
+
+  return useCallback(() => {
+    openDialog((_, onCancel) => ({
+      title: '플레이리스트 이름을 입력해주세요',
+      Body: <Form onCancel={onCancel} />,
+    }));
+  }, []);
+}
 
 type FormProps = Pick<PlaylistFormProps, 'onCancel'>;
-
 const Form = (props: FormProps) => {
   const { mutate: createPlaylist } = useCreatePlaylist();
   const { openDialog } = useDialog();
@@ -63,5 +74,3 @@ const Form = (props: FormProps) => {
 
   return <PlaylistForm onSubmit={handleSubmit} {...props} />;
 };
-
-export default Form;

--- a/src/features/playlist/edit/ui/form.component.tsx
+++ b/src/features/playlist/edit/ui/form.component.tsx
@@ -1,7 +1,11 @@
 import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
-import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
-import { useFetchPlaylists } from '@/features/playlist/list/api/use-fetch-playlist.query';
+import {
+  PlaylistForm,
+  PlaylistFormProps,
+  PlaylistFormValues,
+  usePlaylistAction,
+} from '@/entities/playlist';
 import { Playlist } from '@/shared/api/types/playlist';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { useUpdatePlaylist } from '../api/use-update-playlist.mutation';
@@ -22,8 +26,8 @@ type FormProps = Pick<PlaylistFormProps, 'onCancel'> & {
 };
 const Form = ({ listId, ...props }: FormProps) => {
   const { mutate: updatePlaylist } = useUpdatePlaylist();
-  const { data } = useFetchPlaylists();
-  const target = data?.find((v) => v.id === listId);
+  const playlistAction = usePlaylistAction();
+  const target = playlistAction.list.find((v) => v.id === listId);
 
   const handleSubmit: SubmitHandler<PlaylistFormValues> = async ({ name }) => {
     updatePlaylist(

--- a/src/features/playlist/list-musics/ui/musics.component.tsx
+++ b/src/features/playlist/list-musics/ui/musics.component.tsx
@@ -1,3 +1,4 @@
+import { usePlaylistAction } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/types/playlist';
 import { PFAddPlaylist, PFDelete } from '@/shared/ui/icons';
 import Music from './music.component';
@@ -5,18 +6,13 @@ import { useFetchPlaylistMusics } from '../api/use-fetch-playlist-musics.query';
 
 type MusicsInPlaylistProps = {
   playlist: Playlist;
-  onDeleteFromList: (musicId: number) => void;
-  onMoveToOtherList: (musicId: number) => void;
 };
 
-const MusicsInPlaylist = ({
-  playlist,
-  onDeleteFromList,
-  onMoveToOtherList,
-}: MusicsInPlaylistProps) => {
+const MusicsInPlaylist = ({ playlist }: MusicsInPlaylistProps) => {
   const { data } = useFetchPlaylistMusics(playlist.id, {
     pageSize: playlist.count,
   });
+  const playlistAction = usePlaylistAction();
 
   return (
     <div className='flex flex-col gap-3'>
@@ -26,12 +22,12 @@ const MusicsInPlaylist = ({
           music={music}
           menuItems={[
             {
-              onClickItem: () => onDeleteFromList(music.musicId),
+              onClickItem: () => playlistAction.removeMusics([music.musicId]),
               label: '재생목록에서 삭제',
               Icon: <PFDelete />,
             },
             {
-              onClickItem: () => onMoveToOtherList(music.musicId),
+              onClickItem: () => alert('Not Impl'),
               label: '다른 재생목록으로 이동',
               Icon: <PFAddPlaylist />,
             },

--- a/src/features/playlist/list/api/use-fetch-playlists.query.ts
+++ b/src/features/playlist/list/api/use-fetch-playlists.query.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/react-query/keys';
 import { PlaylistService } from '@/shared/api/services/playlist';
-import { FIVE_MINUTES } from '@/shared/config/time';
+import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 
 export const useFetchPlaylists = () => {
   return useQuery({
     queryKey: [QueryKeys.Playlist],
     queryFn: () => PlaylistService.getPlaylists(),
-    staleTime: 0,
+    staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });
 };

--- a/src/features/playlist/list/index.ts
+++ b/src/features/playlist/list/index.ts
@@ -1,2 +1,3 @@
 export { default as EditablePlaylists } from './ui/editable-list.component';
 export { default as CollapsablePlaylists } from './ui/collapsable-list.component';
+export { useFetchPlaylists } from './api/use-fetch-playlists.query';

--- a/src/features/playlist/list/ui/collapsable-list.component.tsx
+++ b/src/features/playlist/list/ui/collapsable-list.component.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Disclosure } from '@headlessui/react';
-import { useFetchPlaylists } from '@/features/playlist/list/api/use-fetch-playlist.query';
+import { usePlaylistAction } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/types/playlist';
 import { CollapseList } from '@/shared/ui/components/collapse-list';
 
@@ -9,11 +9,11 @@ type CollapsableListProps = {
 };
 
 const CollapsableList = ({ musicsRender }: CollapsableListProps) => {
-  const { data: playlists } = useFetchPlaylists();
+  const playlistAction = usePlaylistAction();
 
   return (
     <div className='flexCol gap-3'>
-      {playlists?.map((playlist) => (
+      {playlistAction.list.map((playlist) => (
         <CollapseList key={playlist.id} title={playlist.name} infoText={`${playlist.count}곡`}>
           <Disclosure.Panel as='article' className=' text-gray-200'>
             {musicsRender(playlist)}

--- a/src/features/playlist/list/ui/editable-list.component.tsx
+++ b/src/features/playlist/list/ui/editable-list.component.tsx
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
-import { useFetchPlaylists } from '@/features/playlist/list/api/use-fetch-playlist.query';
+import { useState } from 'react';
+import { usePlaylistAction } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/types/playlist';
 import { Checkbox } from '@/shared/ui/components/checkbox';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFEdit } from '@/shared/ui/icons';
 
 type EditableListProps = {
-  onEditItem?: (id: Playlist['id']) => void;
-  onChangeSelectedItem?: (ids: Playlist['id'][]) => void;
+  onChangeSelectedItem: (ids: Playlist['id'][]) => void;
 };
 
-const EditableList = ({ onEditItem, onChangeSelectedItem }: EditableListProps) => {
-  const { data: playlists } = useFetchPlaylists();
+const EditableList = ({ onChangeSelectedItem }: EditableListProps) => {
+  const playlistAction = usePlaylistAction();
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   const handleChange = (id: number) => {
@@ -30,12 +29,12 @@ const EditableList = ({ onEditItem, onChangeSelectedItem }: EditableListProps) =
     }
 
     setSelectedIds(newIds);
-    onChangeSelectedItem?.(newIds);
+    onChangeSelectedItem(newIds);
   };
 
   return (
     <div className='flex flex-col gap-3'>
-      {playlists?.map((item) => (
+      {playlistAction.list.map((item) => (
         <div
           key={item.id}
           className='w-full flex gap-2 items-center px-4 py-3 rounded bg-gray-800 text-left text-gray-50 hover:bg-gray-700 '
@@ -47,7 +46,7 @@ const EditableList = ({ onEditItem, onChangeSelectedItem }: EditableListProps) =
           <Typography className='truncate flex-1'>{item.name}</Typography>
 
           <Typography className='text-gray-300'>{item.count}곡</Typography>
-          <button onClick={() => onEditItem?.(item.id)}>
+          <button onClick={() => playlistAction.edit(item.id)}>
             <PFEdit />
           </button>
         </div>

--- a/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
+++ b/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
@@ -1,12 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/react-query/keys';
 import { PlaylistService } from '@/shared/api/services/playlist';
+import { PlaylistMusic } from '@/shared/api/types/playlist';
 
-export const useDeletePlaylistMusic = () => {
+export const useRemovePlaylistMusics = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (listIds: number[]) => PlaylistService.deleteMusicFromPlaylist({ listIds }),
+    mutationFn: (musicIds: PlaylistMusic['musicId'][]) =>
+      PlaylistService.removeMusicFromPlaylist({ listIds: musicIds }),
     onSuccess: (data) => {
       data.listIds.forEach((id) => {
         queryClient.invalidateQueries({

--- a/src/features/playlist/remove-musics/index.ts
+++ b/src/features/playlist/remove-musics/index.ts
@@ -1,1 +1,1 @@
-export { useDeletePlaylistMusic } from './api/use-delete-playlist-music.mutation';
+export { useRemovePlaylistMusics } from './api/use-remove-playlist-music.mutation';

--- a/src/features/playlist/remove/api/use-remove-playlist.mutation.ts
+++ b/src/features/playlist/remove/api/use-remove-playlist.mutation.ts
@@ -2,11 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/react-query/keys';
 import { PlaylistService } from '@/shared/api/services/playlist';
 
-export const useDeletePlaylist = () => {
+export const useRemovePlaylist = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (listIds: number[]) => PlaylistService.deletePlaylist({ listIds }),
+    mutationFn: (listIds: number[]) => PlaylistService.removePlaylist({ listIds }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],

--- a/src/features/playlist/remove/index.ts
+++ b/src/features/playlist/remove/index.ts
@@ -1,1 +1,2 @@
 export { default as RemovePlaylistButton } from './ui/remove-button.component';
+export { useRemovePlaylist } from './api/use-remove-playlist.mutation';

--- a/src/features/playlist/remove/ui/remove-button.component.tsx
+++ b/src/features/playlist/remove/ui/remove-button.component.tsx
@@ -1,16 +1,17 @@
+import { usePlaylistAction } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/types/playlist';
 import { Button } from '@/shared/ui/components/button';
 import { Dialog, useDialog } from '@/shared/ui/components/dialog';
 import { PFDelete } from '@/shared/ui/icons';
-import { useDeletePlaylist } from '../api/use-delete-playlist.mutation';
 
 type RemoveButtonProps = {
   targetIds: Playlist['id'][];
+  onSuccess?: () => void;
 };
 
-const RemoveButton = ({ targetIds }: RemoveButtonProps) => {
+const RemoveButton = ({ targetIds, onSuccess }: RemoveButtonProps) => {
   const { openDialog } = useDialog();
-  const { mutate: deletePlaylist } = useDeletePlaylist();
+  const playlistAction = usePlaylistAction();
 
   const handleClick = () => {
     openDialog((_, onCancel) => ({
@@ -22,8 +23,9 @@ const RemoveButton = ({ targetIds }: RemoveButtonProps) => {
           </Dialog.Button>
           <Dialog.Button
             onClick={() =>
-              deletePlaylist(targetIds, {
+              playlistAction.remove(targetIds, {
                 onSuccess: () => {
+                  onSuccess?.();
                   onCancel?.();
                 },
               })

--- a/src/shared/api/services/playlist.ts
+++ b/src/shared/api/services/playlist.ts
@@ -22,10 +22,10 @@ export const PlaylistService: PlaylistClient = {
   updatePlaylist: (listId, params) => {
     return pfpAxiosInstance.patch(`${ROUTE_V1}/${listId}`, params);
   },
-  deletePlaylist: (data) => {
+  removePlaylist: (data) => {
     return pfpAxiosInstance.delete(`${ROUTE_V1}`, { data });
   },
-  deleteMusicFromPlaylist: (data) => {
+  removeMusicFromPlaylist: (data) => {
     return pfpAxiosInstance.delete(`${ROUTE_V1}/music`, { data });
   },
 };

--- a/src/shared/api/types/playlist.ts
+++ b/src/shared/api/types/playlist.ts
@@ -68,10 +68,10 @@ export interface AddPlaylistMusicResponse {
   duration: string;
 }
 
-export interface DeletePlaylistRequestBody {
+export interface RemovePlaylistRequestBody {
   listIds: number[];
 }
-export interface DeletePlaylistResponse {
+export interface RemovePlaylistResponse {
   listIds: number[];
 }
 
@@ -84,10 +84,10 @@ export interface UpdatePlaylistResponse {
   name: string;
 }
 
-export interface DeletePlaylistMusicRequestBody {
+export interface RemovePlaylistMusicRequestBody {
   listIds: number[];
 }
-export interface DeletePlaylistMusicResponse {
+export interface RemovePlaylistMusicResponse {
   listIds: number[];
 }
 
@@ -103,12 +103,12 @@ export interface PlaylistClient {
     listId: number,
     params: UpdatePlaylistRequestBody
   ) => Promise<UpdatePlaylistResponse>;
-  deletePlaylist: (params: DeletePlaylistRequestBody) => Promise<DeletePlaylistResponse>;
+  removePlaylist: (params: RemovePlaylistRequestBody) => Promise<RemovePlaylistResponse>;
   addMusicToPlaylist: (
     listId: number,
     params: AddPlaylistMusicRequestBody
   ) => Promise<AddPlaylistMusicResponse>;
-  deleteMusicFromPlaylist: (
-    params: DeletePlaylistMusicRequestBody
-  ) => Promise<DeletePlaylistMusicResponse>;
+  removeMusicFromPlaylist: (
+    params: RemovePlaylistMusicRequestBody
+  ) => Promise<RemovePlaylistMusicResponse>;
 }

--- a/src/widgets/sidebar/lib/playlist-action.provider.tsx
+++ b/src/widgets/sidebar/lib/playlist-action.provider.tsx
@@ -1,0 +1,55 @@
+import { ReactNode, useCallback } from 'react';
+import { PlaylistActionContext } from '@/entities/playlist';
+import { PlaylistActionrOptions } from '@/entities/playlist/lib/playlist-action.context';
+import { useAddPlaylistDialog } from '@/features/playlist/add';
+import { useAddPlaylistMusic } from '@/features/playlist/add-musics';
+import { useEditPlaylistDialog } from '@/features/playlist/edit';
+import { useFetchPlaylists } from '@/features/playlist/list';
+import { useRemovePlaylist } from '@/features/playlist/remove';
+import { useRemovePlaylistMusics } from '@/features/playlist/remove-musics';
+import { AddPlaylistMusicRequestBody, Playlist } from '@/shared/api/types/playlist';
+
+export default function PlaylistActionProvider({ children }: { children: ReactNode }) {
+  const { data: list = [] } = useFetchPlaylists();
+  const add = useAddPlaylistDialog();
+  const edit = useEditPlaylistDialog();
+  const { mutate: _remove } = useRemovePlaylist();
+
+  const { mutate: _addMusic } = useAddPlaylistMusic();
+  const { mutate: removeMusics } = useRemovePlaylistMusics();
+
+  const remove = useCallback(
+    (targetIds: Playlist['id'][], options?: PlaylistActionrOptions) => {
+      _remove(targetIds, {
+        onSuccess: options?.onSuccess,
+      });
+    },
+    [_remove]
+  );
+
+  const addMusic = useCallback(
+    (targetId: Playlist['id'], music: AddPlaylistMusicRequestBody) => {
+      _addMusic({
+        listId: targetId,
+        ...music,
+      });
+    },
+    [_addMusic]
+  );
+
+  return (
+    <PlaylistActionContext.Provider
+      value={{
+        list,
+        add,
+        edit,
+        remove,
+
+        addMusic,
+        removeMusics,
+      }}
+    >
+      {children}
+    </PlaylistActionContext.Provider>
+  );
+}

--- a/src/widgets/sidebar/ui/my-playlist.component.tsx
+++ b/src/widgets/sidebar/ui/my-playlist.component.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
 import { AddPlaylistButton } from '@/features/playlist/add';
 import { AddMusicsToPlaylistButton } from '@/features/playlist/add-musics';
-import { useEditPlaylistDialog } from '@/features/playlist/edit';
 import { CollapsablePlaylists, EditablePlaylists } from '@/features/playlist/list';
 import { MusicsInPlaylist } from '@/features/playlist/list-musics';
 import { RemovePlaylistButton } from '@/features/playlist/remove';
-import { useDeletePlaylistMusic } from '@/features/playlist/remove-musics';
 import { Drawer } from '@/shared/ui/components/drawer';
 import { TextButton } from '@/shared/ui/components/text-button';
 
@@ -19,18 +17,8 @@ const MyPlaylist = ({ drawerOpen, setDrawerOpen }: MyPlaylistProps) => {
   const [editMode, setEditMode] = useState(false);
   const [selectedPlaylistIds, setSelectedPlaylistIds] = useState<number[]>([]);
 
-  const { mutate: deletePlaylistMusic } = useDeletePlaylistMusic();
-  const openEditPlaylistDialog = useEditPlaylistDialog();
-
   const handleEditConfirm = () => {
     setEditMode(false);
-  };
-  const handleDeleteMusicFromList = (musicId: number) => {
-    deletePlaylistMusic([musicId]);
-  };
-  const handleMoveMusicToOtherList = () => {
-    // TODO: API 연동 필요
-    alert('API 연동 필요');
   };
 
   return (
@@ -38,7 +26,10 @@ const MyPlaylist = ({ drawerOpen, setDrawerOpen }: MyPlaylistProps) => {
       <div className='flexRow justify-between items-center mt-10 mb-6'>
         {editMode ? (
           <>
-            <RemovePlaylistButton targetIds={selectedPlaylistIds} />
+            <RemovePlaylistButton
+              targetIds={selectedPlaylistIds}
+              onSuccess={() => setSelectedPlaylistIds([])}
+            />
             <TextButton className='text-red-300' onClick={handleEditConfirm}>
               완료
             </TextButton>
@@ -55,19 +46,10 @@ const MyPlaylist = ({ drawerOpen, setDrawerOpen }: MyPlaylistProps) => {
       </div>
 
       {editMode ? (
-        <EditablePlaylists
-          onEditItem={openEditPlaylistDialog}
-          onChangeSelectedItem={setSelectedPlaylistIds}
-        />
+        <EditablePlaylists onChangeSelectedItem={setSelectedPlaylistIds} />
       ) : (
         <CollapsablePlaylists
-          musicsRender={(playlist) => (
-            <MusicsInPlaylist
-              playlist={playlist}
-              onDeleteFromList={handleDeleteMusicFromList}
-              onMoveToOtherList={handleMoveMusicToOtherList}
-            />
-          )}
+          musicsRender={(playlist) => <MusicsInPlaylist playlist={playlist} />}
         />
       )}
     </Drawer>

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -5,6 +5,7 @@ import { ProfileEditFormV2 } from '@/features/edit-profile-meta';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFDj, PFHeadset } from '@/shared/ui/icons';
+import PlaylistActionProvider from 'widgets/sidebar/lib/playlist-action.provider';
 import MyPlaylist from './my-playlist.component';
 
 interface SidebarProps {
@@ -70,7 +71,9 @@ const Sidebar = ({ className, showDJQueue }: SidebarProps) => {
         )}
       </aside>
 
-      <MyPlaylist drawerOpen={showMyPlaylist} setDrawerOpen={setShowMyPlaylist} />
+      <PlaylistActionProvider>
+        <MyPlaylist drawerOpen={showMyPlaylist} setDrawerOpen={setShowMyPlaylist} />
+      </PlaylistActionProvider>
     </>
   );
 };


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
entities/playlist 에서 플레이리스트 관련 action에 대한 Context를 선언하고,
플레이리스트 위젯이 들어있는 widgets/sidebar에서 features/playlist 슬라이스 그룹 내에 퍼져있는 playlist 관련 액션을 모아 위 Context value의 구현체를 provide 합니다.
이로써 얻을 수 있는 이점은 아래와 같습니다.

* fsd의 동일 레이어 내 슬라이스 간 참조 불가 규칙을 무시하지 않습니다.
  * 각 feature는 다른 feature의 구현체를 바라보지 않고 context의 인터페이스만 바라봅니다.
* 결합도는 낮게 유지하면서, 응집도는 높입니다.
  * 각 action들을 한 곳에 모아 응집도는 높이면서도, feature slice 분리는 유지하여 결합도는 낮게 유지합니다.
* 과도한 props 드릴링을 방지합니다 (이건 단순히 context의 이점)

PR 범위와 관련있는 작은 리팩터링 및 수정 건들이 포함됩니다 (죄송합니다)