### PR TITLE
feat: 각 제재 요청이 완료 됐을 시 전파 받은 penaltyType에 따라 후속조치

### DIFF
--- a/src/app/parties/(room)/[id]/page.tsx
+++ b/src/app/parties/(room)/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PartyroomChatPanel } from '@/widgets/partyroom-chat-panel';
 import { PartyroomDetailTrigger } from '@/widgets/partyroom-detail';
 import { PartyroomDisplayBoard } from '@/widgets/partyroom-display-board';
 import { DjingDialog } from '@/widgets/partyroom-djing-dialog';
+import PenaltyNotificationDialog from '@/widgets/partyroom-djing-dialog/ui/penalty-notification-dialog.component';
 import { PartyroomParticipantPanel } from '@/widgets/partyroom-participant-panel';
 import { Sidebar } from '@/widgets/sidebar';
 
@@ -95,6 +96,8 @@ const PartyroomPage = () => {
         open={isDjingDialogOpen}
         close={closeDjingDialog}
       />
+
+      <PenaltyNotificationDialog />
     </>
   );
 };

--- a/src/entities/current-partyroom/lib/use-chat.hook.ts
+++ b/src/entities/current-partyroom/lib/use-chat.hook.ts
@@ -9,7 +9,11 @@ import { useStores } from '@/shared/lib/store/stores.context';
  */
 export function useChat() {
   const { useCurrentPartyroom } = useStores();
-  const chat = useCurrentPartyroom((state) => state.chat);
+  const [chat, chatUpdated, setChatUpdated] = useCurrentPartyroom((state) => [
+    state.chat,
+    state.chatUpdated,
+    state.setChatUpdated,
+  ]);
   const [messages, setMessages] = useState(chat.getMessages());
 
   useEffect(() => {
@@ -23,6 +27,13 @@ export function useChat() {
       chat.removeMessageListener(handleMessage);
     };
   }, [chat]);
+
+  useEffect(() => {
+    if (chatUpdated) {
+      setMessages(chat.getMessages());
+      setChatUpdated(false);
+    }
+  }, [chatUpdated]);
 
   return messages;
 }

--- a/src/entities/current-partyroom/model/chat-message.model.ts
+++ b/src/entities/current-partyroom/model/chat-message.model.ts
@@ -5,6 +5,7 @@ export type Model = {
   crew: PartyroomCrew;
   message: ChatEvent['message'];
   receivedAt: number;
+  removed?: boolean;
 };
 
 export const uniqueId = (model: Model) => {

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -1,4 +1,4 @@
-import { GradeType } from '@/shared/api/http/types/@enums';
+import { GradeType, PenaltyType } from '@/shared/api/http/types/@enums';
 import { PartyroomPlayback, PartyroomReaction } from '@/shared/api/http/types/partyrooms';
 import { ChatEvent } from '@/shared/api/websocket/types/partyroom';
 import { Chat } from '@/shared/lib/chat';
@@ -9,6 +9,12 @@ import * as Crew from './crew.model';
 export type MyPartyroomInfo = {
   crewId: number;
   gradeType: GradeType;
+};
+
+export type PenaltyNotification = {
+  punishedId: number;
+  penaltyType: PenaltyType;
+  detail: string;
 };
 
 export type Model = {
@@ -53,6 +59,12 @@ export type Model = {
    * 채팅 메세지 삭제 시 호출되는 함수입니다
    */
   updateChatMessage: ({ messageId, content }: { messageId: string; content: string }) => void;
+
+  /**
+   * 패널티 전파
+   */
+  penaltyNotification?: PenaltyNotification;
+  setPenaltyNotification: (notification: PenaltyNotification | undefined) => void;
 
   init: (
     next: Pick<

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -42,6 +42,18 @@ export type Model = {
   chat: Chat<ChatMessage.Model>;
   appendChatMessage: (crewId: number, message: ChatEvent['message']) => void;
 
+  /**
+   *  chatUpdated는 채팅 메세지 삭제 시 useChat.hook.ts에서 chatMessages에 대체된 메세지를 리렌더 하기 위해 'updateChatMessage' action에서 호출되는 함수입니다.
+   */
+
+  chatUpdated: boolean;
+  setChatUpdated: (updated: boolean) => void;
+
+  /**
+   * 채팅 메세지 삭제 시 호출되는 함수입니다
+   */
+  updateChatMessage: ({ messageId, content }: { messageId: string; content: string }) => void;
+
   init: (
     next: Pick<
       Model,

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -114,13 +114,19 @@ export const createCurrentPartyroomStore = () => {
           }
           return message;
         });
-        console.log({ messageId, content, updatedMessages });
 
         return {
           ...state,
           chat: Chat.create(updatedMessages),
           chatUpdated: true,
         };
+      });
+    },
+
+    penaltyNotification: undefined,
+    setPenaltyNotification: (penaltyNotification) => {
+      return set({
+        penaltyNotification,
       });
     },
 

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -97,6 +97,33 @@ export const createCurrentPartyroomStore = () => {
       });
     },
 
