### PR TITLE
feat(shared/ui/select): 누락된 onChange prop 추가, option 확장, 그 외 기타 개선

### DIFF
--- a/src/shared/ui/components/select/select.component.tsx
+++ b/src/shared/ui/components/select/select.component.tsx
@@ -1,74 +1,79 @@
 'use client';
 import { Fragment, useState } from 'react';
-import { Listbox, Transition } from '@headlessui/react';
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+  Transition,
+} from '@headlessui/react';
 import { cn } from '@/shared/lib/functions/cn';
 import { PFChevronDown, PFChevronUp } from '@/shared/ui/icons';
 import { Typography } from '../typography';
 
-export type SelectListItem = {
+export type SelectOption = {
   label: string;
   value: string;
 };
 
 interface SelectProps {
-  selectListConfig: Array<SelectListItem>;
-  initialValue?: SelectListItem;
+  options: SelectOption[];
+  initialValue?: SelectOption;
   classNames?: {
     container?: string;
-    selectButton?: string;
-    optionPanel?: string;
+    button?: string;
+    options?: string;
   };
 }
 
-export const Select = ({ selectListConfig, initialValue, classNames }: SelectProps) => {
-  const [selected, setSelected] = useState<SelectListItem>(initialValue ?? selectListConfig[0]);
+export default function Select({ options, initialValue, classNames }: SelectProps) {
+  const [selected, setSelected] = useState<SelectOption>(initialValue ?? options[0]);
 
   return (
     <Listbox value={selected} onChange={setSelected}>
       {({ open }) => (
         <div className={cn('relative w-full', classNames?.container)}>
-          <Listbox.Button
+          <ListboxButton
             className={cn([
               'relative w-full h-12 flexRow justify-between items-center rounded bg-gray-800 px-4 text-gray-50 border-[1px] border-gray-500 cursor-pointer focus:outline-none',
-              classNames?.selectButton,
+              classNames?.button,
             ])}
           >
             <Typography type='detail1' overflow='ellipsis' className='w-5/6 text-left'>
               {selected.label}
             </Typography>
             <span>{open ? <PFChevronUp /> : <PFChevronDown />}</span>
-          </Listbox.Button>
+          </ListboxButton>
+
           <Transition
             as={Fragment}
             leave='transition ease-in duration-100'
             leaveFrom='opacity-100'
             leaveTo='opacity-0'
           >
-            <Listbox.Options
+            <ListboxOptions
               className={cn([
                 'absolute max-h-[264px] w-full mt-2 py-3 overflow-auto rounded bg-gray-800 border-[1px] border-gray-500 focus:outline-none',
-                classNames?.optionPanel,
+                classNames?.options,
               ])}
             >
-              {selectListConfig.map((config) => (
-                <Listbox.Option
-                  key={config.value}
-                  className={({ active }) =>
-                    cn('relative cursor-pointer px-4 py-3', active && 'bg-gray-700')
+              {options.map((option) => (
+                <ListboxOption
+                  key={option.value}
+                  className={({ focus }) =>
+                    cn('relative cursor-pointer px-4 py-3', focus && 'bg-gray-700')
                   }
-                  value={config}
+                  value={option}
                 >
                   <Typography type='detail1' overflow='ellipsis' className='text-gray-50'>
-                    {config.label}
+                    {option.label}
                   </Typography>
-                </Listbox.Option>
+                </ListboxOption>
               ))}
-            </Listbox.Options>
+            </ListboxOptions>
           </Transition>
         </div>
       )}
     </Listbox>
   );
-};
-
-export default Select;
+}

--- a/src/shared/ui/components/select/select.stories.tsx
+++ b/src/shared/ui/components/select/select.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import Select, { SelectListItem } from './select.component';
+import Select, { SelectOption } from './select.component';
 import { Typography } from '../typography';
 
 const meta = {
@@ -13,7 +13,7 @@ const meta = {
 
 export default meta;
 
-const selectListConfig: Array<SelectListItem> = [
+const options: SelectOption[] = [
   { label: 'Wade Cooper long long long text', value: 'Wade Cooper2' },
   { label: 'Arlene Mccoy', value: 'Arlene Mccoy2' },
   { label: 'Devon Webb long long long text', value: 'Devon Webb2' },
@@ -23,7 +23,7 @@ const selectListConfig: Array<SelectListItem> = [
 ];
 
 export const SelectDefault = () => {
-  return <Select selectListConfig={selectListConfig} />;
+  return <Select options={options} />;
 };
 
 export const SelectWithInitialValue = () => {
@@ -32,7 +32,7 @@ export const SelectWithInitialValue = () => {
       <Typography type='title2' className='text-white'>
         Select with initial value
       </Typography>
-      <Select selectListConfig={selectListConfig} initialValue={selectListConfig[2]} />
+      <Select options={options} initialValue={options[2]} />
     </>
   );
 };

--- a/src/shared/ui/components/select/select.stories.tsx
+++ b/src/shared/ui/components/select/select.stories.tsx
@@ -1,38 +1,58 @@
-import type { Meta } from '@storybook/react';
+import { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { Tag } from '@/shared/ui/components/tag';
+import { Typography } from '@/shared/ui/components/typography';
 import Select, { SelectOption } from './select.component';
-import { Typography } from '../typography';
 
 const meta = {
   title: 'base/Select',
   tags: ['autodocs'],
   component: Select,
   decorators: [
-    (Story) => <div className='w-full h-72 flexCol item-center gap-4 p-4 bg-black'>{Story()}</div>,
+    (Story) => <div className='w-full h-80 flexCol item-center gap-4 p-4 bg-black'>{Story()}</div>,
   ],
 } satisfies Meta<typeof Select>;
 
 export default meta;
+type Story = StoryFn<typeof Select>;
 
-const options: SelectOption[] = [
-  { label: 'Wade Cooper long long long text', value: 'Wade Cooper2' },
-  { label: 'Arlene Mccoy', value: 'Arlene Mccoy2' },
-  { label: 'Devon Webb long long long text', value: 'Devon Webb2' },
-  { label: 'Tom Cook', value: 'Tom Cook2' },
-  { label: 'Tanya Fox', value: 'Tanya Fox2' },
-  { label: 'Hellen Schmidt', value: 'Hellen Schmidt2' },
+const options: SelectOption<string>[] = [
+  { label: 'AA', value: 'aa' },
+  { label: 'BB', value: 'bb' },
+  { label: 'CC', value: 'cc' },
+  { label: 'long long long long long long long text', value: 'long' },
 ];
 
-export const SelectDefault = () => {
-  return <Select options={options} />;
-};
+export const Default: Story = () => {
+  const [selected, setSelected] = useState<string>();
 
-export const SelectWithInitialValue = () => {
   return (
     <>
-      <Typography type='title2' className='text-white'>
-        Select with initial value
+      <Typography>Selected value: {selected}</Typography>
+
+      <Select className='w-[300px]' options={options} onChange={setSelected} />
+    </>
+  );
+};
+
+export const PrefixAndSuffix: Story = () => {
+  const [selected, setSelected] = useState<string>();
+
+  const newOptions = options.map((option) => ({
+    ...option,
+    prefix: <Tag variant='outlined' value='Tag' />,
+    suffix: (
+      <Typography type='caption1' className='text-gray-300'>
+        unit
       </Typography>
-      <Select options={options} initialValue={options[2]} />
+    ),
+  }));
+
+  return (
+    <>
+      <Typography>Selected value: {selected}</Typography>
+
+      <Select className='w-[300px]' options={newOptions} onChange={setSelected} />
     </>
   );
 };


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

<img width="419" alt="스크린샷 2024-09-01 오전 3 33 36" src="https://github.com/user-attachments/assets/422c64f0-9c8b-4ffd-b05c-a45468207de3">

Select 컴포넌트를 개선합니다.

* 누락됐던 onChange prop 추가
* option 확장
  * [prefix, suffix](https://www.figma.com/design/9I5PR6OqN8cHJ7WVTOKe00/PFPlay-GUI-%EC%84%A4%EA%B3%84%EC%84%9C-%ED%95%A9%EB%B3%B8?node-id=2257-25419&t=ArCFDtTTnbNHMs19-4) 추가
  * label 타입 string >> ReactNode
  * value 타입 string >> 제네릭
* classNames 제거 (className으로 대체)
  * 요구처가 없는데 미리 확장하지 않는다는 맥락