### PR TITLE
feat: generate new enums

### DIFF
--- a/scripts/copy-java-enums/index.js
+++ b/scripts/copy-java-enums/index.js
@@ -4,7 +4,7 @@ const { glob } = require('glob');
 
 const ROOT = `${__dirname}/../..`;
 const BACKEND_DIRNAME = `${__dirname}/api`; // 백엔드의 소스 디렉터리(main/java/com/pfplaybackend/api)를 카피해오세요
-const ENUMS_DIRNAME = `${ROOT}/src/api/types`;
+const ENUMS_DIRNAME = `${ROOT}/src/shared/api/types`;
 const ENUMS_FILENAME = `${ENUMS_DIRNAME}/@enums.ts`;
 const exceptionEnumNames = new Set(['ExceptionEnum', 'ApiHeader', 'Domain']);
 
@@ -29,7 +29,7 @@ function main() {
 
 function extractEnums(content) {
   const enums = [];
-  const enumRegex = /public enum (?<enumName>\w+)\s*{(?<enumBody>[^}]*)}/g;
+  const enumRegex = /public enum (?<enumName>\w+)\s*{(?<enumBody>[^;}]*)/g;
   let match;
 
   while ((match = enumRegex.exec(content)) !== null) {
@@ -43,14 +43,10 @@ function extractEnums(content) {
         const trimmedValue = v.trim();
         if (!trimmedValue) return acc;
 
-        const additionalDataMatch = trimmedValue.match(/(?<key>\w+)\s*\("(?<value>[^"]+)"\)/);
-        const result = additionalDataMatch
-          ? `${additionalDataMatch.groups.key} = "${additionalDataMatch.groups.value}"` // "KEY("VALUE")" 형태의 enum 항목을 처리
-          : /^\w+$/.test(trimmedValue) // "KEY" 형태의 enum 항목을 처리
-          ? `${trimmedValue} = "${trimmedValue}"`
-          : trimmedValue; // 그 외의 형태(주로 주석이나 공백)는 그대로 유지
+        const match = trimmedValue.match(/(?<key>[A-Z_]+).*/);
+        if (!match) return acc;
 
-        acc.push(result);
+        acc.push(`${match.groups.key} = "${match.groups.key}"`);
         return acc;
       }, [])
       .join(', ');

--- a/src/shared/api/__fixture__/avatar-parts-list.fixture.ts
+++ b/src/shared/api/__fixture__/avatar-parts-list.fixture.ts
@@ -1,11 +1,11 @@
 //  TODO: 아바타 이미지 데이터 가져오면 mock arr, file 지우기
-import { AvatarType } from '@/shared/api/types/@enums';
+import { ObtainmentType } from '@/shared/api/types/@enums';
 import { AvatarParts } from '@/shared/api/types/avatar';
 
 export const fixtureAvatarPartsList: AvatarParts[] = [
   {
     id: 1,
-    type: AvatarType.BASIC,
+    type: ObtainmentType.BASIC,
     name: '도깨비불',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -13,7 +13,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 2,
-    type: AvatarType.BASIC,
+    type: ObtainmentType.BASIC,
     name: '유령',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -21,7 +21,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 3,
-    type: AvatarType.BASIC,
+    type: ObtainmentType.BASIC,
     name: '기본1',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -29,7 +29,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 4,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타1',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -37,7 +37,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 5,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타2',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -45,7 +45,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 6,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타3',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -53,7 +53,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 7,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타4',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -61,7 +61,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 8,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타5',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -69,7 +69,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 9,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타6',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -77,7 +77,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 10,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타7',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -85,7 +85,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 11,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타8',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -93,7 +93,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 12,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타9',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -101,7 +101,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 13,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타10',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -109,7 +109,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 14,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타11',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -117,7 +117,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 15,
-    type: AvatarType.DJ,
+    type: ObtainmentType.DJ_PNT,
     name: '디제잉 아바타12',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -125,7 +125,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 16,
-    type: AvatarType.REF,
+    type: ObtainmentType.REF_LINK,
     name: '레퍼럴 아바타1',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -133,7 +133,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 17,
-    type: AvatarType.REF,
+    type: ObtainmentType.REF_LINK,
     name: '레퍼럴 아바타2',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -141,7 +141,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 18,
-    type: AvatarType.REF,
+    type: ObtainmentType.REF_LINK,
     name: '레퍼럴 아바타3',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -149,7 +149,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 19,
-    type: AvatarType.REF,
+    type: ObtainmentType.REF_LINK,
     name: '레퍼럴 아바타4',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -157,7 +157,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 20,
-    type: AvatarType.ROOM,
+    type: ObtainmentType.ROOM_ACT,
     name: '누적 DJ 아바타1',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -165,7 +165,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 21,
-    type: AvatarType.ROOM,
+    type: ObtainmentType.ROOM_ACT,
     name: '누적 DJ 아바타2',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -173,7 +173,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 22,
-    type: AvatarType.ROOM,
+    type: ObtainmentType.ROOM_ACT,
     name: '누적 DJ 아바타3',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',
@@ -181,7 +181,7 @@ export const fixtureAvatarPartsList: AvatarParts[] = [
   },
   {
     id: 23,
-    type: AvatarType.ROOM,
+    type: ObtainmentType.ROOM_ACT,
     name: '누적 DJ 아바타4',
     image:
       'https://postfiles.pstatic.net/MjAyMzA3MjlfMTE3/MDAxNjkwNjE0MTc3MjUz.owpzAVyLyeWQNKejvnYsd7g4Qv9SPvwwzl6voUCAeZ0g.Re2hKthxs8iV4NJr2Ofd-4_DfiXe46GzvPfhrjftX3Eg.PNG.sylviuss/avatar_empty.png?type=w773',

--- a/src/shared/api/types/@enums.ts
+++ b/src/shared/api/types/@enums.ts
@@ -1,30 +1,90 @@
-export enum PartyroomType {
-  PARTY = 'PARTY',
-  MAIN = 'MAIN',
+export enum ObtainmentType {
+  BASIC = 'BASIC',
+  DJ_PNT = 'DJ_PNT',
+  REF_LINK = 'REF_LINK',
+  ROOM_ACT = 'ROOM_ACT',
 }
 
-export enum PartyroomStatus {
-  ACTIVE = 'ACTIVE',
-  INACTIVE = 'INACTIVE',
+export enum AuthorityTier {
+  FM = 'FM',
+  AM = 'AM',
+  GT = 'GT',
 }
 
-export enum Authority {
+export enum ActivityType {
+  DJ_PNT = 'DJ_PNT',
+  REF_LINK = 'REF_LINK',
+  ROOM_ACT = 'ROOM_ACT',
+}
+
+export enum PlaylistType {
+  GRABLIST = 'GRABLIST',
+  PLAYLIST = 'PLAYLIST',
+}
+
+export enum PlaylistOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export enum PartyroomPenaltyType {
+  DELETE = 'DELETE',
+  GGUL = 'GGUL',
+  KICK = 'KICK',
+  BAN = 'BAN',
+}
+
+export enum PartyroomGrade {
   ADMIN = 'ADMIN',
-  COMMUNITY_MANAGER = 'COMMUNITY_MANAGER',
-  MODERATOR = 'MODERATOR',
+  CM = 'CM',
+  MOD = 'MOD',
   CLUBBER = 'CLUBBER',
   LISTENER = 'LISTENER',
 }
 
-export enum UserType {
-  ROLE_USER = 'ROLE_USER',
-  ROLE_GUEST = 'ROLE_GUEST',
-  ROLE_WALLET_USER = 'ROLE_WALLET_USER',
+export enum MessageType {
+  CHAT = 'CHAT',
+  PROMOTE = 'PROMOTE',
+  PENALTY = 'PENALTY',
 }
 
-export enum AvatarType {
-  BASIC = 'BASIC',
-  DJ = 'DJ',
-  REF = 'REF',
-  ROOM = 'ROOM',
+export enum MemberGrade {
+  HOST = 'HOST',
+  MODERATE = 'MODERATE',
+  CLUBBER = 'CLUBBER',
+}
+
+export enum AccessLevel {
+  ROLE_ADMIN = 'ROLE_ADMIN',
+  ROLE_MEMBER = 'ROLE_MEMBER',
+  ROLE_GUEST = 'ROLE_GUEST',
+}
+
+export enum RedirectionableLocation {
+  MAIN = 'MAIN',
+  PARTY_ROOM = 'PARTY_ROOM',
+}
+
+export enum ProviderType {
+  GOOGLE = 'GOOGLE',
+}
+
+export enum TokenSubject {
+  ACCESS_TOKEN_SUBJECT = 'ACCESS_TOKEN_SUBJECT',
+}
+
+export enum TokenClaim {
+  UID = 'UID',
+  EMAIL = 'EMAIL',
+  ACCESS_LEVEL = 'ACCESS_LEVEL',
+  AUTHORITY_TIER = 'AUTHORITY_TIER',
+}
+
+/**
+ * @deprecated
+ * 제거된 enum. 관련 API 응답 명세가 아직 나오지 않아 남겨둠
+ */
+export enum PartyroomStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
 }

--- a/src/shared/api/types/avatar.ts
+++ b/src/shared/api/types/avatar.ts
@@ -1,8 +1,8 @@
-import { AvatarType } from '@/shared/api/types/@enums';
+import { ObtainmentType } from '@/shared/api/types/@enums';
 
 export interface AvatarParts {
   id: number | string;
-  type?: AvatarType;
+  type?: ObtainmentType;
   name: string;
   image: string;
   point?: number;

--- a/src/shared/api/types/parties.ts
+++ b/src/shared/api/types/parties.ts
@@ -1,4 +1,8 @@
-import { Authority, PartyroomStatus, PartyroomType } from '@/shared/api/types/@enums';
+import {
+  PartyroomGrade,
+  PartyroomStatus,
+  RedirectionableLocation,
+} from '@/shared/api/types/@enums';
 import { PaginationPayload, PaginationResponse } from '@/shared/api/types/@shared';
 
 export interface CreatePartyroomRequest {
@@ -23,7 +27,7 @@ export interface PartyroomSummary {
 }
 
 export type DefaultPartyPermission = {
-  authority: Authority;
+  authority: PartyroomGrade;
   partyInfoFetch: boolean;
   partyClose: boolean;
   notice: boolean;
@@ -44,7 +48,7 @@ export interface CreatePartyroomResponse {
   introduce: string;
   domain: string;
   djingLimit: number;
-  type: PartyroomType;
+  type: RedirectionableLocation;
   status: PartyroomStatus;
   admin: {
     profile: string;

--- a/src/shared/api/types/user.ts
+++ b/src/shared/api/types/user.ts
@@ -1,4 +1,4 @@
-import { Authority } from '@/shared/api/types/@enums';
+import { PartyroomGrade } from '@/shared/api/types/@enums';
 
 export interface UserProfile {
   nickname: string;
@@ -32,7 +32,7 @@ export interface UserLoginResponse {
   id: number;
   name: string;
   registered: boolean;
-  authority: Authority;
+  authority: PartyroomGrade;
   accessToken: string;
   userPermission: UserPermission;
   profileUpdated: boolean;

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,4 +1,4 @@
-import { Authority } from '@/shared/api/types/@enums';
+import { PartyroomGrade } from '@/shared/api/types/@enums';
 import { UserPermission } from '@/shared/api/types/user';
 
 // NOTE: User, JWT 인터페이스는 UserLoginResponse + 'email' + 'accessToken' 이며,
@@ -14,7 +14,7 @@ declare module 'next-auth' {
     id: number;
     name: string;
     registered: boolean;
-    authority: Authority;
+    authority: PartyroomGrade;
     email: string;
     accessToken: string;
     userPermission: UserPermission;
@@ -35,7 +35,7 @@ declare module 'next-auth/jwt' {
     id: number;
     name: string;
     registered: boolean;
-    authority: Authority;
+    authority: PartyroomGrade;
     email: string;
     accessToken: string;
     userPermission: UserPermission;


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
백엔드 측에 새로 생성된 enum들을 generate 합니다.
새로운 enum case들에 맞춰 스크립트도 일부 수정합니다.

user.authority가 PartyroomGrade enum이 된건 이상하지만, 일단 이전 Authority enum과 구성이 같아 붙여뒀습니다. 이후 PR에서 인증 관련 API 변경 사항을 반영하면서 같이 수정될 것으로 보입니다.