### PR TITLE
feat(features/playlist/list): 언어가 변경될 때마다 해당 언어에 맞춰 Grab Playlist의 이름 덮어씌우기

### DIFF
--- a/src/features/playlist/list/api/use-fetch-playlists.query.ts
+++ b/src/features/playlist/list/api/use-fetch-playlists.query.ts
@@ -1,38 +1,47 @@
 'use client';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import PlaylistsService from '@/shared/api/http/services/playlists';
+import { PlaylistType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { GetPlaylistsResponse, Playlist } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
-import { Language } from '@/shared/lib/localization/constants';
-import { useLang } from '@/shared/lib/localization/lang.context';
+import { Dictionary, useI18n } from '@/shared/lib/localization/i18n.context';
 
-export const useFetchPlaylists = () => {
-  const lang = useLang();
+export default function useFetchPlaylists() {
+  const queryClient = useQueryClient();
+  const t = useI18n();
+
+  useEffect(() => {
+    // 언어가 변경될 때마다 해당 언어에 맞춰 Grab Playlist의 이름을 다시 덮어씌움
+    const cached = queryClient.getQueryData<GetPlaylistsResponse>([QueryKeys.Playlist]);
+
+    if (cached) {
+      queryClient.setQueryData<GetPlaylistsResponse>([QueryKeys.Playlist], {
+        playlists: overwriteGrabPlaylistName(cached.playlists, t),
+      });
+    }
+  }, [t]);
 
   return useQuery<GetPlaylistsResponse, AxiosError<APIError>, Playlist[]>({
     queryKey: [QueryKeys.Playlist],
     queryFn: () => PlaylistsService.getPlaylists(),
-    /**
-     * FIXME
-     * https://pfplay.slack.com/archives/C051N8A0ZSB/p1719775341481399
-     * 번역을 FE에서 주관하고 있어서 백엔드에서 생성하는 그랩 플레이리스트명을 번역할 방법이 아직 없음.. 일단 나쁜 짓으로 처리.
-     * 방안 논의 필요
-     */
-    select: ({ playlists }) => {
-      return playlists.map((playlist) => {
-        if (playlist.name === '그랩한 곡' && lang === Language.En) {
-          return {
-            ...playlist,
-            name: 'Grabbed song',
-          };
-        }
-        return playlist;
-      });
-    },
+    select: ({ playlists }) => overwriteGrabPlaylistName(playlists, t),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });
-};
+}
+
+function overwriteGrabPlaylistName(playlists: Playlist[], t: Dictionary) {
+  return playlists.map((playlist) => {
+    if (playlist.type === PlaylistType.GRABLIST) {
+      return {
+        ...playlist,
+        name: t.playlist.title.grabbed_song,
+      };
+    }
+    return playlist;
+  });
+}

--- a/src/features/playlist/list/index.ts
+++ b/src/features/playlist/list/index.ts
@@ -1,4 +1,4 @@
 export { default as EditablePlaylists } from './ui/editable-list.component';
 export { default as Playlists } from './ui/list.component';
 export { default as PlaylistListItem } from './ui/list-item.component';
-export { useFetchPlaylists } from './api/use-fetch-playlists.query';
+export { default as useFetchPlaylists } from './api/use-fetch-playlists.query';


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
현재 다국어 json은 FE에서 들고 있습니다. BE에선 grab playlist에 대해 FE의 언어가 무엇이든 상관없이(알 방법이 없으니) '그랩한 곡'이라는 문자를 name 필드에 고정으로 내려줍니다.

playlists 목록을 새로 받을 때, 그리고 언어가 변경될 때마다 현재 언어에 맞춰 grab playlist의 name 필드를 덮어씌우도록 설정합니다.