### PR TITLE
fix: production 환경에서 드로워 안 열리는 문제

### DIFF
--- a/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
+++ b/src/features/partyroom/select-playlist-for-djing/ui/use-select-playlist.hook.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Playlist } from '@/shared/api/http/types/playlists';
-import useDidUpdateEffect from '@/shared/lib/hooks/use-did-update-effect';
+import useDidMountEffect from '@/shared/lib/hooks/use-did-mount-effect';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -75,9 +75,9 @@ export default function useSelectPlaylist({ playlists }: Props): () => Promise<P
           closePlaylistDrawer();
         };
 
-        useDidUpdateEffect(() => {
+        useDidMountEffect(() => {
           closePlaylistDrawer();
-        }, []);
+        });
 
         useEffect(() => {
           if (!selected) return;

--- a/src/shared/lib/hooks/use-portal-root.hook.ts
+++ b/src/shared/lib/hooks/use-portal-root.hook.ts
@@ -2,19 +2,19 @@ import { useState } from 'react';
 import { DomId } from '@/shared/config/dom-id';
 import { errorLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
-import useDidUpdateEffect from 'shared/lib/hooks/use-did-update-effect';
+import useDidMountEffect from '@/shared/lib/hooks/use-did-mount-effect';
 
 export default function usePortalRoot(id: string) {
   const [root, setRoot] = useState<HTMLElement | null>(null);
 
-  useDidUpdateEffect(() => {
+  useDidMountEffect(() => {
     const root = document.getElementById(DomId.DrawerRoot);
     if (root) {
       setRoot(root);
     } else {
       log(`Cannot find portal root element. id: ${id}`);
     }
-  }, []);
+  });
 
   return root;
 }


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

react 18이상에선 dev모드에서만 useEffect가 최초에 두 번 실행됩니다. (strict mode)

이 동작으로 "dev에선 동작하지만 production에선 동작하지 않는", 이 이슈 제목 같은 문제들이 발생했습니다. 이들을 찾아 수정합니다.