### PR TITLE
feat(features/create-partyroom): 파티룸 생성 기능 작성

### DIFF
--- a/src/app/parties/(lobby)/page.tsx
+++ b/src/app/parties/(lobby)/page.tsx
@@ -23,10 +23,10 @@ const PartyLobbyPage = () => {
         <section
           className={cn([
             'grid gap-[1.5rem] mt-6 overflow-y-auto',
-            'grid-rows-[repeat(auto-fit,240px)]',
+            'grid-rows-[240px] auto-rows-[240px] grid-flow-row-dense',
             'grid-cols-1',
-            'tablet:grid-cols-[repeat(auto-fit,minmax(calc((100%-1.5rem)/2),1fr))]', // 100%-{COL_GAP}
-            'desktop:grid-cols-[repeat(auto-fit,minmax(calc((100%-3rem)/3),1fr))]', // 100%-({COL_GAP}*2)
+            'tablet:grid-cols-[repeat(auto-fit,calc((100%-1.5rem)/2))]', // 100%-{COL_GAP}
+            'desktop:grid-cols-[repeat(auto-fit,calc((100%-3rem)/3))]', // 100%-({COL_GAP}*2)
           ])}
         >
           <PartyroomCreateCard />

--- a/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
+++ b/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { APIError } from '@/shared/api/http/types/@shared';
+import {
+  CreatePartyroomPayload,
+  CreatePartyroomResponse,
+} from '@/shared/api/http/types/partyrooms';
+
+export default function useCreatePartyroom() {
+  return useMutation<CreatePartyroomResponse, AxiosError<APIError>, CreatePartyroomPayload>({
+    mutationFn: PartyroomsService.create,
+  });
+}

--- a/src/features/partyroom/create/model/form.model.ts
+++ b/src/features/partyroom/create/model/form.model.ts
@@ -3,6 +3,11 @@ import type { Dictionary } from '@/shared/lib/localization/i18n.context';
 
 export type Model = z.infer<ReturnType<typeof getSchema>>;
 
+export const MAX_LENGTH = {
+  NAME: 30,
+  INTRODUCE: 50,
+};
+
 export const getSchema = (t: Dictionary) =>
   z.object({
     name: z
@@ -23,7 +28,7 @@ export const getSchema = (t: Dictionary) =>
         message: '도메인에 공백이나 띄어쓰기를 포함할 수 없습니다',
       }),
     limit: z.coerce
-      .number({ invalid_type_error: t.createparty.para.noti_djing_limit })
+      .number()
       .int()
       .nonnegative()
       .gte(3, { message: t.createparty.para.noti_djing_limit }),

--- a/src/features/partyroom/create/ui/card.component.tsx
+++ b/src/features/partyroom/create/ui/card.component.tsx
@@ -7,32 +7,28 @@ import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
 import CreatePartyroomForm from './form.component';
 
-const PartyroomCreateCard = () => {
+export default function PartyroomCreateCard() {
   const t = useI18n();
   const lang = useLang();
-  const { openDialog, openAlertDialog } = useDialog();
+  const { openDialog, openConfirmDialog } = useDialog();
 
   const handleClickBeAHostBtn = () => {
     openDialog((_, onCancel) => ({
       title: t.createparty.title.create_party,
       titleAlign: 'left',
       showCloseIcon: true,
-      // closeConfirm: () => {
-      //   const [title, content] = t.createparty.para.cancel_confirm.split('\n');
-      //   return openConfirmDialog({
-      //     title,
-      //     content,
-      //   });
-      // },
+      closeConfirm: () => {
+        const [title, content] = t.createparty.para.cancel_confirm.split('\n');
+        return openConfirmDialog({
+          title,
+          content,
+        });
+      },
       classNames: {
         container: lang === Language.Ko ? 'w-[800px]' : 'w-[900px]',
       },
-      Body: () => <CreatePartyroomForm onModalClose={onCancel} />,
+      Body: () => <CreatePartyroomForm onClose={onCancel} />,
     }));
-
-    openAlertDialog({
-      content: 'Partyroom creation is Comming Soon :)',
-    });
   };
 
   return (
@@ -53,6 +49,4 @@ const PartyroomCreateCard = () => {
       </div>
     </button>
   );
-};
-
-export default PartyroomCreateCard;
+}

--- a/src/features/partyroom/create/ui/form.component.tsx
+++ b/src/features/partyroom/create/ui/form.component.tsx
@@ -2,9 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { AxiosError } from 'axios';
 import { useSuspenseFetchMe } from '@/entities/me';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
 import { cn } from '@/shared/lib/functions/cn';
 import { Language } from '@/shared/lib/localization/constants';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
@@ -17,17 +15,19 @@ import { InputNumber } from '@/shared/ui/components/input-number';
 import { TextArea } from '@/shared/ui/components/textarea';
 import { Tooltip } from '@/shared/ui/components/tooltip';
 import { Typography } from '@/shared/ui/components/typography';
+import useCreatePartyroom from '../api/use-create-partyroom.mutation';
 import * as Form from '../model/form.model';
 
-interface PartyroomCreateFormProps {
-  onModalClose?: () => void;
-}
+type Props = {
+  onClose?: () => void;
+};
 
-const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
+export default function PartyroomCreateForm({ onClose }: Props) {
   const t = useI18n();
   const lang = useLang();
   const { data: me } = useSuspenseFetchMe();
   const router = useRouter();
+  const { mutate: create } = useCreatePartyroom();
 
   const {
     handleSubmit,
@@ -38,40 +38,34 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
     mode: 'all',
     resolver: zodResolver(Form.getSchema(t)),
     defaultValues: {
-      name: '',
-      introduce: '', // FIXME: BE가 attribute name 수정 하면 수정 필요
-      domain: '',
-      limit: 7,
+      limit: DEFAULT_LIMIT, // FIXME: placeholder로 표기하고, 값이 비어있을 경우 submit 핸들러에서 DEFAULT_LIMIT을 넣어주도록 수정 - zod schema에서 number에 대해 "비어있거나 3이상일 때 valid" 라는 조건을 설정하는 법을 모르겠음
     },
   });
 
   const btnDisabled = Object.keys(errors).length > 0 || !isValid;
 
-  const handleFormSubmit: SubmitHandler<Form.Model> = async ({
-    name,
-    introduce,
-    limit,
-    domain,
-  }) => {
-    try {
-      // FIXME: 생성 API 서비스에 추가 및 반영 필요
-      // @ts-ignore
-      const response = await PartyroomsService.create({
-        name,
-        introduce,
-        limit,
-        domain: domain || undefined,
-      });
-
-      onModalClose && onModalClose();
-
-      router.push(`/parties/${domain || response.name}`);
-    } catch (error: unknown) {
-      // FIXME: BE와 api 논의 후 수정 필요. 1. 유저가 이미 파티를 개설한 경우 2. 도메인이 이미 존재하는 경우
-      if (error instanceof AxiosError && error.response?.status === 409) {
-        setError('domain', { message: t.createparty.para.domain_in_use });
+  const handleFormSubmit: SubmitHandler<Form.Model> = async (values) => {
+    create(
+      {
+        title: values.name,
+        introduction: values.introduce,
+        linkDomain: values.domain,
+        playbackTimeLimit: values.limit,
+      },
+      {
+        onSuccess: (data) => {
+          onClose?.();
+          router.push(`/parties/${data.partyroomId}`);
+        },
+        onError: (error) => {
+          if (error.response?.status === 409) {
+            setError('domain', {
+              message: t.createparty.para.domain_in_use,
+            });
+          }
+        },
       }
-    }
+    );
   };
 
   return (
@@ -82,25 +76,29 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
         'child-form-labels:w-[120px]': lang === Language.En,
       })}
     >
-      <div className=' w-full items-end gap-12 flexCol'>
+      <div className='w-full items-end gap-12 flexCol'>
         <FormItem
           label={t.party.title.party_name}
           error={errors.name?.message}
           required
           classNames={{ label: 'text-gray-200', container: 'w-full' }}
         >
-          <Input {...register('name')} placeholder={t.common.ec.char_limit_12} maxLength={30} />
+          <Input
+            {...register('name')}
+            maxLength={Form.MAX_LENGTH.NAME}
+            placeholder={t.common.ec.char_limit_12}
+          />
         </FormItem>
 
         <FormItem
           label={t.party.title.party_desc}
           required
-          error={errors.introduce && t.common.ec.char_limit_50}
+          error={errors.introduce?.message}
           classNames={{ label: 'text-gray-200', container: 'w-full' }}
         >
           <TextArea
             {...register('introduce')}
-            maxLength={50}
+            maxLength={Form.MAX_LENGTH.INTRODUCE}
             rows={3}
             placeholder={t.common.ec.char_limit_50}
           />
@@ -136,7 +134,7 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
                     visible={!!errors.limit?.message}
                   >
                     <Typography type='body2'>
-                      {/* TODO: 문구 줄바꿈 적용 필요*/}
+                      {/* TODO: i18n - 문구 줄바꿈 적용 필요*/}
                       {t.db.title.dj_time_limit}
                     </Typography>
                   </Tooltip>
@@ -148,7 +146,7 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
                   }),
                 }}
               >
