### PR TITLE
fix(partyroom-avatars): 페이지 컴포넌트 리렌더 시 아바타들이 재배치되는 문제

### DIFF
--- a/src/widgets/partyroom-avatars/lib/use-assign-avatar-positions.hook.ts
+++ b/src/widgets/partyroom-avatars/lib/use-assign-avatar-positions.hook.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { Crew } from '@/entities/current-partyroom';
+import { Area, getRandomPoint, Point } from '../model/avatar-position.model';
+
+type Props = {
+  originCrews: Crew.Model[];
+  allowArea: Area;
+  denyArea: Area;
+};
+
+type PositionedCrew = Crew.Model & { position: Point };
+
+export default function useAssignAvatarPositions({
+  originCrews,
+  allowArea,
+  denyArea,
+}: Props): PositionedCrew[] {
+  const [positionedCrews, setPositionedCrews] = useState<PositionedCrew[]>(
+    originCrews.map((crew) => assignPositionToCrew(crew, allowArea, denyArea))
+  );
+
+  useEffect(() => {
+    const { added, removed } = diffCrews(positionedCrews, originCrews);
+
+    if (added.length) {
+      const newCrews = added.map((crew) => assignPositionToCrew(crew, allowArea, denyArea));
+
+      setPositionedCrews((prev) => [...prev, ...newCrews]);
+    }
+
+    if (removed.length) {
+      setPositionedCrews((prev) =>
+        prev.filter((crew) => !removed.some((removedCrew) => removedCrew.uid === crew.uid))
+      );
+    }
+  }, [originCrews]);
+
+  return positionedCrews;
+}
+
+function assignPositionToCrew(crew: Crew.Model, allowArea: Area, denyArea: Area): PositionedCrew {
+  const position = getRandomPoint(allowArea, denyArea);
+
+  return { ...crew, position };
+}
+
+function diffCrews(
+  prevCrews: Crew.Model[],
+  nextCrews: Crew.Model[]
+): { added: Crew.Model[]; removed: Crew.Model[] } {
+  const prevCrewSet = new Set(prevCrews.map((crew) => crew.uid));
+  const nextCrewSet = new Set(nextCrews.map((crew) => crew.uid));
+
+  const added = nextCrews.filter((crew) => !prevCrewSet.has(crew.uid));
+  const removed = prevCrews.filter((crew) => !nextCrewSet.has(crew.uid));
+
+  return { added, removed };
+}

--- a/src/widgets/partyroom-avatars/model/avatar-position.model.ts
+++ b/src/widgets/partyroom-avatars/model/avatar-position.model.ts
@@ -11,10 +11,6 @@ export type Area = {
   to: Point;
 };
 
