### PR TITLE
refactor: combineRef 작성 및 적용 

### DIFF
--- a/src/features/playlist/add-musics/ui/search-input.component.tsx
+++ b/src/features/playlist/add-musics/ui/search-input.component.tsx
@@ -18,7 +18,7 @@ const SearchInput = ({ onSearch }: SearchInputProps) => {
       Prefix={<PFSearch />}
       placeholder={t.playlist.para.search_url}
       classNames={{ container: 'flex-1' }}
-      initialValue={value}
+      defaultValue={value}
       onChange={handleChange}
     />
   );

--- a/src/shared/lib/functions/combine-ref.test.ts
+++ b/src/shared/lib/functions/combine-ref.test.ts
@@ -1,0 +1,32 @@
+import type { RefObject, RefCallback } from 'react';
+import { combineRef } from './combine-ref';
+
+describe('combineRef', () => {
+  test('모든 ref가 정상적으로 합쳐져야 한다.', () => {
+    const fakeRef1: RefObject<string> = { current: null };
+    const fakeRef2: RefObject<string> = { current: null };
+    const fakeRef3: RefCallback<string> = jest.fn();
+
+    const combinedRef = combineRef([fakeRef1, fakeRef2, fakeRef3]);
+
+    const value = 'value'; // ref에 전달될 값
+    combinedRef(value);
+
+    expect(fakeRef1.current).toBe(value);
+    expect(fakeRef2.current).toBe(value);
+    expect(fakeRef3).toHaveBeenCalledWith(value);
+  });
+
+  test('undefined 또는 null ref가 있는 경우에도 정상적으로 처리해야 한다.', () => {
+    const fakeRef1: RefObject<string> = { current: null };
+    const fakeRef2 = null;
+    const fakeRef3 = undefined;
+
+    const combinedRef = combineRef([fakeRef1, fakeRef2, fakeRef3]);
+
+    const value = 'value'; // ref에 전달될 값
+    combinedRef(value);
+
+    expect(fakeRef1.current).toBe(value);
+  });
+});

