### PR TITLE
refactor: zustand store를 provider로 제공하도록 변경

### DIFF
--- a/src/app/_providers/stores.context.tsx
+++ b/src/app/_providers/stores.context.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { StoreApi, UseBoundStore } from 'zustand';
+import { UIState } from '@/entities/ui-state';
+import { CurrentPartyroom } from 'entities/current-partyroom';
+
+export type Stores = {
+  useUIState: UseBoundStore<StoreApi<UIState.Model>>;
+  useCurrentPartyroom: UseBoundStore<StoreApi<CurrentPartyroom.Model>>;
+};
+
+export const StoresContext = createContext<Stores | null>(null);
+
+/**
+ * zustand store가 RSC에서 오용되는걸 방지하기 위해 context로 제공.
+ * @see https://github.com/pmndrs/zustand/discussions/2200
+ */
+export const useStores = () => {
+  const context = useContext(StoresContext);
+
+  if (!context) {
+    throw new Error('useStore must be used within a StoreContext');
+  }
+
+  return context;
+};

--- a/src/app/_providers/stores.provider.tsx
+++ b/src/app/_providers/stores.provider.tsx
@@ -1,9 +1,17 @@
 'use client';
 
 import { ReactNode, useState } from 'react';
-import { createUIStateStore } from '@/entities/ui-state';
-import { createCurrentPartyroomStore } from 'entities/current-partyroom';
-import { StoresContext, Stores } from './stores.context';
+import { StoreApi, UseBoundStore } from 'zustand';
+import { UIState, createUIStateStore } from '@/entities/ui-state';
+import { StoresContext, Stores } from '@/shared/lib/store/stores.context';
+import { CurrentPartyroom, createCurrentPartyroomStore } from 'entities/current-partyroom';
+
+declare module '@/shared/lib/store/stores.context' {
+  interface Stores {
+    useUIState: UseBoundStore<StoreApi<UIState.Model>>;
+    useCurrentPartyroom: UseBoundStore<StoreApi<CurrentPartyroom.Model>>;
+  }
+}
 
 export default function StoresProvider({ children }: { children: ReactNode }) {
   const [stores] = useState<Stores>(() => ({

--- a/src/app/_providers/stores.provider.tsx
+++ b/src/app/_providers/stores.provider.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { createUIStateStore } from '@/entities/ui-state';
+import { createCurrentPartyroomStore } from 'entities/current-partyroom';
+import { StoresContext, Stores } from './stores.context';
+
+export default function StoresProvider({ children }: { children: ReactNode }) {
+  const [stores] = useState<Stores>(() => ({
+    useUIState: createUIStateStore(),
+    useCurrentPartyroom: createCurrentPartyroomStore(),
+  }));
+
+  return <StoresContext.Provider value={stores}>{children}</StoresContext.Provider>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import '@rainbow-me/rainbowkit/styles.css';
 import '@/shared/ui/foundation/globals.css';
 
 import { PropsWithChildren } from 'react';
+import StoresProvider from '@/app/_providers/stores.provider';
 import { MeHydration } from '@/entities/me';
 import { DomId } from '@/shared/config/dom-id';
 import { Language } from '@/shared/lib/localization/constants';
@@ -37,7 +38,9 @@ const RootLayout = async ({ children }: PropsWithChildren) => {
             <I18nProvider dictionary={dictionary}>
               <DialogProvider>
                 <MeHydration>
-                  <PartyroomConnectionProvider>{children}</PartyroomConnectionProvider>
+                  <StoresProvider>
+                    <PartyroomConnectionProvider>{children}</PartyroomConnectionProvider>
+                  </StoresProvider>
                 </MeHydration>
               </DialogProvider>
             </I18nProvider>

--- a/src/entities/current-partyroom/index.ts
+++ b/src/entities/current-partyroom/index.ts
@@ -1,9 +1,9 @@
 export { isPartyroomSubscription, getPartyroomDestination } from './config/destination';
 
-export { default as useCurrentPartyroom } from './model/current-partyroom.store';
-export type { MyPartyroomInfo } from './model/current-partyroom.model';
+export { createCurrentPartyroomStore } from './model/current-partyroom.store';
+export * as CurrentPartyroom from './model/current-partyroom.model';
 export * as Dj from './model/dj.model';
 
-export { default as handlePartyroomSubscriptionEvent } from './lib/handle-subscription-event';
+export { default as useHandlePartyroomSubscriptionEvent } from './lib/handle-subscription-event';
 
 export { default as fetchPartyroomSetUpInfo } from './api/fetch-set-up-info';

--- a/src/entities/current-partyroom/lib/handle-subscription-event.ts
+++ b/src/entities/current-partyroom/lib/handle-subscription-event.ts
@@ -1,54 +1,65 @@
+import { useCallback } from 'react';
 import { IMessage } from '@stomp/stompjs';
 import { PartyroomEventType, PartyroomSubEvent } from '@/shared/api/websocket/types/partyroom';
 import { warnLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
-import accessCallback from './subscription-callbacks/access-callback';
-import aggregationCallback from './subscription-callbacks/aggregation-callback';
-import chatCallback from './subscription-callbacks/chat-callback';
-import deactivationCallback from './subscription-callbacks/deactivation-callback';
-import motionCallback from './subscription-callbacks/motion-callback';
-import noticeCallback from './subscription-callbacks/notice-callback';
-import playbackCallback from './subscription-callbacks/playback-callback';
+import useAccessCallback from './subscription-callbacks/use-access-callback.hook';
+import useAggregationCallback from './subscription-callbacks/use-aggregation-callback.hook';
+import useChatCallback from './subscription-callbacks/use-chat-callback.hook';
+import useDeactivationCallback from './subscription-callbacks/use-deactivation-callback.hook';
+import useMotionCallback from './subscription-callbacks/use-motion-callback.hook';
+import useNoticeCallback from './subscription-callbacks/use-notice-callback.hook';
+import usePlaybackCallback from './subscription-callbacks/use-playback-callback.hook';
 
 const logger = withDebugger(0);
 const warnLogger = logger(warnLog);
 
-export default function handleSubscriptionEvent(message: IMessage) {
-  const event = parseMessage(message);
+export default function useHandleSubscriptionEvent() {
+  const accessCallback = useAccessCallback();
+  const chatCallback = useChatCallback();
+  const motionCallback = useMotionCallback();
+  const noticeCallback = useNoticeCallback();
+  const aggregationCallback = useAggregationCallback();
+  const playbackCallback = usePlaybackCallback();
+  const deactivationCallback = useDeactivationCallback();
 
-  if (!hasEventType(event)) {
-    // It's probably a message that hasn't been processed on the backend.
-    return;
-  }
+  return useCallback((message: IMessage) => {
+    const event = parseMessage(message);
 
-  if (!isPartyroomSubEvent(event)) {
-    warnLogger('Unknown event type:', event);
-    return;
-  }
+    if (!hasEventType(event)) {
+      // It's probably a message that hasn't been processed on the backend.
+      return;
+    }
 
-  switch (event.eventType) {
-    case PartyroomEventType.ACCESS:
-      accessCallback(event);
-      break;
-    case PartyroomEventType.CHAT:
-      chatCallback(event);
-      break;
-    case PartyroomEventType.MOTION:
-      motionCallback(event);
-      break;
-    case PartyroomEventType.NOTICE:
-      noticeCallback(event);
-      break;
-    case PartyroomEventType.AGGREGATION:
-      aggregationCallback(event);
-      break;
-    case PartyroomEventType.PLAYBACK:
-      playbackCallback(event);
-      break;
-    case PartyroomEventType.DEACTIVATION:
-      deactivationCallback(event);
-      break;
-  }
+    if (!isPartyroomSubEvent(event)) {
+      warnLogger('Unknown event type:', event);
+      return;
+    }
+
+    switch (event.eventType) {
+      case PartyroomEventType.ACCESS:
+        accessCallback(event);
+        break;
+      case PartyroomEventType.CHAT:
+        chatCallback(event);
+        break;
+      case PartyroomEventType.MOTION:
+        motionCallback(event);
+        break;
+      case PartyroomEventType.NOTICE:
+        noticeCallback(event);
+        break;
+      case PartyroomEventType.AGGREGATION:
+        aggregationCallback(event);
+        break;
+      case PartyroomEventType.PLAYBACK:
+        playbackCallback(event);
+        break;
+      case PartyroomEventType.DEACTIVATION:
+        deactivationCallback(event);
+        break;
+    }
+  }, []);
 }
 
 function hasEventType(event: Record<string, unknown>): event is { eventType: unknown } {

--- a/src/entities/current-partyroom/lib/subscription-callbacks/access-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/access-callback.ts
@@ -1,5 +1,0 @@
-import { AccessEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function accessCallback(event: AccessEvent) {
-  console.log('accessCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/aggregation-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/aggregation-callback.ts
@@ -1,5 +1,0 @@
-import { AggregationEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function aggregationCallback(event: AggregationEvent) {
-  console.log('aggregationCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/chat-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/chat-callback.ts
@@ -1,5 +1,0 @@
-import { ChatEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function chatCallback(event: ChatEvent) {
-  console.log('chatCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/deactivation-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/deactivation-callback.ts
@@ -1,5 +1,0 @@
-import { DeactivationEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function deactivationCallback(event: DeactivationEvent) {
-  console.log('deactivationCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/motion-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/motion-callback.ts
@@ -1,5 +1,0 @@
-import { MotionEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function motionCallback(event: MotionEvent) {
-  console.log('motionCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/notice-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/notice-callback.ts
@@ -1,5 +1,0 @@
-import { NoticeEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function noticeCallback(event: NoticeEvent) {
-  console.log('noticeCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/playback-callback.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/playback-callback.ts
@@ -1,5 +1,0 @@
-import { PlaybackEvent } from '@/shared/api/websocket/types/partyroom';
-
-export default function playbackCallback(event: PlaybackEvent) {
-  console.log('playbackCallback', event);
-}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-access-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-access-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { AccessEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useAccessCallback() {
+  return useCallback((event: AccessEvent) => {
+    console.log('AccessEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-aggregation-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-aggregation-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { AggregationEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useAggregationCallback() {
+  return useCallback((event: AggregationEvent) => {
+    console.log('AggregationEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-chat-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-chat-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { ChatEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useChatCallback() {
+  return useCallback((event: ChatEvent) => {
+    console.log('ChatEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-deactivation-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-deactivation-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { DeactivationEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useDeactivationCallback() {
+  return useCallback((event: DeactivationEvent) => {
+    console.log('DeactivationEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-motion-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-motion-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { MotionEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useMotionCallback() {
+  return useCallback((event: MotionEvent) => {
+    console.log('MotionEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-notice-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-notice-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { NoticeEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function useNoticeCallback() {
+  return useCallback((event: NoticeEvent) => {
+    console.log('NoticeEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/lib/subscription-callbacks/use-playback-callback.hook.ts
+++ b/src/entities/current-partyroom/lib/subscription-callbacks/use-playback-callback.hook.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { PlaybackEvent } from '@/shared/api/websocket/types/partyroom';
+
+export default function usePlaybackCallback() {
+  return useCallback((event: PlaybackEvent) => {
+    console.log('PlaybackEvent:', event);
+  }, []);
+}

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -8,7 +8,7 @@ export type MyPartyroomInfo = {
   host: boolean;
 };
 
-export type CurrentPartyroom = {
+export type Model = {
   id?: number;
 
   me?: MyPartyroomInfo;
@@ -23,8 +23,6 @@ export type CurrentPartyroom = {
   reaction?: PartyroomReaction;
   updateReaction: (next: Next<PartyroomReaction | undefined>) => void;
 
-  init: (
-    next: Pick<CurrentPartyroom, 'id' | 'me' | 'playbackActivated' | 'playback' | 'reaction'>
-  ) => void;
+  init: (next: Pick<Model, 'id' | 'me' | 'playbackActivated' | 'playback' | 'reaction'>) => void;
   reset: () => void;
 };

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -2,71 +2,71 @@
 
 import { create } from 'zustand';
 import { update } from '@/shared/lib/functions/update';
-import { CurrentPartyroom } from '../model/current-partyroom.model';
+import * as CurrentPartyroom from '../model/current-partyroom.model';
 
-const useCurrentPartyroom = create<CurrentPartyroom>((set) => ({
-  id: undefined,
+export const createCurrentPartyroomStore = () => {
+  return create<CurrentPartyroom.Model>((set) => ({
+    id: undefined,
 
-  me: undefined,
-  updateMe: (next) => {
-    return set((state) => {
-      const updated = update(state.me, next);
+    me: undefined,
+    updateMe: (next) => {
+      return set((state) => {
+        const updated = update(state.me, next);
 
-      return {
-        me: updated,
-      };
-    });
-  },
+        return {
+          me: updated,
+        };
+      });
+    },
 
-  playbackActivated: false,
-  updatePlaybackActivated: (next) => {
-    return set((state) => {
-      const updated = update(state.playbackActivated, next);
+    playbackActivated: false,
+    updatePlaybackActivated: (next) => {
+      return set((state) => {
+        const updated = update(state.playbackActivated, next);
 
-      return {
-        playbackActivated: updated,
-      };
-    });
-  },
+        return {
+          playbackActivated: updated,
+        };
+      });
+    },
 
-  playback: undefined,
-  updatePlayback: (next) => {
-    return set((state) => {
-      const updated = update(state.playback, next);
+    playback: undefined,
+    updatePlayback: (next) => {
+      return set((state) => {
+        const updated = update(state.playback, next);
 
-      return {
-        playback: updated,
-      };
-    });
-  },
+        return {
+          playback: updated,
+        };
+      });
+    },
 
-  reaction: undefined,
-  updateReaction: (next) => {
-    return set((state) => {
-      const updated = update(state.reaction, next);
+    reaction: undefined,
+    updateReaction: (next) => {
+      return set((state) => {
+        const updated = update(state.reaction, next);
 
-      return {
-        reaction: updated,
-      };
-    });
-  },
+        return {
+          reaction: updated,
+        };
+      });
+    },
 
-  init: (next) => {
-    return set(next, true);
-  },
+    init: (next) => {
+      return set(next, true);
+    },
 
-  reset: () => {
-    return set(
-      {
-        id: undefined,
-        me: undefined,
-        playbackActivated: false,
-        playback: undefined,
-        reaction: undefined,
-      },
-      true
-    );
-  },
-}));
-
-export default useCurrentPartyroom;
+    reset: () => {
+      return set(
+        {
+          id: undefined,
+          me: undefined,
+          playbackActivated: false,
+          playback: undefined,
+          reaction: undefined,
+        },
+        true
+      );
+    },
+  }));
+};

--- a/src/entities/ui-state/index.ts
+++ b/src/entities/ui-state/index.ts
@@ -1,1 +1,2 @@
-export { default as useUIState } from './model/ui-state.store';
+export * as UIState from './model/ui-state.model';
+export { createUIStateStore } from './model/ui-state.store';

--- a/src/entities/ui-state/model/ui-state.store.tsx
+++ b/src/entities/ui-state/model/ui-state.store.tsx
@@ -9,32 +9,32 @@ import * as UIState from './ui-state.model';
 const logger = withDebugger(0);
 const log = logger(warnLog);
 
-const useUIState = create<UIState.Model>((set) => ({
-  playlistDrawer: {
-    ...UIState.initialValues.playlistDrawer,
-  },
-  setPlaylistDrawer: (v) => {
-    return set((state) => {
-      const updated = update(state.playlistDrawer, v);
+export const createUIStateStore = () => {
+  return create<UIState.Model>((set) => ({
+    playlistDrawer: {
+      ...UIState.initialValues.playlistDrawer,
+    },
+    setPlaylistDrawer: (v) => {
+      return set((state) => {
+        const updated = update(state.playlistDrawer, v);
 
-      if (!updated.open) {
-        resetValues('interactable', 'zIndex', 'selectedPlaylist');
+        if (!updated.open) {
+          resetValues('interactable', 'zIndex', 'selectedPlaylist');
 
-        function resetValues<K extends keyof UIState.Model['playlistDrawer']>(...keys: K[]) {
-          keys.forEach((key) => {
-            if (updated[key] !== UIState.initialValues.playlistDrawer[key]) {
-              log(`플레이리스트가 닫혀 ${key}가 초기 값으로 변경됩니다.`);
-              updated[key] = UIState.initialValues.playlistDrawer[key];
-            }
-          });
+          function resetValues<K extends keyof UIState.Model['playlistDrawer']>(...keys: K[]) {
+            keys.forEach((key) => {
+              if (updated[key] !== UIState.initialValues.playlistDrawer[key]) {
+                log(`플레이리스트가 닫혀 ${key}가 초기 값으로 변경됩니다.`);
+                updated[key] = UIState.initialValues.playlistDrawer[key];
+              }
+            });
+          }
         }
-      }
 
-      return {
-        playlistDrawer: updated,
-      };
-    });
-  },
-}));
-
-export default useUIState;
+        return {
+          playlistDrawer: updated,
+        };
+      });
+    },
+  }));
+};

--- a/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
+++ b/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
@@ -1,6 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useStores } from '@/app/_providers/stores.context';
 import {
   fetchPartyroomSetUpInfo,
   getPartyroomDestination,
@@ -12,6 +11,7 @@ import { APIError } from '@/shared/api/http/types/@shared';
 import { EnterPayload, EnterResponse } from '@/shared/api/http/types/partyrooms';
 import { errorLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
 
 export function useEnterPartyroom() {

--- a/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
+++ b/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { useStores } from '@/app/_providers/stores.context';
 import {
   fetchPartyroomSetUpInfo,
   getPartyroomDestination,
-  handlePartyroomSubscriptionEvent,
-  useCurrentPartyroom,
+  useHandlePartyroomSubscriptionEvent,
 } from '@/entities/current-partyroom';
 import { usePartyroomClient } from '@/entities/partyroom-client';
 import PartyroomsService from '@/shared/api/http/services/partyrooms';
@@ -15,9 +15,11 @@ import withDebugger from '@/shared/lib/functions/log/with-debugger';
 import { useDialog } from '@/shared/ui/components/dialog';
 
 export function useEnterPartyroom() {
+  const { useCurrentPartyroom } = useStores();
   const initPartyroom = useCurrentPartyroom((state) => state.init);
   const { openErrorDialog } = useDialog();
   const client = usePartyroomClient();
+  const handleEvent = useHandlePartyroomSubscriptionEvent();
 
   const handleSuccess = (enterResponse: EnterResponse, { partyroomId }: EnterPayload) => {
     fetchPartyroomSetUpInfo(partyroomId, {
@@ -37,7 +39,7 @@ export function useEnterPartyroom() {
           reaction: setUpInfo.display.reaction,
         });
 
-        client.subscribe(getPartyroomDestination(partyroomId), handlePartyroomSubscriptionEvent);
+        client.subscribe(getPartyroomDestination(partyroomId), handleEvent);
       },
       onError: (error) => {
         errorLogger(error);

--- a/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
+++ b/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useCurrentPartyroom } from '@/entities/current-partyroom';
+import { useStores } from '@/app/_providers/stores.context';
 import { usePartyroomClient } from '@/entities/partyroom-client';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import PartyroomsService from '@/shared/api/http/services/partyrooms';
@@ -10,6 +10,7 @@ import { ExitPayload } from '@/shared/api/http/types/partyrooms';
 export function useExitPartyroom() {
   const queryClient = useQueryClient();
   const client = usePartyroomClient();
+  const { useCurrentPartyroom } = useStores();
   const resetPartyroom = useCurrentPartyroom((state) => state.reset);
 
   return useMutation<void, AxiosError<APIError>, ExitPayload>({

--- a/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
+++ b/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useStores } from '@/app/_providers/stores.context';
 import { usePartyroomClient } from '@/entities/partyroom-client';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import PartyroomsService from '@/shared/api/http/services/partyrooms';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { ExitPayload } from '@/shared/api/http/types/partyrooms';
+import { useStores } from '@/shared/lib/store/stores.context';
 
 export function useExitPartyroom() {
   const queryClient = useQueryClient();

--- a/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
+++ b/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useUIState } from '@/entities/ui-state';
+import { useStores } from '@/app/_providers/stores.context';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import useDidMountEffect from '@/shared/lib/hooks/use-did-mount-effect';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
@@ -20,6 +20,7 @@ type Props = {
 export default function useSelectPlaylist({ playlists }: Props): () => Promise<Playlist | void> {
   const t = useI18n();
   const { openConfirmDialog, openDialog } = useDialog();
+  const { useUIState } = useStores();
   const setPlaylistDrawer = useUIState((state) => state.setPlaylistDrawer);
 
   const guidePrepareSelect = async () => {
@@ -44,8 +45,9 @@ export default function useSelectPlaylist({ playlists }: Props): () => Promise<P
         </Typography>
       ),
       Body: () => {
-        const [selected, setSelected] = useState<Playlist>();
+        const { useUIState } = useStores();
         const setPlaylistDrawer = useUIState((state) => state.setPlaylistDrawer);
+        const [selected, setSelected] = useState<Playlist>();
 
         const closePlaylistDrawer = () => {
           setPlaylistDrawer({

--- a/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
+++ b/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { useStores } from '@/app/_providers/stores.context';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import useDidMountEffect from '@/shared/lib/hooks/use-did-mount-effect';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
 import theme from '@/shared/ui/foundation/theme';

--- a/src/features/playlist/add-musics/ui/entry-button.component.tsx
+++ b/src/features/playlist/add-musics/ui/entry-button.component.tsx
@@ -1,7 +1,7 @@
-import { useStores } from '@/app/_providers/stores.context';
 import { usePlaylistAction } from '@/entities/playlist';
 import { PlaylistActionBypassProvider } from '@/entities/playlist/lib/playlist-action.context';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { TextButton } from '@/shared/ui/components/text-button';

--- a/src/features/playlist/add-musics/ui/entry-button.component.tsx
+++ b/src/features/playlist/add-musics/ui/entry-button.component.tsx
@@ -1,6 +1,6 @@
+import { useStores } from '@/app/_providers/stores.context';
 import { usePlaylistAction } from '@/entities/playlist';
 import { PlaylistActionBypassProvider } from '@/entities/playlist/lib/playlist-action.context';
-import { useUIState } from '@/entities/ui-state';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import { useDialog } from '@/shared/ui/components/dialog';
@@ -12,6 +12,7 @@ const EntryButton = () => {
   const t = useI18n();
   const { openDialog } = useDialog();
   const playlistAction = usePlaylistAction();
+  const { useUIState } = useStores();
   const playlistDrawer = useUIState((state) => state.playlistDrawer);
 
   const handleAddMusic = () => {

--- a/src/features/playlist/add/ui/form.component.tsx
+++ b/src/features/playlist/add/ui/form.component.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
-import { useStores } from '@/app/_providers/stores.context';
 import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
 import { ErrorCode } from '@/shared/api/http/types/@shared';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Dialog } from '@/shared/ui/components/dialog';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';

--- a/src/features/playlist/add/ui/form.component.tsx
+++ b/src/features/playlist/add/ui/form.component.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
+import { useStores } from '@/app/_providers/stores.context';
 import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
-import { useUIState } from '@/entities/ui-state';
 import { ErrorCode } from '@/shared/api/http/types/@shared';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Dialog } from '@/shared/ui/components/dialog';
@@ -12,6 +12,7 @@ import { useCreatePlaylist } from '../api/use-create-playlist.mutation';
 export default function useAddPlaylistDialog() {
   const t = useI18n();
   const { openDialog } = useDialog();
+  const { useUIState } = useStores();
   const playlistDrawer = useUIState((state) => state.playlistDrawer);
 
   return useCallback(() => {

--- a/src/features/playlist/edit/ui/form.component.tsx
+++ b/src/features/playlist/edit/ui/form.component.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
-import { useStores } from '@/app/_providers/stores.context';
 import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { useUpdatePlaylist } from '../api/use-update-playlist.mutation';
 

--- a/src/features/playlist/edit/ui/form.component.tsx
+++ b/src/features/playlist/edit/ui/form.component.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SubmitHandler } from 'react-hook-form';
+import { useStores } from '@/app/_providers/stores.context';
 import { PlaylistForm, PlaylistFormProps, PlaylistFormValues } from '@/entities/playlist';
-import { useUIState } from '@/entities/ui-state';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useDialog } from '@/shared/ui/components/dialog';
@@ -10,6 +10,7 @@ import { useUpdatePlaylist } from '../api/use-update-playlist.mutation';
 export default function useEditPlaylistDialog(playlists: Playlist[]) {
   const t = useI18n();
   const { openDialog } = useDialog();
+  const { useUIState } = useStores();
   const playlistDrawer = useUIState((state) => state.playlistDrawer);
 
   return useCallback(

--- a/src/features/playlist/remove/ui/remove-button.component.tsx
+++ b/src/features/playlist/remove/ui/remove-button.component.tsx
@@ -1,5 +1,5 @@
+import { useStores } from '@/app/_providers/stores.context';
 import { usePlaylistAction } from '@/entities/playlist';
-import { useUIState } from '@/entities/ui-state';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
@@ -15,6 +15,7 @@ const RemoveButton = ({ targetIds, onSuccess }: RemoveButtonProps) => {
   const t = useI18n();
   const { openDialog } = useDialog();
   const playlistAction = usePlaylistAction();
+  const { useUIState } = useStores();
   const playlistDrawer = useUIState((state) => state.playlistDrawer);
 
   const handleClick = () => {

--- a/src/features/playlist/remove/ui/remove-button.component.tsx
+++ b/src/features/playlist/remove/ui/remove-button.component.tsx
@@ -1,7 +1,7 @@
-import { useStores } from '@/app/_providers/stores.context';
 import { usePlaylistAction } from '@/entities/playlist';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
 import { Dialog, useDialog } from '@/shared/ui/components/dialog';
 import { PFDelete } from '@/shared/ui/icons';

--- a/src/shared/lib/store/stores.context.tsx
+++ b/src/shared/lib/store/stores.context.tsx
@@ -1,14 +1,23 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import { StoreApi, UseBoundStore } from 'zustand';
-import { UIState } from '@/entities/ui-state';
-import { CurrentPartyroom } from 'entities/current-partyroom';
 
-export type Stores = {
-  useUIState: UseBoundStore<StoreApi<UIState.Model>>;
-  useCurrentPartyroom: UseBoundStore<StoreApi<CurrentPartyroom.Model>>;
-};
+/**
+ * context 구현부에서 declaration-merging을 통해 인터페이스를 확장하여 사용해주세요.
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+ *
+ * @example
+ * ```ts
+ * declare module '@/shared/lib/store/stores.context' {
+ *   interface Stores {
+ *     useStoreA: ...;
+ *     useStoreB: ...;
+ *   }
+ * }
+ * ```
+ */
+export interface Stores {}
 
 export const StoresContext = createContext<Stores | null>(null);
 

--- a/src/widgets/my-playlist/ui/my-playlist.component.tsx
+++ b/src/widgets/my-playlist/ui/my-playlist.component.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useStores } from '@/app/_providers/stores.context';
 import { AddPlaylistButton } from '@/features/playlist/add';
 import { AddMusicsToPlaylistButton } from '@/features/playlist/add-musics';
 import { Playlists, EditablePlaylists, PlaylistListItem } from '@/features/playlist/list';
@@ -8,6 +7,7 @@ import { RemovePlaylistButton } from '@/features/playlist/remove';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Drawer, DrawerProps } from '@/shared/ui/components/drawer';
 import { TextButton } from '@/shared/ui/components/text-button';
 import { PFArrowLeft } from '@/shared/ui/icons';

--- a/src/widgets/my-playlist/ui/my-playlist.component.tsx
+++ b/src/widgets/my-playlist/ui/my-playlist.component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useUIState } from '@/entities/ui-state';
+import { useStores } from '@/app/_providers/stores.context';
 import { AddPlaylistButton } from '@/features/playlist/add';
 import { AddMusicsToPlaylistButton } from '@/features/playlist/add-musics';
 import { Playlists, EditablePlaylists, PlaylistListItem } from '@/features/playlist/list';
@@ -14,6 +14,7 @@ import { PFArrowLeft } from '@/shared/ui/icons';
 
 export default function MyPlaylist() {
   const t = useI18n();
+  const { useUIState } = useStores();
   const { playlistDrawer, setPlaylistDrawer } = useUIState();
   const [editMode, setEditMode] = useState(false);
   const [removeTargets, setRemoveTargets] = useState<Playlist['id'][]>([]);

--- a/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
@@ -1,8 +1,8 @@
-import { useStores } from '@/app/_providers/stores.context';
 import { Dj } from '@/entities/current-partyroom';
 import { DjingQueue } from '@/shared/api/http/types/partyrooms';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
 import { DjListItem } from '@/shared/ui/components/dj-list-item';
 import { Typography } from '@/shared/ui/components/typography';

--- a/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
@@ -1,4 +1,5 @@
-import { Dj, useCurrentPartyroom } from '@/entities/current-partyroom';
+import { useStores } from '@/app/_providers/stores.context';
+import { Dj } from '@/entities/current-partyroom';
 import { DjingQueue } from '@/shared/api/http/types/partyrooms';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
@@ -20,6 +21,7 @@ export default function Body({ djingQueue, onCancel }: Props) {
   }
 
   const t = useI18n();
+  const { useCurrentPartyroom } = useStores();
   const myMemberId = useCurrentPartyroom((state) => state.me?.memberId);
 
   const [currentDj, ...queue] = djingQueue.djs;

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { ReactNode } from 'react';
-import { useStores } from '@/app/_providers/stores.context';
 import { useSuspenseFetchMe } from '@/entities/me';
 import { ProfileEditFormV2 } from '@/features/edit-profile-bio';
 import { mergeDeep } from '@/shared/lib/functions/merge-deep';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
 import Profile from '@/shared/ui/components/profile/profile.component';
 import { Typography } from '@/shared/ui/components/typography';

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ReactNode } from 'react';
+import { useStores } from '@/app/_providers/stores.context';
 import { useSuspenseFetchMe } from '@/entities/me';
-import { useUIState } from '@/entities/ui-state';
 import { ProfileEditFormV2 } from '@/features/edit-profile-bio';
 import { mergeDeep } from '@/shared/lib/functions/merge-deep';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
@@ -23,6 +23,7 @@ const Sidebar = ({ className, extraButton }: SidebarProps) => {
   const t = useI18n();
   const { data: me } = useSuspenseFetchMe();
   const { openDialog } = useDialog();
+  const { useUIState } = useStores();
   const setPlaylistDrawer = useUIState((state) => state.setPlaylistDrawer);
 
   const togglePlaylist = () => {


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

RSC에서 소위 '글로벌' 스코프를 사용하면 최악의 경우 모든 유저가 서버 내 하나의 스토어 상태를 바라보는 결과를 낳을 수 있습니다.

zustand 레포 내에서도 [이에 대에 주의할 것을 당부하고 있습니다.](https://github.com/pmndrs/zustand/discussions/2200)

오용을 방지하기 위해 스토어를 context를 통해 제공하도록 변경합니다.


### NOTE 1
`handleSubscriptionEvent` 하위 핸들러들을 함수로 뒀던 이유는 "내부에서 '글로벌' 스토어 레퍼런스의 setState를 호출하는 방향으로 작업하려고" 였기 때문입니다. 이제 훅을 통해 스토어를 참조해야 하니, 이 함수 또한 훅으로 변경합니다.

### NOTE 2
현재 스토어 사용법은 아래와 같습니다.

```tsx
const { useFooBar } = useStores(); // 스토어를 컨텍스트에서 꺼내옴
const foo = useFooBar(state => state.foo) // 여기서부턴 zustand store 사용법
```

매번 스토어를 사용할 때마다 이 같은 과정을 거쳐야 한다니 좀 난잡한데요,

```tsx
const foo = useBoundStore(state => state.fooBar.foo); // 이렇게 간편하게 사용하게 하고 싶었으나..
```

[슬라이스 패턴](https://docs.pmnd.rs/zustand/guides/typescript#slices-pattern)은 프로퍼티들이 스코프로 묶이지 않는다는 단점이 있고, 각 슬라이스를 바로 위 예제와 같이 store 객체 내 하나의 key(스코프)에 할당하려면 슬라이스 구현부가 매우 더러워집니다. 더러워지지 않으려면 뭔가 [zustand 미들웨어](https://docs.pmnd.rs/zustand/guides/typescript#middleware-that-changes-the-store-type)를 통해 이상한걸 구현해야 하여.. 그냥 포기하고 사용부에서 약간 불편함 감수하기로 했습니다.