-                <InputNumber {...register('limit', { valueAsNumber: true })} initialValue={7} />
+                <InputNumber {...register('limit', { valueAsNumber: true })} />
                 <Typography as='span' type='detail1' className='text-gray-200 ml-[8px]'>
                   {t.createparty.para.min}
                 </Typography>
@@ -165,14 +163,14 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
             }
             classNames={{ label: 'text-gray-200' }}
           >
-            <DjListItem userConfig={{ username: me.nickname, src: '' }} />
+            <DjListItem userConfig={{ username: me.nickname, src: me.avatarIconUri }} />
           </FormItem>
 
           <Button
             type='submit'
-            variant={'fill'}
+            variant='fill'
             size='lg'
-            className={'px-[74px]'}
+            className='px-[74px]'
             disabled={btnDisabled}
           >
             {t.createparty.btn.create_party}
@@ -181,6 +179,6 @@ const PartyroomCreateForm = ({ onModalClose }: PartyroomCreateFormProps) => {
       </div>
     </form>
   );
-};
+}
 
-export default PartyroomCreateForm;
+const DEFAULT_LIMIT = 7;

--- a/src/features/partyroom/list/ui/partyroom-card.component.tsx
+++ b/src/features/partyroom/list/ui/partyroom-card.component.tsx
@@ -20,7 +20,7 @@ const PartyroomCard = ({ roomId, summary }: PartyroomCardProps) => {
       <Link
         /* TODO: set proper route with id */
         href={`/parties/${roomId}`}
-        className='flexCol gap-[61px] py-6 px-7 backdrop-blur-xl bg-backdrop-black/80'
+        className='h-full flexCol justify-between gap-[61px] py-6 px-7 backdrop-blur-xl bg-backdrop-black/80'
       >
         <Typography type='title2' className='text-gray-50'>
           {summary.title}
@@ -53,7 +53,7 @@ const PartyroomCard = ({ roomId, summary }: PartyroomCardProps) => {
               count={summary.crewCount}
               icons={summary.primaryIcons.map((avatar) => avatar.avatarIconUri)}
             />
-            <PFInfoOutline width={24} height={24} />
+            <PFInfoOutline width={24} height={24} role='presentation' />
           </div>
         </div>
       </Link>

--- a/src/shared/api/http/services/partyrooms.ts
+++ b/src/shared/api/http/services/partyrooms.ts
@@ -22,12 +22,18 @@ import type {
   GetRoomIdByDomainPayload,
   GetRoomIdByDomainResponse,
   PartyroomSummary,
+  CreatePartyroomPayload,
+  CreatePartyroomResponse,
 } from 'shared/api/http/types/partyrooms';
 import HTTPClient from '../client/client';
 
 @Singleton
 class PartyroomsService extends HTTPClient implements PartyroomsClient {
   private ROUTE_V1 = 'v1/partyrooms';
+
+  public create = (payload: CreatePartyroomPayload) => {
+    return this.post<CreatePartyroomResponse>(this.ROUTE_V1, payload);
+  };
 
   public getList = () => {
     return this.get<PartyroomSummary[]>(`${this.ROUTE_V1}`);

--- a/src/shared/api/http/types/partyrooms.ts
+++ b/src/shared/api/http/types/partyrooms.ts
@@ -8,6 +8,17 @@ import {
   StageType,
 } from '@/shared/api/http/types/@enums';
 
+export type CreatePartyroomPayload = {
+  title: string;
+  introduction: string;
+  linkDomain?: string;
+  playbackTimeLimit: number;
+};
+
+export type CreatePartyroomResponse = {
+  partyroomId: number;
+};
+
 export type PartyroomDetailSummary = {
   title: string;
   introduction: string;
@@ -221,6 +232,10 @@ export type ReactionResponse = {
 };
 
 export interface PartyroomsClient {
+  /**
+   * 파티룸 생성
+   */
+  create(payload: CreatePartyroomPayload): Promise<CreatePartyroomResponse>;
   /**
    * 파티룸 목록 조회
    */


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

파티룸 생성 기능을 작성합니다.

<img width="1071" alt="스크린샷 2024-10-05 오후 7 12 58" src="https://github.com/user-attachments/assets/d1a0d1fc-ebca-46e9-bce5-85f7806164ec">

### Todo

djing limit 필드는 기획상 placeholder로 기본 값을 보여준 뒤 submit 시점에 값이 비어있다면 기본 값을 넣어 api 요청을 쏴야합니다.
하지만 zod에서 number 필드에 대해 "비어있거나 3보다 클 때 valid" 라는 조건을 달성하는 법을 찾지 못해, placeholder가 아닌 defaultValue로 임의 처리합니다. 

### Issue

#193