### PR TITLE
fix: zod register가 ref로 set한 값이 안 보이거나 적용되지 않는 문제

### DIFF
--- a/src/features/partyroom/create/ui/form.component.tsx
+++ b/src/features/partyroom/create/ui/form.component.tsx
@@ -148,7 +148,7 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
                   }),
                 }}
               >
-                <InputNumber {...register('limit', { valueAsNumber: true })} initialValue={7} />
+                <InputNumber {...register('limit', { valueAsNumber: true })} />
                 <Typography as='span' type='detail1' className='text-gray-200 ml-[8px]'>
                   {t.createparty.para.min}
                 </Typography>

--- a/src/shared/ui/components/input-number/input-number.component.tsx
+++ b/src/shared/ui/components/input-number/input-number.component.tsx
@@ -3,16 +3,20 @@ import { ChangeEventHandler, ComponentProps, useState, forwardRef, useRef } from
 import { cn } from '@/shared/lib/functions/cn';
 import { combineRef } from '@/shared/lib/functions/combine-ref';
 
-export interface InputNumberProps extends Omit<ComponentProps<'input'>, 'type' | 'value'> {
-  initialValue?: number | '';
+export interface InputNumberProps
+  extends Omit<ComponentProps<'input'>, 'type' | 'value' | 'defaultValue'> {
+  defaultValue?: number;
+  value?: number;
   locale?: boolean;
 }
 
 const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(
-  ({ initialValue = '', onChange, max, min, className, locale = false, ...rest }, ref) => {
-    const [localValue, setLocalValue] = useState<number | ''>(initialValue);
+  ({ defaultValue, value, onChange, max, min, className, locale = false, ...rest }, ref) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const combinedRef = combineRef([ref, inputRef]);
+
+    const [localValue, setLocalValue] = useState(defaultValue);
+    const _value = value ?? localValue;
 
     const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       const value = e.target.value.replace(/[^0-9]/g, ''); // 현재 소수점, 음수 미지원
@@ -43,7 +47,7 @@ const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(
           'bg-gray-700 placeholder:gray-400 text-gray-50 caret-red-300 focus:interaction-outline',
           className
         )}
-        value={locale ? localValue?.toLocaleString() : localValue}
+        value={locale ? _value?.toLocaleString() : _value}
         onChange={handleChange}
         {...rest}
       />

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -35,7 +35,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       value: _value,
-      defaultValue = '',
+      defaultValue,
       onChange,
       maxLength,
       size = 'md',
@@ -53,6 +53,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const [localValue, setLocalValue] = useState(defaultValue);
     const value = _value ?? localValue;
+    const valueLength = value?.length ?? 0;
 
     const handleClickWrapper: MouseEventHandler<HTMLDivElement> = (e) => {
       if (!(e.target as HTMLElement).closest('button')) {
@@ -100,13 +101,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         />
 
         {Number.isInteger(maxLength) && (
-          <Typography className={cn('text-gray-400 ml-[12px]', !!value.length && 'text-gray-50')}>
+          <Typography className={cn('text-gray-400 ml-[12px]', { 'text-gray-50': !!valueLength })}>
             <strong
               className={cn({
-                'text-red-300': maxLength && value.length > maxLength,
+                'text-red-300': maxLength && valueLength > maxLength,
               })}
             >
-              {String(value.length).padStart(String(maxLength).length, '0')}
+              {String(valueLength).padStart(String(maxLength).length, '0')}
             </strong>
             /{maxLength}
           </Typography>


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

Input과 InputNumber에 zod register가 ref로 set한 값이 안 보이거나 적용되지 않는 문제가 있었습니다.

  * defaultValue 기본 값이 '' 라서 value가 항상 string이고, 이 때문에 zod register에서 ref로 set된 값은 리렌더 시 value에 덮어씌워집니다.
  * 이전 ref는 RefCallback 이라 ref가 set되면 리렌더가 발생하며, 때문에 mount 시점에 ref로 set된 값이 곧바로 덮어씌워져 없어지며 마치 처음부터 zod register가 동작하지 않은 것처럼 보여지고 있었습니다.
  * defaultValue 기본 값을 제거하여 해결합니다.