### PR TITLE
Fix: menu item panel positioning issue fix

### DIFF
--- a/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
+++ b/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
@@ -1,4 +1,4 @@
-import { useState, JSX, useCallback } from 'react';
+import { useState, JSX } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
 import useClickOutside from '@/shared/lib/hooks/use-click-outside.hook';
 import { PFMoreVert } from '@/shared/ui/icons';
@@ -21,14 +21,14 @@ const DisplayOptionMenuOnHoverListener = ({
   const [isHover, setIsHover] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const handleMenuIconClick = useCallback(() => {
+  const handleMenuIconClick = () => {
     setIsMenuOpen((prev) => !prev);
-  }, []);
+  };
 
-  const handleMenuClose = useCallback(() => {
+  const handleMenuClose = () => {
     setIsMenuOpen(false);
     setIsHover(false);
-  }, []);
+  };
 
   const handleMouseEnter = () => {
     setIsHover(true);

--- a/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
+++ b/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
@@ -1,4 +1,4 @@
-import { useState, JSX } from 'react';
+import { useState, JSX, useCallback } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
 import useClickOutside from '@/shared/lib/hooks/use-click-outside.hook';
 import { PFMoreVert } from '@/shared/ui/icons';
@@ -21,25 +21,28 @@ const DisplayOptionMenuOnHoverListener = ({
   const [isHover, setIsHover] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const handleMenuIconClick = () => {
-    setIsMenuOpen(true);
-  };
+  const handleMenuIconClick = useCallback(() => {
+    setIsMenuOpen((prev) => !prev);
+  }, []);
 
-  const handleMouseLeave = () => {
-    setIsHover(false);
-    if (!isMenuOpen) {
-      setIsMenuOpen(false);
-    }
-  };
-
-  const handleMenuClose = () => {
+  const handleMenuClose = useCallback(() => {
     setIsMenuOpen(false);
     setIsHover(false);
+  }, []);
+
+  const handleMouseEnter = () => {
+    setIsHover(true);
   };
+
   const menuRef = useClickOutside<HTMLDivElement>(handleMenuClose);
 
   return (
-    <div onMouseEnter={() => setIsHover(true)} onMouseLeave={handleMouseLeave} className='relative'>
+    <div
+      ref={menuRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMenuClose}
+      className='relative'
+    >
       {children(isHover)}
 
       {!listenerDisabled && (
@@ -66,6 +69,7 @@ const DisplayOptionMenuOnHoverListener = ({
             ])}
             ref={menuRef}
             menuItemPanel={{ size: 'md' }}
+            menuOpened={isMenuOpen}
           />
         </>
       )}

--- a/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
+++ b/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
@@ -25,28 +25,21 @@ const DisplayOptionMenuOnHoverListener = ({
     setIsMenuOpen(true);
   };
 
+  const handleMouseLeave = () => {
+    setIsHover(false);
+    if (!isMenuOpen) {
+      setIsMenuOpen(false);
+    }
+  };
+
   const handleMenuClose = () => {
     setIsMenuOpen(false);
     setIsHover(false);
   };
-
   const menuRef = useClickOutside<HTMLDivElement>(handleMenuClose);
 
   return (
-    <div
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => !isMenuOpen && setIsHover(false)}
-      onClick={(e) => {
-        // when menu is open and click the container, set the hover state to false
-        if (isMenuOpen) {
-          setIsHover(false);
-          return;
-        }
-        // keep the hover state when click the container, unless other CTA is triggered
-        e.stopPropagation();
-      }}
-      className='relative'
-    >
+    <div onMouseEnter={() => setIsHover(true)} onMouseLeave={handleMouseLeave} className='relative'>
       {children(isHover)}
 
       {!listenerDisabled && (
@@ -56,7 +49,7 @@ const DisplayOptionMenuOnHoverListener = ({
               'absolute inset-0',
               'bg-gradient-to-r from-transparent to-black',
               'opacity-from-zero',
-              isHover && 'opacity-100'
+              (isHover || isMenuOpen) && 'opacity-100'
             )}
           />
 
@@ -68,7 +61,7 @@ const DisplayOptionMenuOnHoverListener = ({
             menuContainerStyle={cn([
               'absolute top-[5px] right-0',
               'opacity-from-zero',
-              isHover && 'opacity-100',
+              (isHover || isMenuOpen) && 'opacity-100',
               menuPositionStyle,
             ])}
             ref={menuRef}

--- a/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
+++ b/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
@@ -69,7 +69,6 @@ const DisplayOptionMenuOnHoverListener = ({
             ])}
             ref={menuRef}
             menuItemPanel={{ size: 'md' }}
-            menuOpened={isMenuOpen}
           />
         </>
       )}

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Menu } from '@headlessui/react';
 import { cn } from '@/shared/lib/functions/cn';
 import { MenuItem, MenuButton, MenuItemPanelSize, MenuItemPanel } from '../menu';
@@ -30,23 +31,36 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
     },
     ref
   ) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    const handleMenuOpen = () => {
+      setAnchorEl(buttonRef.current);
+      onMenuIconClick && onMenuIconClick();
+    };
+
     return (
       <div className={cn(menuContainerStyle)} ref={ref}>
         <Menu as='section' className={`relative w-fit`}>
-          {({ close }) => (
+          {({ open, close }) => (
             <>
-              <MenuButton type='icon' onMenuIconClick={onMenuIconClick}>
+              <MenuButton type='icon' onMenuIconClick={handleMenuOpen} ref={buttonRef}>
                 {MenuButtonIcon}
               </MenuButton>
-              <MenuItemPanel
-                menuItemConfig={menuItemConfig}
-                HeaderIcon={HeaderIcon}
-                MenuItemPrefixIcon={PrefixIcon}
-                menuItemPanelStyle={className}
-                size={size}
-                close={close}
-                onMenuClose={onMenuClose}
-              />
+              {open &&
+                createPortal(
+                  <MenuItemPanel
+                    menuItemConfig={menuItemConfig}
+                    HeaderIcon={HeaderIcon}
+                    MenuItemPrefixIcon={PrefixIcon}
+                    menuItemPanelStyle={className}
+                    size={size}
+                    close={close}
+                    onMenuClose={onMenuClose}
+                    anchorEl={anchorEl}
+                  />,
+                  document.body
+                )}
             </>
           )}
         </Menu>

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -38,16 +38,15 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
       onMenuIconClick && onMenuIconClick();
     };
 
-    const handleMenuClose = (close?: () => void) => {
+    const handleMenuClose = () => {
       setAnchorEl(null);
       onMenuClose?.();
-      close?.();
     };
 
     return (
       <div className={cn(menuContainerStyle)} ref={ref}>
         <Menu as='section' className={`relative w-fit`}>
-          {({ open, close }) => (
+          {({ open }) => (
             <>
               <MenuButton type='icon' onMenuIconClick={handleMenuOpen} ref={buttonRef}>
                 {MenuButtonIcon}
@@ -59,7 +58,7 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
                   MenuItemPrefixIcon={PrefixIcon}
                   menuItemPanelStyle={className}
                   size={size}
-                  close={() => handleMenuClose(close)}
+                  close={() => handleMenuClose()}
                   anchorEl={anchorEl}
                 />
               )}

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -16,7 +16,6 @@ interface IconMenuProps {
   MenuButtonIcon: ReactNode;
   onMenuClose?: () => void;
   onMenuIconClick?: () => void;
-  menuOpened: boolean;
 }
 
 const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -44,28 +44,26 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
     };
 
     return (
-      <div className={cn(menuContainerStyle)} ref={ref}>
-        <Menu as='section' className={`relative w-fit`}>
-          {({ open }) => (
-            <>
-              <MenuButton type='icon' onMenuIconClick={handleMenuOpen} ref={buttonRef}>
-                {MenuButtonIcon}
-              </MenuButton>
-              {open && (
-                <MenuItemPanel
-                  menuItemConfig={menuItemConfig}
-                  HeaderIcon={HeaderIcon}
-                  MenuItemPrefixIcon={PrefixIcon}
-                  menuItemPanelStyle={className}
-                  size={size}
-                  close={() => handleMenuClose()}
-                  anchorEl={anchorEl}
-                />
-              )}
-            </>
-          )}
-        </Menu>
-      </div>
+      <Menu as='div' className={cn(menuContainerStyle)} ref={ref}>
+        {({ open }) => (
+          <>
+            <MenuButton type='icon' onMenuIconClick={handleMenuOpen} ref={buttonRef}>
+              {MenuButtonIcon}
+            </MenuButton>
+            {open && (
+              <MenuItemPanel
+                menuItemConfig={menuItemConfig}
+                HeaderIcon={HeaderIcon}
+                MenuItemPrefixIcon={PrefixIcon}
+                menuItemPanelStyle={className}
+                size={size}
+                close={() => handleMenuClose()}
+                anchorEl={anchorEl}
+              />
+            )}
+          </>
+        )}
+      </Menu>
     );
   }
 );

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { forwardRef, ReactNode, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { Menu } from '@headlessui/react';
 import { cn } from '@/shared/lib/functions/cn';
 import { MenuItem, MenuButton, MenuItemPanelSize, MenuItemPanel } from '../menu';
@@ -17,6 +16,7 @@ interface IconMenuProps {
   MenuButtonIcon: ReactNode;
   onMenuClose?: () => void;
   onMenuIconClick?: () => void;
+  menuOpened: boolean;
 }
 
 const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
@@ -39,6 +39,12 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
       onMenuIconClick && onMenuIconClick();
     };
 
+    const handleMenuClose = (close?: () => void) => {
+      setAnchorEl(null);
+      onMenuClose?.();
+      close?.();
+    };
+
     return (
       <div className={cn(menuContainerStyle)} ref={ref}>
         <Menu as='section' className={`relative w-fit`}>
@@ -47,20 +53,17 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
               <MenuButton type='icon' onMenuIconClick={handleMenuOpen} ref={buttonRef}>
                 {MenuButtonIcon}
               </MenuButton>
-              {open &&
-                createPortal(
-                  <MenuItemPanel
-                    menuItemConfig={menuItemConfig}
-                    HeaderIcon={HeaderIcon}
-                    MenuItemPrefixIcon={PrefixIcon}
-                    menuItemPanelStyle={className}
-                    size={size}
-                    close={close}
-                    onMenuClose={onMenuClose}
-                    anchorEl={anchorEl}
-                  />,
-                  document.body
-                )}
+              {open && (
+                <MenuItemPanel
+                  menuItemConfig={menuItemConfig}
+                  HeaderIcon={HeaderIcon}
+                  MenuItemPrefixIcon={PrefixIcon}
+                  menuItemPanelStyle={className}
+                  size={size}
+                  close={() => handleMenuClose(close)}
+                  anchorEl={anchorEl}
+                />
+              )}
             </>
           )}
         </Menu>

--- a/src/shared/ui/components/menu/menu-button.component.tsx
+++ b/src/shared/ui/components/menu/menu-button.component.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { forwardRef, PropsWithChildren } from 'react';
 import { Menu } from '@headlessui/react';
 import { cn } from '@/shared/lib/functions/cn';
 import { buttonColorsDict, buttonSizeDict } from '../button';
@@ -7,26 +7,25 @@ interface MenuButtonProps {
   type: 'icon' | 'button';
   onMenuIconClick?: () => void;
 }
-export const MenuButton = ({
-  type = 'icon',
-  children,
-  onMenuIconClick,
-}: PropsWithChildren<MenuButtonProps>) => {
-  return (
-    <Menu.Button
-      onClick={() => {
-        onMenuIconClick && onMenuIconClick();
-      }}
-      className={cn(
-        'flex h-max items-center justify-center gap-[8px] rounded-[4px]',
-        type === 'icon' && 'flex items-center gap-2 text-gray-50 p-1',
-        type === 'button' &&
-          `border border-solid px-[16px] h-[36px] ${buttonSizeDict['md']} ${buttonColorsDict['secondary']['outline'].default}`
-      )}
-    >
-      {children}
-    </Menu.Button>
-  );
-};
+const MenuButton = forwardRef<HTMLButtonElement, PropsWithChildren<MenuButtonProps>>(
+  ({ type = 'icon', children, onMenuIconClick }, ref) => {
+    return (
+      <Menu.Button
+        ref={ref}
+        onClick={() => {
+          onMenuIconClick && onMenuIconClick();
+        }}
+        className={cn(
+          'flex h-max items-center justify-center gap-[8px] rounded-[4px]',
+          type === 'icon' && 'flex items-center gap-2 text-gray-50 p-1',
+          type === 'button' &&
+            `border border-solid px-[16px] h-[36px] ${buttonSizeDict['md']} ${buttonColorsDict['secondary']['outline'].default}`
+        )}
+      >
+        {children}
+      </Menu.Button>
+    );
+  }
+);
 
 export default MenuButton;

--- a/src/shared/ui/components/menu/menu-item-panel.component.tsx
+++ b/src/shared/ui/components/menu/menu-item-panel.component.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useEffect, useRef, useState } from 'react';
+import { Fragment, ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { Transition, Menu } from '@headlessui/react';
 import { cn } from '@/shared/lib/functions/cn';
 
@@ -19,7 +19,6 @@ interface MenuItemPanelProps {
   size?: MenuItemPanelSize;
   close: () => void;
   anchorEl: HTMLElement | null;
-  onMenuClose?: () => void;
 }
 
 const MenuItemPanel = ({
@@ -30,12 +29,12 @@ const MenuItemPanel = ({
   size = 'lg',
   close,
   anchorEl,
-  onMenuClose,
 }: MenuItemPanelProps) => {
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+  const [isPositioned, setIsPositioned] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // 메뉴의 위치를 동적으로 계산해 화면 밖으로 나가지 않도록 조정
     const updatePosition = () => {
       if (anchorEl && menuRef.current) {
@@ -58,12 +57,12 @@ const MenuItemPanel = ({
         }
 
         setMenuPosition({ top, left });
+        setIsPositioned(true);
       }
     };
 
     const handleScroll = () => {
       close();
-      onMenuClose && onMenuClose();
     };
 
     updatePosition();
@@ -74,11 +73,10 @@ const MenuItemPanel = ({
       window.removeEventListener('resize', updatePosition);
       window.addEventListener('scroll', handleScroll, true);
     };
-  }, [anchorEl, close, onMenuClose]);
+  }, [anchorEl, close]);
 
   const handleMenuItemClick = (config: MenuItem) => {
     config.onClickItem();
-    onMenuClose && onMenuClose();
   };
 
   return (
@@ -104,6 +102,7 @@ const MenuItemPanel = ({
           left: `${menuPosition.left}px`,
           maxHeight: '80vh', // 메뉴가 화면을 완전히 차지하지 않도록 제한
           overflowY: 'auto', // 메뉴 내용이 maxHeight를 초과할 경우 세로 스크롤바를 표시
+          visibility: isPositioned ? 'visible' : 'hidden',
         }}
       >
         <ul>

--- a/src/shared/ui/components/menu/menu-item-panel.component.tsx
+++ b/src/shared/ui/components/menu/menu-item-panel.component.tsx
@@ -18,7 +18,7 @@ interface MenuItemPanelProps {
   menuItemPanelStyle?: string;
   size?: MenuItemPanelSize;
   close: () => void;
-  anchorEl: HTMLElement | null;
+  anchorEl?: HTMLElement | null;
 }
 
 const MenuItemPanel = ({
@@ -35,6 +35,8 @@ const MenuItemPanel = ({
   const menuRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
+    if (!anchorEl) return;
+
     // 메뉴의 위치를 동적으로 계산해 화면 밖으로 나가지 않도록 조정
     const updatePosition = () => {
       if (anchorEl && menuRef.current) {
@@ -98,11 +100,13 @@ const MenuItemPanel = ({
           MenuItemBoxSize[size]
         )}
         style={{
-          top: `${menuPosition.top}px`,
-          left: `${menuPosition.left}px`,
-          maxHeight: '80vh', // 메뉴가 화면을 완전히 차지하지 않도록 제한
-          overflowY: 'auto', // 메뉴 내용이 maxHeight를 초과할 경우 세로 스크롤바를 표시
-          visibility: isPositioned ? 'visible' : 'hidden',
+          ...(anchorEl && {
+            top: `${menuPosition.top}px`,
+            left: `${menuPosition.left}px`,
+            maxHeight: '80vh', // 메뉴가 화면을 완전히 차지하지 않도록 제한
+            overflowY: 'auto', // 메뉴 내용이 maxHeight를 초과할 경우 세로 스크롤바를 표시
+            visibility: isPositioned ? 'visible' : 'hidden',
+          }),
         }}
       >
         <ul>


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->


<img width="374" alt="2024-08-05_15-00-56" src="https://github.com/user-attachments/assets/f67e4a3d-96be-4f76-a117-2636091baa54">

- Menu Item panel의 포지션을 기본은 메뉴 버튼의 아래 왼쪽으로 놓고, item panel이 화면 최하단에 위치 해 화면을 뚫고 넘어갈 시에 패널 포지션을 버튼 위로 설정
- hover시에 Icon Menu 버튼 클릭 시 IconMenu가 사라지는 이슈 해결
- Icon Menu 버튼 클릭 해 패널이 열리고 다시 Icon Menu 버튼을 눌렀을 때 Icon Menu 버튼이 사라지는 이슈 해결
- DisplayOptionMenuOnHoverListener 적용된 children 컴포넌트를 hover시에 눌렀을 때 Icon Menu 버튼이 사라지는 이슈 해결

### Todo

N/A

### Issue

N/A

### Reference

<!--
  개발하시면서 도움이 되었던 참고자료들을 이곳에 적어주세요.
  다른 팀원들에게 큰 도움이 됩니다. :)
-->

N/A
