### PR TITLE
fix(widgets/partyroom-djing-dialog): DJ를 단순 index가 아닌 orderNumber 순으로 나열

### DIFF
--- a/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
@@ -24,7 +24,9 @@ export default function Body({ djingQueue, onCancel }: Props) {
   const { useCurrentPartyroom } = useStores();
   const myMemberId = useCurrentPartyroom((state) => state.me?.memberId);
 
-  const [currentDj, ...queue] = djingQueue.djs;
+  const [currentDj, ...queue] = djingQueue.djs
+    .slice()
+    .sort((a, b) => a.orderNumber - b.orderNumber);
   const isMeInQueue = queue.some((dj) => dj.djId === myMemberId);
 
   return (


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
 DJ를 단순 index가 아닌 orderNumber 순으로 나열