### PR TITLE
refactor(entities/ui-state): initialValues를 zustand api 활용하도록 변경

### DIFF
--- a/src/entities/ui-state/model/ui-state.model.tsx
+++ b/src/entities/ui-state/model/ui-state.model.tsx
@@ -1,7 +1,5 @@
-import { ReadonlyDeep } from 'type-fest';
 import { Playlist } from '@/shared/api/http/types/playlists';
 import type { Next } from '@/shared/lib/functions/update';
-import theme from '@/shared/ui/foundation/theme';
 
 type PlaylistDrawerState = {
   open: boolean;
@@ -14,12 +12,3 @@ export type Model = {
   playlistDrawer: PlaylistDrawerState;
   setPlaylistDrawer: (v: Next<PlaylistDrawerState>) => void;
 };
-
-export const initialValues: ReadonlyDeep<Pick<Model, 'playlistDrawer'>> = Object.freeze({
-  playlistDrawer: Object.freeze({
-    open: false,
-    interactable: true,
-    zIndex: theme.zIndex.drawer,
-    selectedPlaylist: undefined,
-  }),
-});

--- a/src/entities/ui-state/model/ui-state.store.tsx
+++ b/src/entities/ui-state/model/ui-state.store.tsx
@@ -4,15 +4,19 @@ import { create } from 'zustand';
 import { warnLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
 import { update } from '@/shared/lib/functions/update';
+import theme from '@/shared/ui/foundation/theme';
 import * as UIState from './ui-state.model';
 
 const logger = withDebugger(0);
 const log = logger(warnLog);
 
 export const createUIStateStore = () => {
-  return create<UIState.Model>((set) => ({
+  return create<UIState.Model>((set, _, api) => ({
     playlistDrawer: {
-      ...UIState.initialValues.playlistDrawer,
+      open: false,
+      interactable: true,
+      zIndex: theme.zIndex.drawer,
+      selectedPlaylist: undefined,
     },
     setPlaylistDrawer: (v) => {
       return set((state) => {
@@ -22,10 +26,12 @@ export const createUIStateStore = () => {
           resetValues('interactable', 'zIndex', 'selectedPlaylist');
 
           function resetValues<K extends keyof UIState.Model['playlistDrawer']>(...keys: K[]) {
+            const initialValues = api.getInitialState().playlistDrawer;
+
             keys.forEach((key) => {
-              if (updated[key] !== UIState.initialValues.playlistDrawer[key]) {
+              if (updated[key] !== initialValues[key]) {
                 log(`플레이리스트가 닫혀 ${key}가 초기 값으로 변경됩니다.`);
-                updated[key] = UIState.initialValues.playlistDrawer[key];
+                updated[key] = initialValues[key];
               }
             });
           }


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
zustand의 create 함수 세번째 인자는 getInitialState 라는 메서드를 가지고 있어서 초기 상태를 얻어올 수 있습니다.

기존에 초기 상태를 활용하기 위해 별도 변수로 빼뒀는데, getInitialState를 활용하도록 변경합니다.