+    chatUpdated: false,
+    setChatUpdated: (chatUpdated) => set({ chatUpdated }),
+    updateChatMessage: ({ messageId, content }) => {
+      return set((state) => {
+        const updatedMessages = state.chat.getMessages().map((message) => {
+          if (message.message.messageId === messageId) {
+            return {
+              ...message,
+              message: {
+                ...message.message,
+                content,
+              },
+              removed: true,
+            };
+          }
+          return message;
+        });
+        console.log({ messageId, content, updatedMessages });
+
+        return {
+          ...state,
+          chat: Chat.create(updatedMessages),
+          chatUpdated: true,
+        };
+      });
+    },
+
     init: (next) => {
       return set(
         {

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
@@ -1,28 +1,43 @@
 import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { CrewPenaltyEvent } from '@/shared/api/websocket/types/partyroom';
+import { errorLog } from '@/shared/lib/functions/log/logger';
+import withDebugger from '@/shared/lib/functions/log/with-debugger';
 import { useStores } from '@/shared/lib/store/stores.context';
 
+const logger = withDebugger(0);
+const errorLogger = logger(errorLog);
+
+/**
+ * WS에서 패널티 관련 event 처리하는 콜백
+ */
 export default function useCrewPenaltyCallback() {
   const { useCurrentPartyroom } = useStores();
-  const [updateChatMessage, crews] = useCurrentPartyroom((state) => [
+  const [updateChatMessage, crews, setPenaltyNotification] = useCurrentPartyroom((state) => [
     state.updateChatMessage,
     state.crews,
+    state.setPenaltyNotification,
   ]);
 
   return (event: CrewPenaltyEvent) => {
-    switch (event.penaltyType) {
-      case PenaltyType.CHAT_MESSAGE_REMOVAL:
-        const punisher = crews.find((crew) => crew.crewId === event.punisher.crewId);
-        const punished = crews.find((crew) => crew.crewId === event.punished.crewId);
+    if (event.penaltyType === PenaltyType.CHAT_MESSAGE_REMOVAL) {
+      const punisher = crews.find((crew) => crew.crewId === event.punisher.crewId);
+      const punished = crews.find((crew) => crew.crewId === event.punished.crewId);
 
-        updateChatMessage({
-          messageId: event.detail,
-          content: `'${punisher?.nickname}'(이)가 '${punished?.nickname}'의 채팅을 삭제했습니다.`, // TODO: i18n 적용
-        });
-        break;
+      if (!punisher || !punished) {
+        errorLogger('Punisher and Punished not found');
+        return;
+      }
 
-      case PenaltyType.CHAT_BAN_30_SECONDS:
-        break;
+      updateChatMessage({
+        messageId: event.detail,
+        content: `'${punisher?.nickname}'(이)가 '${punished?.nickname}'의 채팅을 삭제했습니다.`, // TODO: i18n 적용
+      });
+    } else {
+      setPenaltyNotification({
+        punishedId: event.punished.crewId,
+        penaltyType: event.penaltyType,
+        detail: event.detail,
+      });
     }
   };
 }

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
@@ -1,7 +1,28 @@
+import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { CrewPenaltyEvent } from '@/shared/api/websocket/types/partyroom';
+import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function useCrewPenaltyCallback() {
-  return (_event: CrewPenaltyEvent) => {
-    // TODO: implementation
+  const { useCurrentPartyroom } = useStores();
+  const [updateChatMessage, crews] = useCurrentPartyroom((state) => [
+    state.updateChatMessage,
+    state.crews,
+  ]);
+
+  return (event: CrewPenaltyEvent) => {
+    switch (event.penaltyType) {
+      case PenaltyType.CHAT_MESSAGE_REMOVAL:
+        const punisher = crews.find((crew) => crew.crewId === event.punisher.crewId);
+        const punished = crews.find((crew) => crew.crewId === event.punished.crewId);
+
+        updateChatMessage({
+          messageId: event.detail,
+          content: `'${punisher?.nickname}'(이)가 '${punished?.nickname}'의 채팅을 삭제했습니다.`, // TODO: i18n 적용
+        });
+        break;
+
+      case PenaltyType.CHAT_BAN_30_SECONDS:
+        break;
+    }
   };
 }

--- a/src/features/partyroom/impose-penalty/lib/use-impost-penalty.tsx
+++ b/src/features/partyroom/impose-penalty/lib/use-impost-penalty.tsx
@@ -34,13 +34,11 @@ export default function useImposePenalty() {
         </Typography>
       ),
       Body: () => {
-        const [isLoading, setIsLoading] = useState(false);
-        const { mutate: imposePenalty } = useImposePenaltyMutation();
+        const { mutate: imposePenalty, isPending } = useImposePenaltyMutation();
         const [reason, setReason] = useState('');
         const disabled = reason.length < 2;
 
         const handleConfirmBtnClick = () => {
-          setIsLoading(true);
           imposePenalty(
             {
               partyroomId,
@@ -50,7 +48,6 @@ export default function useImposePenalty() {
             },
             {
               onSettled: () => {
-                setIsLoading(false);
                 onOk();
               },
             }
@@ -71,11 +68,11 @@ export default function useImposePenalty() {
                 {t.common.btn.cancel}
               </Dialog.Button>
               <Dialog.Button
-                loading={isLoading}
+                loading={isPending}
                 onClick={handleConfirmBtnClick}
                 disabled={disabled}
               >
-                {!isLoading ? t.common.btn.confirm : ''}
+                {t.common.btn.confirm}
               </Dialog.Button>
             </Dialog.ButtonGroup>
           </>

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -12,6 +12,7 @@ import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
 import { DisplayOptionMenuOnHoverListener } from '@/shared/ui/components/display-option-menu-on-hover-listener';
 import { Input } from '@/shared/ui/components/input';
+import { Typography } from '@/shared/ui/components/typography';
 import { PFSend } from '@/shared/ui/icons';
 import ChatItem from './chat-item.component';
 
@@ -35,6 +36,14 @@ export default function PartyroomChatPanel() {
     <div ref={containerRef} className='flexCol gap-1'>
       <div ref={scrollContainerRef} className='flex-[1_0_0] flexCol gap-4 overflow-y-auto py-4'>
         {chatMessages.map((message, i) => {
+          if (message.removed) {
+            return (
+              <Typography type='caption1' className='text-red-200 p-2 pl-[58px]'>
+                {message.message.content}
+              </Typography>
+            );
+          }
+
           const isLast = i === chatMessages.length - 1;
           const isMe = message.crew.crewId === me?.crewId;
 

--- a/src/widgets/partyroom-detail/ui/use-open-share-dialog.hook.tsx
+++ b/src/widgets/partyroom-detail/ui/use-open-share-dialog.hook.tsx
@@ -34,7 +34,8 @@ function Body({ partyroom }: { partyroom?: PartyroomDetailSummary }) {
   const [isCopied, setIsCopied] = useState(false);
 
   const t = useI18n();
-  const sharedUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/party/${partyroom?.linkDomain}`;
+  // 개발환경에서는 브라우저 주소창에 사용하는 localhost를 붙이고 나머지 path 입력해서 테스트. e.g) https://localhost:3000/party/...
+  const sharedUrl = `https://pfplay.io/party/${partyroom?.linkDomain}`;
 
   if (typeof id === 'undefined') {
     throw new Error('partyroomId is not found. maybe you are not in the partyroom.');

--- a/src/widgets/partyroom-djing-dialog/ui/penalty-notification-dialog.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/penalty-notification-dialog.component.tsx
@@ -1,0 +1,71 @@
+import { PenaltyType } from '@/shared/api/http/types/@enums';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { replaceVar } from '@/shared/lib/localization/split-render';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { Dialog } from '@/shared/ui/components/dialog';
+import { Typography } from '@/shared/ui/components/typography';
+
+export default function PenaltyNotificationDialog() {
+  const t = useI18n();
+  const [penaltyNotification, setPenaltyNotification, me] = useStores().useCurrentPartyroom(
+    (state) => [state.penaltyNotification, state.setPenaltyNotification, state.me]
+  );
+  const isPunished = penaltyNotification && me?.crewId === penaltyNotification.punishedId;
+
+  if (!isPunished) {
+    return null;
+  }
+
+  const handleClose = () => {
+    setPenaltyNotification(undefined);
+  };
+
+  return (
+    <Dialog
+      open={!!isPunished}
+      onClose={handleClose}
+      title={({ defaultTypographyType, defaultClassName }) => (
+        <Typography type={defaultTypographyType} className={defaultClassName}>
+          {getPenaltyTypeTitle(penaltyNotification.penaltyType)}
+        </Typography>
+      )}
+      Sub={
+        <Typography type='body3' className='text-gray-50'>
+          Reason: {penaltyNotification.detail}
+        </Typography>
+      }
+      Body={
+        <Dialog.ButtonGroup>
+          <Dialog.Button onClick={handleClose}>{t.common.btn.confirm}</Dialog.Button>
+        </Dialog.ButtonGroup>
+      }
+    />
+  );
+}
+
+// TODO: i18n 적용
+const getPenaltyTypeTitle = (penaltyType: PenaltyType) => {
+  switch (penaltyType) {
+    case PenaltyType.CHAT_BAN_30_SECONDS:
+      return replaceVar('관리자에 의해 $1됩니다', {
+        $1: <b className='text-red-300'>30초간 채팅이 금지</b>,
+      });
+
+    case PenaltyType.PERMANENT_EXPULSION:
+      return replaceVar('관리자에 의해 $1되셨으며 $2합니다', {
+        $1: <b className='text-red-300'>영구 퇴출</b>,
+        $2: (
+          <>
+            <br />
+            <b className='text-red-300'>재입장은 불가능</b>
+          </>
+        ),
+      });
+    case PenaltyType.ONE_TIME_EXPULSION:
+      return replaceVar('관리자에 의해 $1되셨습니다', {
+        $1: <b className='text-red-300'>퇴출</b>,
+      });
+    default:
+      return '';
+  }
+};


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

각 제재 요청이 완료 됐을 시 전파 받은 penaltyType에 따라 후속조치 [(화면기획서)](https://www.figma.com/design/9I5PR6OqN8cHJ7WVTOKe00/PFPlay-GUI-%EC%84%A4%EA%B3%84%EC%84%9C-%ED%95%A9%EB%B3%B8?node-id=1-97290&t=2ZnndhNHjOZLPoWf-4)

- CHAT_MESSAGE_REMOVAL일 경우 채팅 창에 삭제 요청된 메세지 삭제처리
- 나머지 제재에 대해선 제재 당한 유저에게 패널티 안내 dialog 띄어주기

### Todo

<!-- 해당 기능을 마무리하기 위해 작업해야할 남은 작업을 적어주세요. -->
- 현재 menuConfig에 모든 제재리스트들을 나열한 것을 디자인에 따라 메뉴 옵션에서 '제재' item을 눌렀을 시 모든 제재 아이템을 메뉴 옵션에 보여주는 식으로 변경해야합니다. 다른 브랜치에서 작업하겠습니다

![image](https://github.com/user-attachments/assets/9452acc6-8c29-4aaf-a8a9-968e14af6f3e)




### Issue

<!-- 작업중에 발생한 이슈를 공유해주세요. -->

N/A

### Reference

<!--
  개발하시면서 도움이 되었던 참고자료들을 이곳에 적어주세요.
  다른 팀원들에게 큰 도움이 됩니다. :)
-->

N/A
