### PR TITLE
fix: 앱 내 useSuspenseQuery 사용부 모두 제거

### DIFF
--- a/src/app/parties/layout.tsx
+++ b/src/app/parties/layout.tsx
@@ -2,20 +2,20 @@
 
 import { useRouter } from 'next/navigation';
 import { PropsWithChildren, useEffect } from 'react';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 
 const ProtectedLayout = ({ children }: PropsWithChildren) => {
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
   const router = useRouter();
 
   useEffect(() => {
     /**
      * 로그인은 했지만 프로필을 아직 생성하지 않은 경우
      */
-    if (!me.profileUpdated) {
+    if (me && !me.profileUpdated) {
       router.replace('/settings/profile');
     }
-  }, [me.profileUpdated]);
+  }, [me]);
 
   return <>{children}</>;
 };

--- a/src/app/settings/profile/layout.tsx
+++ b/src/app/settings/profile/layout.tsx
@@ -2,19 +2,19 @@
 
 import { router } from 'next/client';
 import { PropsWithChildren, useEffect } from 'react';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 
 const ProfileEditLayout = ({ children }: PropsWithChildren) => {
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
 
   useEffect(() => {
     /**
      * 프로필을 등록한 사용자의 경우, 접근 불가
      */
-    if (me.profileUpdated) {
+    if (me && me.profileUpdated) {
       router.replace('/parties');
     }
-  }, [me.profileUpdated]);
+  }, [me]);
 
   return <>{children}</>;
 };

--- a/src/entities/me/api/use-fetch-me.query.ts
+++ b/src/entities/me/api/use-fetch-me.query.ts
@@ -1,19 +1,17 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query/src/types';
+import { AxiosError } from 'axios';
 import { Me } from '@/entities/me/model/me.model';
 import { QueryKeys } from '@/shared/api/react-query/keys';
 import { UsersService } from '@/shared/api/services/users';
+import { APIError } from '@/shared/api/types/@shared';
 import { ONE_HOUR } from '@/shared/config/time';
 
