### PR TITLE
feat(features/playlist/add-musics): 선택된 플레이리스트가 있을 경우 해당 플레이리스트에 바로 음악 추가

### DIFF
--- a/src/features/playlist/add-musics/ui/music-search.component.tsx
+++ b/src/features/playlist/add-musics/ui/music-search.component.tsx
@@ -2,8 +2,12 @@ import { ReactNode, useCallback, useState } from 'react';
 import { usePlaylistAction } from '@/entities/playlist';
 import { MusicListItem } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { IconMenu } from '@/shared/ui/components/icon-menu';
 import LoadingPanel from '@/shared/ui/components/loading/loading-panel.component';
+import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
+import { PFAddCircle, PFAddPlaylist } from '@/shared/ui/icons';
 import { useSearchMusics } from 'features/playlist/add-musics/api/use-search-musics.query';
 import SearchInput from './search-input.component';
 import SearchListItem from './search-list-item.component';
@@ -11,13 +15,16 @@ import SearchListItem from './search-list-item.component';
 type MusicSearchProps = {
   extraAction?: ReactNode;
 };
-const MusicSearch = ({ extraAction }: MusicSearchProps) => {
+
+export default function MusicSearch({ extraAction }: MusicSearchProps) {
   const t = useI18n();
+  const { useUIState } = useStores();
+  const selectedPlaylist = useUIState((state) => state.playlistDrawer.selectedPlaylist);
+  const playlistAction = usePlaylistAction();
   const [search, setSearch] = useState('');
   const { data: musics, isFetching } = useSearchMusics(search);
-  const playlistAction = usePlaylistAction();
 
-  const handleSelectPlaylist = useCallback(
+  const addMusicToPlaylist = useCallback(
     (listId: number, music: MusicListItem) => {
       playlistAction.addMusic(listId, {
         linkId: music.videoId,
@@ -45,13 +52,36 @@ const MusicSearch = ({ extraAction }: MusicSearchProps) => {
             <div key={music.videoId} className='py-3'>
               <SearchListItem
                 music={music}
-                onSelectPlaylist={(listId) => handleSelectPlaylist(listId, music)}
+                suffix={
+                  selectedPlaylist ? (
+                    // 선택된 플레이리스트가 있을 경우 해당 플레이리스트에 바로 음악 추가
+                    <TextButton
+                      Icon={<PFAddPlaylist />}
+                      onClick={() => addMusicToPlaylist(selectedPlaylist.id, music)}
+                    />
+                  ) : (
+                    // 선택된 플레이리스트가 없을 경우 플레이리스트 선택 메뉴 표시
+                    <IconMenu
+                      MenuButtonIcon={<PFAddPlaylist />}
+                      menuItemPanel={{ className: 'm-w-[300px] border border-gray-500' }}
+                      menuItemConfig={[
+                        ...playlistAction.list.map(({ name: label, id }) => ({
+                          label,
+                          onClickItem: () => addMusicToPlaylist(id, music),
+                        })),
+                        {
+                          label: t.playlist.btn.add_playlist,
+                          Icon: <PFAddCircle />,
+                          onClickItem: playlistAction.add,
+                        },
+                      ]}
+                    />
+                  )
+                }
               />
             </div>
           ))}
       </div>
     </div>
   );
-};
-
-export default MusicSearch;
+}

--- a/src/features/playlist/add-musics/ui/music-search.component.tsx
+++ b/src/features/playlist/add-musics/ui/music-search.component.tsx
@@ -52,7 +52,7 @@ export default function MusicSearch({ extraAction }: MusicSearchProps) {
             <div key={music.videoId} className='py-3'>
               <SearchListItem
                 music={music}
-                suffix={
+                Suffix={
                   selectedPlaylist ? (
                     // 선택된 플레이리스트가 있을 경우 해당 플레이리스트에 바로 음악 추가
                     <TextButton

--- a/src/features/playlist/add-musics/ui/search-list-item.component.tsx
+++ b/src/features/playlist/add-musics/ui/search-list-item.component.tsx
@@ -6,12 +6,12 @@ import { Typography } from '@/shared/ui/components/typography';
 
 type SearchListItemProps = {
   music: Pick<MusicListItem, 'videoTitle' | 'runningTime' | 'thumbnailUrl'>;
-  suffix: ReactNode;
+  Suffix: ReactNode;
 };
 
 export default function SearchListItem({
   music: { videoTitle, runningTime, thumbnailUrl },
-  suffix,
+  Suffix,
 }: SearchListItemProps) {
   return (
     <div className='flex items-center gap-[32px]'>
@@ -22,7 +22,7 @@ export default function SearchListItem({
         <Typography>{formatDuration(runningTime)}</Typography>
       </div>
 
-      {suffix}
+      {Suffix}
     </div>
   );
 }

--- a/src/features/playlist/add-musics/ui/search-list-item.component.tsx
+++ b/src/features/playlist/add-musics/ui/search-list-item.component.tsx
@@ -1,41 +1,18 @@
 import Image from 'next/image';
-import { useMemo } from 'react';
-import { usePlaylistAction } from '@/entities/playlist';
+import { ReactNode } from 'react';
 import { MusicListItem } from '@/shared/api/http/types/playlists';
 import { safeDecodeURI } from '@/shared/lib/functions/safe-decode-uri';
-import { useI18n } from '@/shared/lib/localization/i18n.context';
-import { IconMenu } from '@/shared/ui/components/icon-menu';
-import { MenuItem } from '@/shared/ui/components/menu';
 import { Typography } from '@/shared/ui/components/typography';
-import { PFAddCircle, PFAddPlaylist } from '@/shared/ui/icons';
 
 type SearchListItemProps = {
-  music: MusicListItem;
-  onSelectPlaylist?: (id: number) => void;
+  music: Pick<MusicListItem, 'videoTitle' | 'runningTime' | 'thumbnailUrl'>;
+  suffix: ReactNode;
 };
 
-const SearchListItem = ({
+export default function SearchListItem({
   music: { videoTitle, runningTime, thumbnailUrl },
-  onSelectPlaylist,
-}: SearchListItemProps) => {
-  const t = useI18n();
-  const playlistAction = usePlaylistAction();
-
-  const menuItemConfig: MenuItem[] = useMemo(
-    () => [
-      ...playlistAction.list.map(({ name: label, id }) => ({
-        label,
-        onClickItem: () => onSelectPlaylist?.(id),
-      })),
-      {
-        label: t.playlist.btn.add_playlist,
-        Icon: <PFAddCircle />,
-        onClickItem: playlistAction.add,
-      },
-    ],
-    [playlistAction.list, playlistAction.add, t, onSelectPlaylist]
-  );
-
+  suffix,
+}: SearchListItemProps) {
   return (
     <div className='flex items-center gap-[32px]'>
       <div className='flex-1 flex items-center gap-[12px]'>
@@ -45,14 +22,10 @@ const SearchListItem = ({
         <Typography>{formatDuration(runningTime)}</Typography>
       </div>
 
-      <IconMenu
-        MenuButtonIcon={<PFAddPlaylist />}
-        menuItemPanel={{ className: 'm-w-[300px] border border-gray-500' }}
-        menuItemConfig={menuItemConfig}
-      />
+      {suffix}
     </div>
   );
-};
+}
 
 /**
  * Format duration to 'mm:ss'
@@ -67,5 +40,3 @@ function formatDuration(duration: string) {
 
   return `${formattedMinutes}:${formattedSeconds}`;
 }
-
-export default SearchListItem;


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
원래 음악 검색 후 "playlist에 추가" 버튼을 누르면 어떤 플레이리스트로 추가할지 선택하는 드롭다운 메뉴가 나옵니다.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bdef7140-cfe1-498c-a435-059f5bbbeb91">

위처럼 특정 플레이리스트를 선택하여 들어간 상태에선 음악 검색 후 "playlist에 추가" 버튼을 눌렀을 때 해당 플레이리스트로 곧장 음악이 추가되도록 UX를 개선합니다.