### PR TITLE
feat: 파티룸에서 브라우저 탭 종료 시 exit api 호출하도록 처리

### DIFF
--- a/src/app/parties/(room)/[id]/layout.tsx
+++ b/src/app/parties/(room)/[id]/layout.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from 'react';
 import { isPartyroomSubscription } from '@/entities/current-partyroom';
 import { usePartyroomClient } from '@/entities/partyroom-client';
 import { useEnterPartyroom } from '@/features/partyroom/enter';
-import { useExitPartyroom } from '@/features/partyroom/exit';
+import { useExitPartyroom, onBeforePartyroomPageUnload } from '@/features/partyroom/exit';
 import useDidUpdateEffect from '@/shared/lib/hooks/use-did-update-effect';
 
 export default function PartyroomLayout({ children }: PropsWithChildren) {
@@ -21,12 +21,20 @@ export default function PartyroomLayout({ children }: PropsWithChildren) {
       return;
     }
 
+    const handleBeforeUnload = () => {
+      onBeforePartyroomPageUnload(partyroomId);
+    };
+
     client.registerConnectListener(() => {
       enter({ partyroomId });
     });
 
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
     return () => {
       exit({ partyroomId });
+
+      window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
 

--- a/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
+++ b/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
@@ -28,3 +28,10 @@ export function useExitPartyroom() {
     },
   });
 }
+
+/**
+ * 파티룸 내에서 beforeunload 이벤트가 발생하여, onSuccess 내 동작 없이 오직 exit 요청만 보낼 때 사용합니다.
+ */
+export function onBeforePartyroomPageUnload(partyroomId: number) {
+  return PartyroomsService.exit({ partyroomId });
+}

--- a/src/features/partyroom/exit/index.ts
+++ b/src/features/partyroom/exit/index.ts
@@ -1,1 +1,1 @@
-export { useExitPartyroom } from './api/use-exit-partyroom.mutation';
+export { useExitPartyroom, onBeforePartyroomPageUnload } from './api/use-exit-partyroom.mutation';


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
리스트로 돌아가는 것 외 다른 방법으로 탭 종료 시 exit api를 호출하도록 처리합니다.

컴퓨터 종료 등 비정상적인 케이스엔 대응하지 못합니다.
