### PR TITLE
fix(features/list-musics): add music 성공 후 invalidateQueries가 실행되어도 추가된 음악이 화면에 반영되지 않던 문제

### DIFF
--- a/src/features/playlist/list-musics/api/use-fetch-playlist-musics.query.ts
+++ b/src/features/playlist/list-musics/api/use-fetch-playlist-musics.query.ts
@@ -1,15 +1,28 @@
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import PlaylistsService from '@/shared/api/http/services/playlists';
-import { GetPlaylistMusicsParameters } from '@/shared/api/http/types/playlists';
+import { APIError, PaginationResponse } from '@/shared/api/http/types/@shared';
+import { type PlaylistMusic } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES } from '@/shared/config/time';
 
-export const useFetchPlaylistMusics = (listId: number, params: GetPlaylistMusicsParameters) => {
-  return useQuery({
+export const useFetchPlaylistMusics = (listId: number) => {
+  return useQuery<PaginationResponse<PlaylistMusic>, AxiosError<APIError>>({
     queryKey: [QueryKeys.PlaylistMusics, listId],
-    queryFn: () => PlaylistsService.getMusicsFromPlaylist(listId, params),
+    queryFn: () =>
+      /**
+       * TODO: 페이지네이션 무시하고 music 최대 개수 일괄 조회 중. 추후 개선할 것. 100개라 페이지네이션 자체가 필요 없을 수도?
+       */
+      PlaylistsService.getMusicsFromPlaylist(listId, {
+        pageNumber: 0,
+        pageSize: MUSICS_COUNT_LIMIT_PER_1_PLAYLIST,
+      }),
     staleTime: 0,
     gcTime: FIVE_MINUTES,
-    enabled: params.pageSize > 0,
   });
 };
+
+/**
+ * @see https://www.figma.com/design/9I5PR6OqN8cHJ7WVTOKe00/PFPlay-GUI-%EC%84%A4%EA%B3%84%EC%84%9C-%ED%95%A9%EB%B3%B8?node-id=824-14018&t=pxcu7ZeI66HYJK3s-4
+ */
+const MUSICS_COUNT_LIMIT_PER_1_PLAYLIST = 100;

--- a/src/features/playlist/list-musics/ui/musics.component.tsx
+++ b/src/features/playlist/list-musics/ui/musics.component.tsx
@@ -11,10 +11,7 @@ type MusicsInPlaylistProps = {
 
 const MusicsInPlaylist = ({ playlist }: MusicsInPlaylistProps) => {
   const t = useI18n();
-  const { data } = useFetchPlaylistMusics(playlist.id, {
-    pageNumber: 0,
-    pageSize: playlist.musicCount,
-  });
+  const { data } = useFetchPlaylistMusics(playlist.id);
   const playlistAction = usePlaylistAction();
 
   return (

--- a/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
+++ b/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
@@ -18,9 +18,9 @@ export const useRemovePlaylistMusics = () => {
   >({
     mutationFn: PlaylistsService.removeMusicsFromPlaylist,
     onSuccess: (data) => {
-      data.listIds.forEach((id) => {
+      data.listIds.forEach((listId) => {
         queryClient.invalidateQueries({
-          queryKey: [QueryKeys.PlaylistMusics, id],
+          queryKey: [QueryKeys.PlaylistMusics, listId],
         });
         queryClient.invalidateQueries({
           queryKey: [QueryKeys.Playlist], // for refetch count

--- a/src/widgets/my-playlist/ui/my-playlist.component.tsx
+++ b/src/widgets/my-playlist/ui/my-playlist.component.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { usePlaylistAction } from '@/entities/playlist';
 import { AddPlaylistButton } from '@/features/playlist/add';
 import { AddMusicsToPlaylistButton } from '@/features/playlist/add-musics';
 import { Playlists, EditablePlaylists, PlaylistListItem } from '@/features/playlist/list';
@@ -16,6 +17,7 @@ export default function MyPlaylist() {
   const t = useI18n();
   const { useUIState } = useStores();
   const { playlistDrawer, setPlaylistDrawer } = useUIState();
+  const { list: playlists } = usePlaylistAction();
   const [editMode, setEditMode] = useState(false);
   const [removeTargets, setRemoveTargets] = useState<Playlist['id'][]>([]);
 
@@ -55,6 +57,24 @@ export default function MyPlaylist() {
       setEditMode(false);
     }
   }, [playlistDrawer.open]);
+
+  useEffect(() => {
+    /**
+     * playlists가 업데이트 될 때 스토어 내 selectedPlaylist 동기화
+     * 현재 목적은 아래 두 가지임
+     * 1. add musics, remove musics 시에 플레이리스트의 뮤직 카운트를 업데이트하기 위해 get playlists를 다시 호출하는데, 이 때 selectedPlaylist.musicCount도 업데이트 시키기 위함
+     * 2. remove playlist 시에 selectedPlaylist가 삭제되었을 경우, selectedPlaylist을 clear 시킴
+     */
+    if (playlistDrawer.selectedPlaylist) {
+      const recent = playlists.find(
+        (playlist) => playlist.id === playlistDrawer.selectedPlaylist?.id
+      );
+
+      setPlaylistDrawer({
+        selectedPlaylist: recent,
+      });
+    }
+  }, [playlists]);
 
   if (playlistDrawer.selectedPlaylist) {
     return (


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
list-musics의 페이지네이션 요청 내 pageSize가 타겟 플레이리스트의 musicCount로 고정되어 있는데,
이 params 그대로 재요청을 하니 musicCount를 업데이트 하기 전 최신에 추가된 음악들이 응답에서 제외되던게 이유입니다.
pageSize를 항상 musics의 정책상 최대 개수로 설정하여 해결합니다.

추가로 playlists 업데이트 시 selectedPlaylist를 동기화합니다 (musicCount 정상 표시)