--- a/src/shared/lib/functions/combine-ref.ts
+++ b/src/shared/lib/functions/combine-ref.ts
@@ -1,0 +1,18 @@
+import type { LegacyRef, MutableRefObject, RefCallback } from 'react';
+
+/**
+ * prop으로 전달받은 ref와 내부에서 사용하는 ref를 합쳐야할 때 사용할 수 있습니다.
+ */
+export function combineRef<T>(
+  refs: Array<MutableRefObject<T> | LegacyRef<T> | undefined | null>
+): RefCallback<T> {
+  return (value) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref != null) {
+        (ref as MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}

--- a/src/shared/ui/components/input-number/input-number.component.tsx
+++ b/src/shared/ui/components/input-number/input-number.component.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { ChangeEventHandler, ComponentProps, useState, forwardRef } from 'react';
+import { ChangeEventHandler, ComponentProps, useState, forwardRef, useRef } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { combineRef } from '@/shared/lib/functions/combine-ref';
 
 export interface InputNumberProps extends Omit<ComponentProps<'input'>, 'type' | 'value'> {
   initialValue?: number | '';
@@ -10,7 +11,8 @@ export interface InputNumberProps extends Omit<ComponentProps<'input'>, 'type' |
 const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(
   ({ initialValue = '', onChange, max, min, className, locale = false, ...rest }, ref) => {
     const [localValue, setLocalValue] = useState<number | ''>(initialValue);
-    const [_inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const combinedRef = combineRef([ref, inputRef]);
 
     const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       const value = e.target.value.replace(/[^0-9]/g, ''); // 현재 소수점, 음수 미지원
@@ -34,14 +36,7 @@ const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(
 
     return (
       <input
-        ref={(node) => {
-          setInputRef(node);
-          if (typeof ref === 'function') {
-            ref(node);
-          } else if (ref) {
-            ref.current = node;
-          }
-        }}
+        ref={combinedRef}
         type='text'
         className={cn(
           'w-[83px] h-[48px] px-[12px] rounded-[4px] text-center',

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -17,8 +17,8 @@ type InputSize = 'md' | 'lg';
 type InputVariant = 'filled' | 'outlined';
 
 export interface InputProps
-  extends Omit<ComponentProps<'input'>, 'type' | 'value' | 'size' | 'className'> {
-  initialValue?: string;
+  extends Omit<ComponentProps<'input'>, 'type' | 'defaultValue' | 'value' | 'size' | 'className'> {
+  defaultValue?: string;
   value?: string;
   size?: InputSize;
   variant?: InputVariant;
@@ -35,7 +35,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       value: _value,
-      initialValue = '',
+      defaultValue = '',
       onChange,
       maxLength,
       size = 'md',
@@ -52,7 +52,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
     const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
-    const [localValue, setLocalValue] = useState(initialValue);
+    const [localValue, setLocalValue] = useState(defaultValue);
     const value = _value ?? localValue;
 
     const handleClickWrapper: MouseEventHandler<HTMLDivElement> = (e) => {

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -7,8 +7,10 @@ import {
   forwardRef,
   useState,
   KeyboardEventHandler,
+  useRef,
 } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { combineRef } from '@/shared/lib/functions/combine-ref';
 import { Typography } from '../typography';
 
 type InputSize = 'md' | 'lg';
@@ -46,13 +48,15 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     },
     ref
   ) => {
-    const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const combinedRef = combineRef([ref, inputRef]);
+
     const [localValue, setLocalValue] = useState(defaultValue);
     const value = _value ?? localValue;
 
     const handleClickWrapper: MouseEventHandler<HTMLDivElement> = (e) => {
       if (!(e.target as HTMLElement).closest('button')) {
-        inputRef?.focus();
+        inputRef.current?.focus();
       }
     };
 
@@ -83,14 +87,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         {Prefix && <div className='mr-[12px]'>{Prefix}</div>}
 
         <input
-          ref={(node) => {
-            setInputRef(node);
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-          }}
+          ref={combinedRef}
           type='text'
           className={cn(
             'flex-1 bg-transparent placeholder:gray-400 text-gray-50 caret-red-300 focus:outline-none',

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -2,9 +2,7 @@
 import {
   ComponentProps,
   ReactNode,
-  useRef,
   MouseEventHandler,
-  FocusEventHandler,
   ChangeEventHandler,
   forwardRef,
   useState,
@@ -42,15 +40,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       variant = 'filled',
       Prefix,
       Suffix,
-      onFocus,
-      onBlur,
       onPressEnter,
       classNames: { container: containerClassName, input: inputClassName } = {},
       ...rest
     },
     ref
   ) => {
-    const wrapperRef = useRef<HTMLDivElement>(null);
     const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
     const [localValue, setLocalValue] = useState(defaultValue);
     const value = _value ?? localValue;
@@ -59,14 +54,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       if (!(e.target as HTMLElement).closest('button')) {
         inputRef?.focus();
       }
-    };
-    const handleFocusInput: FocusEventHandler<HTMLInputElement> = (e) => {
-      onFocus?.(e);
-      wrapperRef.current?.classList.add('interaction-outline');
-    };
-    const handleBlurInput: FocusEventHandler<HTMLInputElement> = (e) => {
-      onBlur?.(e);
-      wrapperRef.current?.classList.remove('interaction-outline');
     };
 
     const handleChangeInput: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -85,10 +72,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     return (
       <div
-        ref={wrapperRef}
         onClick={handleClickWrapper}
         className={cn([
-          'relative max-w-full flex items-center px-[12px] rounded-[4px] cursor-text',
+          'relative max-w-full flex items-center px-[12px] rounded-[4px] cursor-text focus-within:interaction-outline',
           sizeDict[size],
           variantDict[variant],
           containerClassName,
@@ -112,8 +98,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           )}
           value={value}
           onChange={handleChangeInput}
-          onFocus={handleFocusInput}
-          onBlur={handleBlurInput}
           onKeyDown={handleKeyDownInput}
           {...rest}
         />

--- a/src/shared/ui/components/textarea/textarea.component.tsx
+++ b/src/shared/ui/components/textarea/textarea.component.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { ComponentProps, ChangeEventHandler, useState, forwardRef } from 'react';
+import { ComponentProps, ChangeEventHandler, useState, forwardRef, useRef } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { combineRef } from '@/shared/lib/functions/combine-ref';
 import { Typography } from '../typography';
 
 export interface TextAreaProps extends Omit<ComponentProps<'textarea'>, 'value' | 'className'> {
@@ -24,7 +25,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     ref
   ) => {
     const [localValue, setLocalValue] = useState<string>(initialValue);
-    const [_textareaRef, setTextareaRef] = useState<HTMLTextAreaElement | null>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const combinedRef = combineRef([ref, textareaRef]);
 
     const handleChangeTextArea: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
       setLocalValue(e.target.value);
@@ -34,14 +36,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <div className={cn('relative flex max-w-full', containerClassName)}>
         <textarea
-          ref={(node) => {
-            setTextareaRef(node);
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-          }}
+          ref={combinedRef}
           className={cn(
             'flex-1 min-h-max py-[12px] pl-[12px] pr-[60px] rounded-[4px]',
             'bg-gray-700 text-gray-50 placeholder:gray-400 caret-red-300',


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

외부에서 주입받은 ref와 로컬 ref를 합치고 싶을 때 아래와 같은 형식으로 사용했는데, 이를 유틸화하여 중복을 제거하고 테스트를 더해 안정성을 더합니다.

```tsx
ref={(node) => {
  setRef(node);
  if (typeof ref === 'function') {
    ref(node);
  } else if (ref) {
    ref.current = node;
  }
}}
```

#### NOTE
* Input에 대한 작은 리팩터링 포함됩니다
  * [리팩터링] css 선택자로 해결할 수 있는 걸 js로 해결하고 있었습니다. 이를 개선합니다. (onFocus + onBlur >> :focus-within)