-export function getRandomPoints(length: number, allowArea: Area, denyArea: Area): Point[] {
-  return Array.from({ length }, () => getRandomPoint(allowArea, denyArea));
-}
-
 export function getRandomPoint(allowArea: Area, denyArea: Area): Point {
   assertArea(allowArea);
   assertArea(denyArea);

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -1,14 +1,16 @@
 'use client';
-import { useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Avatar } from '@/entities/avatar';
 import { Crew } from '@/entities/current-partyroom';
 import { MotionType } from '@/shared/api/http/types/@enums';
 import { pick } from '@/shared/lib/functions/pick';
-import useDidUpdateEffect from '@/shared/lib/hooks/use-did-update-effect';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { Area, getRandomPoint, getRandomPoints, Point } from '../model/avatar-position.model';
 
-export default function Avatars() {
+/**
+ * NOTE:부모 컴포넌트 리렌더에 의해 아바타 포지션이 재계산되는걸 방지하기 위해 memo로 감싸줌
+ */
+const Avatars = memo(() => {
   const { useCurrentPartyroom } = useStores();
   const { crews: storedCrews, currentDj } = useCurrentPartyroom((state) =>
     pick(state, ['crews', 'currentDj'])
@@ -55,7 +57,7 @@ export default function Avatars() {
     });
   };
 
-  useDidUpdateEffect(() => {
+  useEffect(() => {
     // 파티룸 진입 시 조건문이 순차로 실행된 후, 이후부턴 storedCrews가 변경될 때마다 syncWithStoredCrews가 실행됨
     if (!storedCrewsInitialized) {
       return;
@@ -126,7 +128,7 @@ export default function Avatars() {
       })}
     </div>
   );
-}
+});
 
 const ALLOW_AREA: Area = {
   from: { x: 10, y: 60 },
@@ -137,3 +139,5 @@ const DENY_AREA: Area = {
   from: { x: 0, y: 0 },
   to: { x: 40, y: 100 },
 };
+
+export default Avatars;

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -1,76 +1,21 @@
 'use client';
-import { memo, useEffect, useState } from 'react';
 import { Avatar } from '@/entities/avatar';
-import { Crew } from '@/entities/current-partyroom';
 import { MotionType } from '@/shared/api/http/types/@enums';
 import { pick } from '@/shared/lib/functions/pick';
 import { useStores } from '@/shared/lib/store/stores.context';
-import { Area, getRandomPoint, getRandomPoints, Point } from '../model/avatar-position.model';
+import useAssignAvatarPositions from '../lib/use-assign-avatar-positions.hook';
+import { Area } from '../model/avatar-position.model';
 
-/**
- * NOTE:부모 컴포넌트 리렌더에 의해 아바타 포지션이 재계산되는걸 방지하기 위해 memo로 감싸줌
- */
-const Avatars = memo(() => {
+export default function Avatars() {
   const { useCurrentPartyroom } = useStores();
-  const { crews: storedCrews, currentDj } = useCurrentPartyroom((state) =>
-    pick(state, ['crews', 'currentDj'])
-  );
-  const [localCrews, setLocalCrews] = useState<Crew.Model[]>([]);
-  const [randomPoints, setRandomPoints] = useState<Point[]>([]);
+  const { crews, currentDj } = useCurrentPartyroom((state) => pick(state, ['crews', 'currentDj']));
+  const dj = currentDj && crews.find((crew) => crew.crewId === currentDj.crewId);
 
-  const dj = currentDj && localCrews.find((crew) => crew.crewId === currentDj.crewId);
-
-  const storedCrewsInitialized = !!storedCrews.length;
-  const localCrewsInitialized = !!localCrews.length && !!randomPoints.length;
-
-  const syncWithStoredCrews = () => {
-    setLocalCrews((prevLocalCrews) => {
-      const isAdded = prevLocalCrews.length < storedCrews.length;
-      const isRemoved = prevLocalCrews.length > storedCrews.length;
-
-      if (isAdded) {
-        // 추가된 멤버의 index에 맞춰 randomPoints에 새로운 point 추가
-        const prevCrewUidSet = new Set(prevLocalCrews.map((m) => m.uid));
-        const newCrewIndex = storedCrews.findIndex((crew) => !prevCrewUidSet.has(crew.uid));
-        const newPoint = getRandomPoint(ALLOW_AREA, DENY_AREA);
-        setRandomPoints((prev) => {
-          const next = [...prev];
-          next.splice(newCrewIndex, 0, newPoint);
-          return next;
-        });
-      }
-
-      if (isRemoved) {
-        // 삭제된 멤버의 index에 맞춰 randomPoints에서 point 제거
-        const changedCrewUidSet = new Set(storedCrews.map((m) => m.uid));
-        const removedCrewIndex = prevLocalCrews.findIndex(
-          (crew) => !changedCrewUidSet.has(crew.uid)
-        );
-        setRandomPoints((prev) => {
-          const next = [...prev];
-          next.splice(removedCrewIndex, 1);
-          return next;
-        });
-      }
-
-      return storedCrews;
-    });
-  };
-
-  useEffect(() => {
-    // 파티룸 진입 시 조건문이 순차로 실행된 후, 이후부턴 storedCrews가 변경될 때마다 syncWithStoredCrews가 실행됨
-    if (!storedCrewsInitialized) {
-      return;
-    }
-
-    if (!localCrewsInitialized) {
-      setLocalCrews(storedCrews);
-      setRandomPoints(getRandomPoints(storedCrews.length, ALLOW_AREA, DENY_AREA));
-      return;
-    }
-
-    syncWithStoredCrews();
-  }, [storedCrewsInitialized, localCrewsInitialized, storedCrews]);
+  const positionedCrews = useAssignAvatarPositions({
+    originCrews: crews,
+    allowArea: ALLOW_AREA,
+    denyArea: DENY_AREA,
+  });
 
   return (
     /*
@@ -97,21 +42,19 @@ const Avatars = memo(() => {
         </div>
       )}
 
-      {localCrews.map((crew, index) => {
-        if (crew.crewId === dj?.crewId) {
+      {positionedCrews.map((crew) => {
+        const isDj = dj?.crewId === crew.crewId;
+        if (isDj) {
           return null;
         }
-        if (!randomPoints[index]) {
-          /* localCrews와 randomPoints의 length가 동기화 되지 않는 일순간이 있을 수 있음 */
-          return null;
-        }
+
         return (
           <div
             key={'partyroom-crew-' + crew.uid}
             className='absolute'
             style={{
-              top: `${randomPoints[index].y}%`,
-              left: `${randomPoints[index].x}%`,
+              top: `${crew.position.y}%`,
+              left: `${crew.position.x}%`,
               transform: 'translate(-100%, -100%)',
             }}
           >
@@ -128,7 +71,7 @@ const Avatars = memo(() => {
       })}
     </div>
   );
-});
+}
 
 const ALLOW_AREA: Area = {
   from: { x: 10, y: 60 },
@@ -139,5 +82,3 @@ const DENY_AREA: Area = {
   from: { x: 0, y: 0 },
   to: { x: 40, y: 100 },
 };
-
-export default Avatars;


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->
파티룸에 크루 입장 및 퇴장 시 페이지 컴포넌트의 crewsCount state에 변경이 생겨 리렌더가 발생합니다.
이 때 자식 컴포넌트인 PartyroomAvatars가 리렌더 되어 아바타들의 포지션이 재계산되는 문제를 방지하기 위해, 해당 컴포넌트를 React.memo로 감쌉니다.