-export function useSuspenseFetchMe() {
-  return useSuspenseQuery<Me>(queryOptions);
+export function useFetchMe(): UseQueryResult<Me, AxiosError<APIError>> {
+  return useQuery(queryOptions);
 }
 
-export function useFetchMe() {
-  return useQuery<Me>(queryOptions);
-}
-
-export const queryOptions: UseQueryOptions<Me> = {
+export const queryOptions: UseQueryOptions<Me, AxiosError<APIError>> = {
   queryKey: [QueryKeys.Me],
   queryFn: async () => {
     const meInfo = await UsersService.getMyInfo();

--- a/src/entities/me/index.ts
+++ b/src/entities/me/index.ts
@@ -1,3 +1,3 @@
 export { type Me } from './model/me.model';
-export { useFetchMe, useSuspenseFetchMe } from './api/use-fetch-me.query';
+export { useFetchMe } from './api/use-fetch-me.query';
 export { default as MeHydration } from './ui/hydration.component';

--- a/src/features/edit-profile-bio/ui/v1.component.tsx
+++ b/src/features/edit-profile-bio/ui/v1.component.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 import { cn } from '@/shared/lib/functions/cn';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { Button } from '@/shared/ui/components/button';
@@ -14,22 +15,20 @@ import * as Form from '../model/form.model';
 
 const ProfileEditFormV1 = () => {
   const router = useAppRouter();
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
   const { mutate: updateBio, isPending } = useUpdateMyBio();
 
   const {
     handleSubmit,
     control,
+    reset,
     setError,
     formState: { errors, isValid },
   } = useForm<Form.Model>({
     mode: 'all',
     resolver: zodResolver(Form.schema),
-    defaultValues: {
-      nickname: me.nickname,
-      introduction: me.introduction,
-    },
   });
+  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
 
   const handleFormSubmit: SubmitHandler<Form.Model> = (values) => {
     updateBio(values, {
@@ -45,7 +44,14 @@ const ProfileEditFormV1 = () => {
     });
   };
 
-  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
+  useEffect(() => {
+    if (me) {
+      reset({
+        nickname: me.nickname,
+        introduction: me.introduction,
+      });
+    }
+  }, [me]);
 
   return (
     <form

--- a/src/features/edit-profile-bio/ui/v2-edit.component.tsx
+++ b/src/features/edit-profile-bio/ui/v2-edit.component.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Image from 'next/image';
+import { useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import { FormItemError } from '@/shared/ui/components/form-item';
@@ -18,7 +19,7 @@ type V2EditModeProps = {
 
 const V2EditMode = ({ changeToViewMode }: V2EditModeProps) => {
   const t = useI18n();
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
   const { mutate: updateBio, isPending } = useUpdateMyBio();
 
   const {
@@ -29,11 +30,8 @@ const V2EditMode = ({ changeToViewMode }: V2EditModeProps) => {
   } = useForm<ProfileForm.Model>({
     mode: 'all',
     resolver: zodResolver(ProfileForm.schema),
-    defaultValues: {
-      nickname: me.nickname,
-      introduction: me.introduction,
-    },
   });
+  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
 
   const onSubmit: SubmitHandler<ProfileForm.Model> = (values) => {
     updateBio(values, {
@@ -46,7 +44,14 @@ const V2EditMode = ({ changeToViewMode }: V2EditModeProps) => {
     reset();
   };
 
-  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
+  useEffect(() => {
+    if (me) {
+      reset({
+        nickname: me.nickname,
+        introduction: me.introduction,
+      });
+    }
+  }, [me]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/features/edit-profile-bio/ui/v2-view.component.tsx
+++ b/src/features/edit-profile-bio/ui/v2-view.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { Button } from '@/shared/ui/components/button';
@@ -16,7 +16,7 @@ type V2ViewModeProps = {
 const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps) => {
   const t = useI18n();
   const router = useAppRouter();
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
 
   const handleClickAvatarEditButton = () => {
     router.push('/settings/avatar');
@@ -43,13 +43,13 @@ const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps)
         <div className='items-start gap-3 flexCol'>
           <div className='flex gap-3 items-center'>
             <Typography type='body1' className='text-white'>
-              {me.nickname}
+              {me?.nickname}
             </Typography>
             <div onClick={changeToEditMode} className='cursor-pointer'>
               <PFEdit />
             </div>
           </div>
-          <Typography className='text-left text-white'>{me.introduction}</Typography>
+          <Typography className='text-left text-white'>{me?.introduction}</Typography>
         </div>
 
         <div className='items-center justify-between flexRow'>

--- a/src/features/partyroom/create/ui/form.component.tsx
+++ b/src/features/partyroom/create/ui/form.component.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { AxiosError } from 'axios';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { useFetchMe } from '@/entities/me';
 import { PartiesService } from '@/shared/api/services/parties';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
@@ -22,7 +22,7 @@ interface PartyroomCreateFormProps {
 
 const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
   const t = useI18n();
-  const { data: me } = useSuspenseFetchMe();
+  const { data: me } = useFetchMe();
   const router = useRouter();
 
   const {
@@ -157,7 +157,7 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
             }
             classNames={{ label: 'text-gray-200' }}
           >
-            <DjListItem userConfig={{ username: me.nickname, src: '' }} />
+            <DjListItem userConfig={{ username: me?.nickname ?? '', src: '' }} />
           </FormItem>
 
           <Button


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
로그인 성공 직후 parties 페이지로 이동 시, 콘솔에 `cannot update a component (`hotreload`) while rendering a different component ...` 에러가 뜨며 me/info api 호출에 401이 나는 문제가 있었습니다.

parties 페이지 진입 시점에 useSuspenseQuery로 me 정보를 가져오는데, 이를 useQuery로 바꾸면 해결됩니다.

원인은 잘 모르겠는데.. 일정상 더 고민할 수 없습니다.

[useSuspenseQuery가 nextjs app router 에서 SSR 시 무한 refetch를 트리거하는 이슈](https://github.com/TanStack/query/issues/6116)가 현재 진행형인 등, 아직 useSuspenseQuery 는 nextjs와 잘 맞지 않는게 이유라고 애써 위로하며 일단 앱 내 useSuspenseQuery 사용부를 모두 제거합니다.