### PR TITLE
fix(shared/ui/dialog): 중첩 모달 중 제일 상단 모달을 닫을 때 모든 모달이 닫혀버리는 문제 

### DIFF
--- a/src/shared/ui/components/dialog/dialog.component.tsx
+++ b/src/shared/ui/components/dialog/dialog.component.tsx
@@ -26,6 +26,7 @@ export interface DialogProps {
   Body: FC | ReactNode;
   onClose: () => void;
   closeConfirm?: () => Promise<boolean | undefined>;
+  closeWhenOverlayClicked?: boolean;
   id?: string;
   showCloseIcon?: boolean;
   classNames?: {
@@ -52,6 +53,7 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
   Body,
   onClose,
   closeConfirm,
+  closeWhenOverlayClicked = true,
   id,
   titleAlign = 'center',
   titleType = 'body1',
@@ -93,7 +95,15 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
 
   return (
     <Transition appear show={open} as={Fragment}>
-      <HUDialog as='div' className='relative z-dialog' onClose={handleClose} id={id}>
+      <HUDialog
+        as='div'
+        className='relative z-dialog'
+        onClick={closeWhenOverlayClicked ? handleClose : undefined}
+        onClose={
+          () => {} /* 여기 close function 을 넣으면 중첩 모달 띄울 때 중첩 모달 내 인터랙션에 의해 직전 모달이 닫혀 버리는 문제가 있음. 해서 onClick 에서 컨트롤 */
+        }
+        id={id}
+      >
         {!hideDim && (
           <Transition.Child
             as={Fragment}

--- a/src/shared/ui/components/dialog/dialog.component.tsx
+++ b/src/shared/ui/components/dialog/dialog.component.tsx
@@ -17,8 +17,8 @@ interface StrWithEmphasis {
   emphasisPhrase: string | string[];
 }
 export interface DialogProps {
+  id?: string;
   open: boolean;
-  hideDim?: boolean;
   title?: string | StrWithEmphasis;
   titleAlign?: 'left' | 'center';
   titleType?: TypographyProps['type'];
@@ -26,9 +26,18 @@ export interface DialogProps {
   Body: FC | ReactNode;
   onClose: () => void;
   closeConfirm?: () => Promise<boolean | undefined>;
+  /**
+   * @default true
+   */
   closeWhenOverlayClicked?: boolean;
-  id?: string;
+  /**
+   * @default false
+   */
   showCloseIcon?: boolean;
+  /**
+   * @default false
+   */
+  hideDim?: boolean;
   classNames?: {
     container?: string;
   };
@@ -57,8 +66,8 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
   id,
   titleAlign = 'center',
   titleType = 'body1',
-  showCloseIcon,
-  hideDim,
+  showCloseIcon = false,
+  hideDim = false,
   classNames,
 }) => {
   const Title = useMemo(() => {

--- a/src/shared/ui/components/dialog/dialog.stories.tsx
+++ b/src/shared/ui/components/dialog/dialog.stories.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef, useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { cn } from '@/shared/lib/functions/cn';
 import { delay } from '@/shared/lib/functions/delay';
+import { useDisclosure } from '@/shared/lib/hooks/use-disclosure.hook';
 import Dialog from './dialog.component';
 import { useDialog } from './use-dialog.hook';
 import { Button } from '../button';
@@ -199,7 +200,7 @@ export const Multiple: Story = () => {
 
 export const Stream: Story = () => {
   const [count, setCount] = useState(0);
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const { open, onOpen, onClose } = useDisclosure();
   const intervalRef = useRef<NodeJS.Timer>();
 
   const streamLike = useMemo(() => {
@@ -219,11 +220,11 @@ export const Stream: Story = () => {
   }, []);
 
   const handleOpenDialog = () => {
-    setDialogOpen(true);
+    onOpen();
     streamLike.startCount();
   };
   const handleCloseDialog = () => {
-    setDialogOpen(false);
+    onClose();
     streamLike.stopCount();
     setCount(0);
   };
@@ -233,7 +234,7 @@ export const Stream: Story = () => {
       <Button onClick={handleOpenDialog}>Click</Button>
 
       <Dialog
-        open={dialogOpen}
+        open={open}
         title='스트림 Like'
         Body={() => (
           <>

--- a/src/shared/ui/components/dialog/dialog.stories.tsx
+++ b/src/shared/ui/components/dialog/dialog.stories.tsx
@@ -173,6 +173,30 @@ export const CloseConfirm: Story = () => {
   return <Button onClick={openDialogWithCloseConfirm}>Click</Button>;
 };
 
+export const Multiple: Story = () => {
+  const { openDialog } = useDialog();
+
+  const openMultipleDialog = (order = 1) => {
+    return openDialog((_, onCancel) => ({
+      title: `${order} 번째 다이얼로그`,
+      Body: () => {
+        return (
+          <>
+            <Dialog.ButtonGroup>
+              <Dialog.Button onClick={() => onCancel?.()}>닫기</Dialog.Button>
+              <Dialog.Button onClick={() => openMultipleDialog(order + 1)}>
+                하나 더 열기
+              </Dialog.Button>
+            </Dialog.ButtonGroup>
+          </>
+        );
+      },
+    }));
+  };
+
+  return <Button onClick={() => openMultipleDialog(1)}>Click</Button>;
+};
+
 export const Stream: Story = () => {
   const [count, setCount] = useState(0);
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/src/shared/ui/components/dialog/use-dialog.hook.tsx
+++ b/src/shared/ui/components/dialog/use-dialog.hook.tsx
@@ -97,7 +97,7 @@ export const useDialog = () => {
         }));
       },
     }),
-    [openDialog]
+    [openDialog, t]
   );
 
   return {


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
headless ui dialog의 onClose 동작이 dialog provider의 중첩 모달 스택 컨트롤 방식과 맞지 않아 생기는 문제였습니다.

내부를 까보진 않았지만, 아마 자식 요소를 제외한 모든 요소에 클릭 이벤트에 대해 onClose를 실행하는 것 같습니다.