### PR TITLE
fix(shared/api): http service들 this 바인딩 문제 수정

### DIFF
--- a/src/app/_providers/react-query.provider.tsx
+++ b/src/app/_providers/react-query.provider.tsx
@@ -82,5 +82,6 @@ function handleBubbledError(error: unknown) {
     return;
   }
 
+  console.error(error);
   alert(errorMessage);
 }

--- a/src/shared/api/http/services/parties.ts
+++ b/src/shared/api/http/services/parties.ts
@@ -12,15 +12,15 @@ import type {
 class PartiesService extends HTTPClient implements PartiesClient {
   private ROUTE_V1 = 'v1/party-room';
 
-  public create(request: CreatePartyroomRequest) {
+  public create = (request: CreatePartyroomRequest) => {
     return this.post<CreatePartyroomResponse>(`${this.ROUTE_V1}/create`, request);
-  }
+  };
 
-  public getList(request: PaginationPayload) {
+  public getList = (request: PaginationPayload) => {
     return this.get<PaginationResponse<PartyroomSummary>>(`${this.ROUTE_V1}/list`, {
       params: request,
     });
-  }
+  };
 }
 
 const instance = new PartiesService();

--- a/src/shared/api/http/services/playlists.ts
+++ b/src/shared/api/http/services/playlists.ts
@@ -24,44 +24,47 @@ import type {
 class PlaylistsService extends HTTPClient implements PlaylistsClient {
   private ROUTE_V1 = 'v1/playlists';
 
-  public getPlaylists() {
+  public getPlaylists = () => {
     return this.get<GetPlaylistsResponse>(`${this.ROUTE_V1}`);
-  }
+  };
 
-  public getMusicsFromPlaylist(playlistId: Playlist['id'], params?: GetPlaylistMusicsParameters) {
+  public getMusicsFromPlaylist = (
+    playlistId: Playlist['id'],
+    params?: GetPlaylistMusicsParameters
+  ) => {
     return this.get<PaginationResponse<PlaylistMusic>>(`${this.ROUTE_V1}/${playlistId}/musics`, {
       params,
     });
-  }
+  };
 
-  public searchMusics(params: SearchMusicsRequest) {
+  public searchMusics = (params: SearchMusicsRequest) => {
     return this.get<SearchMusicsResponse>(`v1/music-search`, { params });
-  }
+  };
 
-  public createPlaylist(params: CreatePlaylistRequestBody) {
+  public createPlaylist = (params: CreatePlaylistRequestBody) => {
     return this.post<CreatePlaylistResponse>(`${this.ROUTE_V1}`, params);
-  }
+  };
 
-  public updatePlaylist(playlistId: Playlist['id'], params: UpdatePlaylistRequestBody) {
+  public updatePlaylist = (playlistId: Playlist['id'], params: UpdatePlaylistRequestBody) => {
     return this.patch<UpdatePlaylistResponse>(`${this.ROUTE_V1}/${playlistId}`, params);
-  }
+  };
 
-  public addMusicToPlaylist(playlistId: Playlist['id'], params: AddPlaylistMusicRequestBody) {
+  public addMusicToPlaylist = (playlistId: Playlist['id'], params: AddPlaylistMusicRequestBody) => {
     return this.post<void>(`${this.ROUTE_V1}/${playlistId}/musics`, params);
-  }
+  };
 
-  public removePlaylist(params: RemovePlaylistRequestBody) {
+  public removePlaylist = (params: RemovePlaylistRequestBody) => {
     return this.delete<RemovePlaylistResponse>(`${this.ROUTE_V1}`, {
       data: params,
     });
-  }
+  };
 
-  public removeMusicsFromPlaylist(params: RemovePlaylistMusicRequestBody) {
+  public removeMusicsFromPlaylist = (params: RemovePlaylistMusicRequestBody) => {
     const { playlistId, ...data } = params;
     return this.delete<RemovePlaylistMusicResponse>(`${this.ROUTE_V1}/${playlistId}/musics`, {
       data,
     });
-  }
+  };
 }
 
 const instance = new PlaylistsService();

--- a/src/shared/api/http/services/users.ts
+++ b/src/shared/api/http/services/users.ts
@@ -20,68 +20,68 @@ import type {
 class UsersService extends HTTPClient implements UsersClient {
   private ROUTE_V1 = 'v1/users';
 
-  public signIn(request: SignInRequest) {
+  public signIn = (request: SignInRequest) => {
     if (typeof window === 'undefined') return;
 
     const url = new URL(`${this.axiosInstance.defaults.baseURL}${this.ROUTE_V1}/members/sign`);
     url.searchParams.append('oauth2Provider', request.oauth2Provider);
 
     window.location.href = url.toString();
-  }
+  };
 
-  public signInGuest(request: SignInGuestRequest) {
+  public signInGuest = (request: SignInGuestRequest) => {
     return this.post<void>(`${this.ROUTE_V1}/guests/sign`, request);
-  }
+  };
 
-  public signOut() {
+  public signOut = () => {
     return this.post<void>(`${this.ROUTE_V1}/logout`);
-  }
+  };
 
-  public temporary_SignInFullMember() {
+  public temporary_SignInFullMember = () => {
     return this.post<void>(`${this.ROUTE_V1}/members/sign/temporary/full-member`);
-  }
+  };
 
-  public temporary_SignInAssociateMember() {
+  public temporary_SignInAssociateMember = () => {
     return this.post<void>(`${this.ROUTE_V1}/members/sign/temporary/associate-member`);
-  }
+  };
 
-  public getMyInfo() {
+  public getMyInfo = () => {
     return this.get<GetMyInfoResponse>(`${this.ROUTE_V1}/me/info`);
-  }
+  };
 
-  public getUserProfileSummary(request: GetUserProfileSummaryRequest) {
+  public getUserProfileSummary = (request: GetUserProfileSummaryRequest) => {
     return this.get<GetUserProfileSummaryResponse>(
       `${this.ROUTE_V1}/${request.uid}/profile/summary`
     );
-  }
+  };
 
-  public getMyProfileSummary() {
+  public getMyProfileSummary = () => {
     return this.get<GetMyProfileSummaryResponse>(`${this.ROUTE_V1}/me/profile/summary`);
-  }
+  };
 
-  public getMyAvatarBodies() {
+  public getMyAvatarBodies = () => {
     return this.get<AvatarBody[]>(`${this.ROUTE_V1}/me/profile/avatar/bodies`);
-  }
+  };
 
-  public getMyAvatarFaces() {
+  public getMyAvatarFaces = () => {
     return this.get<AvatarFace[]>(`${this.ROUTE_V1}/me/profile/avatar/faces`);
-  }
+  };
 
-  public updateMyWallet(request: UpdateMyWalletRequest) {
+  public updateMyWallet = (request: UpdateMyWalletRequest) => {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/wallet`, request);
-  }
+  };
 
-  public updateMyBio(request: UpdateMyBioRequest) {
+  public updateMyBio = (request: UpdateMyBioRequest) => {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/bio`, request);
-  }
+  };
 
-  public updateMyAvatarFace(request: UpdateMyAvatarFaceRequest) {
+  public updateMyAvatarFace = (request: UpdateMyAvatarFaceRequest) => {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/avatar/face`, request);
-  }
+  };
 
-  public updateMyAvatarBody(request: UpdateMyAvatarBodyRequest) {
+  public updateMyAvatarBody = (request: UpdateMyAvatarBodyRequest) => {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/avatar/body`, request);
-  }
+  };
 }
 
 const instance = new UsersService();


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
![image](https://github.com/user-attachments/assets/cf465d85-edb7-4afe-a291-eb4043b2bc4a)

`queryFn: MyService.myMethod` 와 같이 사용할 경우 this 바인딩이 의도와 다르게 동작하는 문제를 수정하기 위해 모든 http 서비스 메서드를 prototype method >> instance method로 변경합니다.

각 서비스 인스턴스는 싱글톤이기에 instance method의 메모리 부하 문제 등은 걱정 없습니다.