### PR TITLE
refactor: delegate updateMessage method to chat class

### DIFF
--- a/src/entities/current-partyroom/lib/use-chat.hook.ts
+++ b/src/entities/current-partyroom/lib/use-chat.hook.ts
@@ -9,11 +9,7 @@ import { useStores } from '@/shared/lib/store/stores.context';
  */
 export function useChat() {
   const { useCurrentPartyroom } = useStores();
-  const [chat, chatUpdated, setChatUpdated] = useCurrentPartyroom((state) => [
-    state.chat,
-    state.chatUpdated,
-    state.setChatUpdated,
-  ]);
+  const chat = useCurrentPartyroom((state) => state.chat);
   const [messages, setMessages] = useState(chat.getMessages());
 
   useEffect(() => {
@@ -27,13 +23,6 @@ export function useChat() {
       chat.removeMessageListener(handleMessage);
     };
   }, [chat]);
-
-  useEffect(() => {
-    if (chatUpdated) {
-      setMessages(chat.getMessages());
-      setChatUpdated(false);
-    }
-  }, [chatUpdated]);
 
   return messages;
 }

--- a/src/entities/current-partyroom/model/chat-message.model.ts
+++ b/src/entities/current-partyroom/model/chat-message.model.ts
@@ -1,13 +1,22 @@
 import { PartyroomCrew } from '@/shared/api/http/types/partyrooms';
 import { ChatEvent } from '@/shared/api/websocket/types/partyroom';
 
-export type Model = {
+export type ChatType = 'user' | 'system';
+
+export type SystemChat = {
+  from: 'system';
+  content: string;
+};
+
+export type UserChat = {
+  from: 'user';
   crew: PartyroomCrew;
   message: ChatEvent['message'];
   receivedAt: number;
-  removed?: boolean;
 };
 
-export const uniqueId = (model: Model) => {
-  return model.crew.crewId + model.crew.uid + model.receivedAt;
+export type Model = SystemChat | UserChat;
+
+export const uniqueId = () => {
+  return crypto.randomUUID();
 };

--- a/src/entities/current-partyroom/model/chat-message.model.ts
+++ b/src/entities/current-partyroom/model/chat-message.model.ts
@@ -6,6 +6,7 @@ export type ChatType = 'user' | 'system';
 export type SystemChat = {
   from: 'system';
   content: string;
+  messageId: ChatEvent['message']['messageId'];
 };
 
 export type UserChat = {

--- a/src/entities/current-partyroom/model/chat-message.model.ts
+++ b/src/entities/current-partyroom/model/chat-message.model.ts
@@ -16,7 +16,3 @@ export type UserChat = {
 };
 
 export type Model = SystemChat | UserChat;
-
-export const uniqueId = () => {
-  return crypto.randomUUID();
-};

--- a/src/entities/current-partyroom/model/chat-message.model.ts
+++ b/src/entities/current-partyroom/model/chat-message.model.ts
@@ -6,7 +6,6 @@ export type ChatType = 'user' | 'system';
 export type SystemChat = {
   from: 'system';
   content: string;
-  messageId: ChatEvent['message']['messageId'];
 };
 
 export type UserChat = {

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -49,13 +49,6 @@ export type Model = {
   appendChatMessage: (crewId: number, message: ChatEvent['message']) => void;
 
   /**
-   *  chatUpdated는 채팅 메세지 삭제 시 useChat.hook.ts에서 chatMessages에 대체된 메세지를 리렌더 하기 위해 'updateChatMessage' action에서 호출되는 함수입니다.
-   */
-
-  chatUpdated: boolean;
-  setChatUpdated: (updated: boolean) => void;
-
-  /**
    * 채팅 메세지 삭제 시 호출되는 함수입니다
    */
   updateChatMessage: ({ messageId, content }: { messageId: string; content: string }) => void;

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -51,7 +51,10 @@ export type Model = {
   /**
    * 채팅 메세지 삭제 시 호출되는 함수입니다
    */
-  updateChatMessage: ({ messageId, content }: { messageId: string; content: string }) => void;
+  updateChatMessage: (
+    predicate: (message: ChatMessage.Model) => boolean,
+    updater: (message: ChatMessage.Model) => ChatMessage.Model
+  ) => void;
 
   /**
    * 패널티 전파

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -88,6 +88,7 @@ export const createCurrentPartyroomStore = () => {
         }
 
         state.chat.appendMessage({
+          from: 'user',
           crew,
           message,
           receivedAt: Date.now(),
@@ -102,16 +103,13 @@ export const createCurrentPartyroomStore = () => {
     updateChatMessage: ({ messageId, content }) => {
       return set((state) => {
         const updatedMessages = state.chat.getMessages().map((message) => {
-          if (message.message.messageId === messageId) {
+          if (message.from === 'user' && message.message.messageId === messageId) {
             return {
-              ...message,
-              message: {
-                ...message.message,
-                content,
-              },
-              removed: true,
+              from: 'system',
+              content,
             };
           }
+
           return message;
         });
 

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -98,26 +98,17 @@ export const createCurrentPartyroomStore = () => {
       });
     },
 
-    chatUpdated: false,
-    setChatUpdated: (chatUpdated) => set({ chatUpdated }),
     updateChatMessage: ({ messageId, content }) => {
       return set((state) => {
-        const updatedMessages = state.chat.getMessages().map((message) => {
-          if (message.from === 'user' && message.message.messageId === messageId) {
-            return {
-              from: 'system',
-              content,
-            };
-          }
+        state.chat.updateMessage(
+          (message) => message.from === 'user' && message.message.messageId === messageId,
+          () => ({
+            from: 'system',
+            content,
+          })
+        );
 
-          return message;
-        });
-
-        return {
-          ...state,
-          chat: Chat.create(updatedMessages),
-          chatUpdated: true,
-        };
+        return state;
       });
     },
 

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -98,16 +98,9 @@ export const createCurrentPartyroomStore = () => {
       });
     },
 
-    updateChatMessage: ({ messageId, content }) => {
+    updateChatMessage: (predicate, updater) => {
       return set((state) => {
-        state.chat.updateMessage(
-          (message) => message.from === 'user' && message.message.messageId === messageId,
-          () => ({
-            from: 'system',
-            content,
-          })
-        );
-
+        state.chat.updateMessage(predicate, updater);
         return state;
       });
     },

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
@@ -12,13 +12,16 @@ const errorLogger = logger(errorLog);
  */
 export default function useCrewPenaltyCallback() {
   const { useCurrentPartyroom } = useStores();
-  const [updateChatMessage, crews, setPenaltyNotification] = useCurrentPartyroom((state) => [
+  const [updateChatMessage, setPenaltyNotification] = useCurrentPartyroom((state) => [
     state.updateChatMessage,
-    state.crews,
     state.setPenaltyNotification,
   ]);
 
   return (event: CrewPenaltyEvent) => {
+    // crews를 훅 내부에서 직접 가져오면 초기 상태(빈 배열)가 클로저에 캡처됨.
+    // 콜백 함수 내에서 crews를 가져오면 실행 시점의 최신 상태를 얻을 수 있음.
+    const crews = useCurrentPartyroom.getState().crews;
+
     if (event.penaltyType === PenaltyType.CHAT_MESSAGE_REMOVAL) {
       const punisher = crews.find((crew) => crew.crewId === event.punisher.crewId);
       const punished = crews.find((crew) => crew.crewId === event.punished.crewId);

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-penalty-callback.hook.ts
@@ -1,3 +1,4 @@
+import { ChatMessage } from '@/entities/current-partyroom';
 import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { CrewPenaltyEvent } from '@/shared/api/websocket/types/partyroom';
 import { errorLog } from '@/shared/lib/functions/log/logger';
@@ -31,10 +32,15 @@ export default function useCrewPenaltyCallback() {
         return;
       }
 
-      updateChatMessage({
-        messageId: event.detail,
-        content: `'${punisher?.nickname}'(이)가 '${punished?.nickname}'의 채팅을 삭제했습니다.`, // TODO: i18n 적용
-      });
+      updateChatMessage(
+        (message: ChatMessage.Model) =>
+          message.from === 'user' && message.message.messageId === event.detail,
+        () => ({
+          from: 'system',
+          content: `'${punisher?.nickname}'(이)가 '${punished?.nickname}'의 채팅을 삭제했습니다.`, // TODO: i18n 적용
+          messageId: event.detail,
+        })
+      );
     } else {
       setPenaltyNotification({
         punishedId: event.punished.crewId,

--- a/src/shared/config/max-message-amount.ts
+++ b/src/shared/config/max-message-amount.ts
@@ -1,0 +1,1 @@
+export const MAX_MESSAGE_AMOUNT = 500;

--- a/src/shared/lib/chat/lib/chat.ts
+++ b/src/shared/lib/chat/lib/chat.ts
@@ -40,16 +40,7 @@ export default class Chat<Message> {
     predicate: (message: Message) => boolean,
     updater: (message: Message) => Message
   ): void {
-    let updatedMessage: Message | undefined;
-
-    this.messages.update(predicate, (message: Message) => {
-      if (!updatedMessage) {
-        updatedMessage = updater(message);
-        return updatedMessage;
-      }
-      return message;
-    });
-
+    const updatedMessage = this.messages.update(predicate, updater);
     if (updatedMessage) {
       this.messageListener.notify({ type: 'update', message: updatedMessage });
     }

--- a/src/shared/lib/chat/lib/circular-buffer-adapter.ts
+++ b/src/shared/lib/chat/lib/circular-buffer-adapter.ts
@@ -15,6 +15,7 @@ export default class CircularBufferAdapter<Message> implements ChatMessages<Mess
   public clear(): void {
     this.buffer.clear();
   }
+
   public update(
     predicate: (message: Message) => boolean,
     updater: (message: Message) => Message

--- a/src/shared/lib/chat/lib/circular-buffer-adapter.ts
+++ b/src/shared/lib/chat/lib/circular-buffer-adapter.ts
@@ -15,4 +15,10 @@ export default class CircularBufferAdapter<Message> implements ChatMessages<Mess
   public clear(): void {
     this.buffer.clear();
   }
+  public update(
+    predicate: (message: Message) => boolean,
+    updater: (message: Message) => Message
+  ): void {
+    this.buffer.update(predicate, updater);
+  }
 }

--- a/src/shared/lib/chat/lib/circular-buffer-adapter.ts
+++ b/src/shared/lib/chat/lib/circular-buffer-adapter.ts
@@ -19,7 +19,7 @@ export default class CircularBufferAdapter<Message> implements ChatMessages<Mess
   public update(
     predicate: (message: Message) => boolean,
     updater: (message: Message) => Message
-  ): void {
-    this.buffer.update(predicate, updater);
+  ): Message | undefined {
+    return this.buffer.update(predicate, updater);
   }
 }

--- a/src/shared/lib/chat/lib/circular-buffer.ts
+++ b/src/shared/lib/chat/lib/circular-buffer.ts
@@ -44,4 +44,26 @@ export default class CircularBuffer<T> {
     this.length = 0;
     this.buffer = new Array<T>(this.max);
   }
+
+  /**
+   * 순환 버퍼의 요소들을 업데이트합니다.
+   *
+   * @param predicate 업데이트할 항목을 결정하는 조건 함수입니다. true를 반환하면 해당 항목이 업데이트됩니다.
+   * @param updater 조건에 맞는 항목을 업데이트하는 함수입니다. 현재 항목을 입력받아 업데이트된 항목을 반환해야 합니다.
+   *
+   * @example
+   * // 짝수 번째 항목의 값을 두 배로 만듭니다.
+   * circularBuffer.update(
+   *   (item) => item % 2 === 0,
+   *   (item) => item * 2
+   * );
+   */
+  public update(predicate: (item: T) => boolean, updater: (item: T) => T): void {
+    for (let i = 0; i < this.length; i++) {
+      const index = (this.start + i) % this.max;
+      if (predicate(this.buffer[index])) {
+        this.buffer[index] = updater(this.buffer[index]);
+      }
+    }
+  }
 }

--- a/src/shared/lib/chat/lib/circular-buffer.ts
+++ b/src/shared/lib/chat/lib/circular-buffer.ts
@@ -49,7 +49,7 @@ export default class CircularBuffer<T> {
    * 순환 버퍼의 요소들을 업데이트합니다.
    *
    * @param predicate 업데이트할 항목을 결정하는 조건 함수입니다. true를 반환하면 해당 항목이 업데이트됩니다.
-   * @param updater 조건에 맞는 항목을 업데이트하는 함수입니다. 현재 항목을 입력받아 업데이트된 항목을 반환해야 합니다.
+   * @param updater 조건에 맞는 항목을 업데이트하는 함수입니다. 현재 항목을 입력받아 업데이트된 항목을 반환하고 즉시 종료합니다.
    *
    * @example
    * // 짝수 번째 항목의 값을 두 배로 만듭니다.
@@ -58,12 +58,15 @@ export default class CircularBuffer<T> {
    *   (item) => item * 2
    * );
    */
-  public update(predicate: (item: T) => boolean, updater: (item: T) => T): void {
+  public update(predicate: (item: T) => boolean, updater: (item: T) => T): T | undefined {
     for (let i = 0; i < this.length; i++) {
       const index = (this.start + i) % this.max;
       if (predicate(this.buffer[index])) {
-        this.buffer[index] = updater(this.buffer[index]);
+        const updatedItem = updater(this.buffer[index]);
+        this.buffer[index] = updatedItem;
+        return updatedItem; // 업데이트된 항목을 반환하고 루프 즉 종료
       }
     }
+    return undefined; // 조건에 맞는 항목을 찾지 못한 경우
   }
 }

--- a/src/shared/lib/chat/lib/observer-adapter.ts
+++ b/src/shared/lib/chat/lib/observer-adapter.ts
@@ -1,17 +1,17 @@
-import Observer, { ObserverChatEvent } from './observer';
-import type { ChatMessageListener } from '../model/chat-message-listener.model';
+import Observer from './observer';
+import { ChatMessageListener, ChatObserverEvent } from '../model/chat-message-listener.model';
 
 export default class ObserverAdapter<Message> implements ChatMessageListener<Message> {
-  public constructor(private observer: Observer<Message>) {}
+  public constructor(private observer: Observer<ChatObserverEvent<Message>>) {}
 
   public register(listener: (message: Message) => void): void {
-    this.observer.subscribe((event: ObserverChatEvent<Message>) => {
+    this.observer.subscribe((event: ChatObserverEvent<Message>) => {
       listener(event.message);
     });
   }
 
   public deregister(listener: (message: Message) => void): void {
-    this.observer.unsubscribe((event: ObserverChatEvent<Message>) => {
+    this.observer.unsubscribe((event: ChatObserverEvent<Message>) => {
       listener(event.message);
     });
   }
@@ -20,11 +20,7 @@ export default class ObserverAdapter<Message> implements ChatMessageListener<Mes
     this.observer.unsubscribeAll();
   }
 
-  public notifyAppend(message: Message): void {
-    this.observer.notify({ type: 'add', message });
-  }
-
-  public notifyUpdate(message: Message): void {
-    this.observer.notify({ type: 'update', message });
+  public notify(event: ChatObserverEvent<Message>): void {
+    this.observer.notify(event);
   }
 }

--- a/src/shared/lib/chat/lib/observer-adapter.ts
+++ b/src/shared/lib/chat/lib/observer-adapter.ts
@@ -1,22 +1,30 @@
-import Observer from './observer';
+import Observer, { ObserverChatEvent } from './observer';
 import type { ChatMessageListener } from '../model/chat-message-listener.model';
 
 export default class ObserverAdapter<Message> implements ChatMessageListener<Message> {
   public constructor(private observer: Observer<Message>) {}
 
   public register(listener: (message: Message) => void): void {
-    this.observer.subscribe(listener);
+    this.observer.subscribe((event: ObserverChatEvent<Message>) => {
+      listener(event.message);
+    });
   }
 
   public deregister(listener: (message: Message) => void): void {
-    this.observer.unsubscribe(listener);
+    this.observer.unsubscribe((event: ObserverChatEvent<Message>) => {
+      listener(event.message);
+    });
   }
 
   public deregisterAll(): void {
     this.observer.unsubscribeAll();
   }
 
-  public notify(message: Message): void {
-    this.observer.notify(message);
+  public notifyAppend(message: Message): void {
+    this.observer.notify({ type: 'add', message });
+  }
+
+  public notifyUpdate(message: Message): void {
+    this.observer.notify({ type: 'update', message });
   }
 }

--- a/src/shared/lib/chat/lib/observer.ts
+++ b/src/shared/lib/chat/lib/observer.ts
@@ -1,6 +1,4 @@
-export type ObserverChatEvent<Message> = { type: 'add' | 'update'; message: Message };
-
-type Listener<T> = (data: ObserverChatEvent<T>) => void;
+type Listener<T> = (data: T) => void;
 
 export default class Observer<T> {
   private listeners: Listener<T>[] = [];
@@ -17,7 +15,7 @@ export default class Observer<T> {
     this.listeners = [];
   }
 
-  public notify(event: ObserverChatEvent<T>) {
+  public notify(event: T) {
     for (const listener of this.listeners) {
       listener(event);
     }

--- a/src/shared/lib/chat/lib/observer.ts
+++ b/src/shared/lib/chat/lib/observer.ts
@@ -1,4 +1,6 @@
-type Listener<T> = (data: T) => void;
+export type ObserverChatEvent<Message> = { type: 'add' | 'update'; message: Message };
+
+type Listener<T> = (data: ObserverChatEvent<T>) => void;
 
 export default class Observer<T> {
   private listeners: Listener<T>[] = [];
@@ -15,9 +17,9 @@ export default class Observer<T> {
     this.listeners = [];
   }
 
-  public notify(data: T) {
+  public notify(event: ObserverChatEvent<T>) {
     for (const listener of this.listeners) {
-      listener(data);
+      listener(event);
     }
   }
 }

--- a/src/shared/lib/chat/model/chat-message-listener.model.ts
+++ b/src/shared/lib/chat/model/chat-message-listener.model.ts
@@ -2,5 +2,6 @@ export interface ChatMessageListener<Message> {
   register(listener: (message: Message) => void): void;
   deregister(listener: (message: Message) => void): void;
   deregisterAll(): void;
-  notify(message: Message): void;
+  notifyAppend(message: Message): void;
+  notifyUpdate(message: Message): void;
 }

--- a/src/shared/lib/chat/model/chat-message-listener.model.ts
+++ b/src/shared/lib/chat/model/chat-message-listener.model.ts
@@ -1,7 +1,8 @@
+export type ChatObserverEvent<Message> = { type: 'add' | 'update'; message: Message };
+
 export interface ChatMessageListener<Message> {
   register(listener: (message: Message) => void): void;
   deregister(listener: (message: Message) => void): void;
   deregisterAll(): void;
-  notifyAppend(message: Message): void;
-  notifyUpdate(message: Message): void;
+  notify(message: ChatObserverEvent<Message>): void;
 }

--- a/src/shared/lib/chat/model/chat-messages.model.ts
+++ b/src/shared/lib/chat/model/chat-messages.model.ts
@@ -2,4 +2,5 @@ export interface ChatMessages<Message> {
   list: Message[];
   append(message: Message): void;
   clear(): void;
+  update(predicate: (message: Message) => boolean, updater: (message: Message) => Message): void;
 }

--- a/src/shared/lib/chat/model/chat-messages.model.ts
+++ b/src/shared/lib/chat/model/chat-messages.model.ts
@@ -2,5 +2,8 @@ export interface ChatMessages<Message> {
   list: Message[];
   append(message: Message): void;
   clear(): void;
-  update(predicate: (message: Message) => boolean, updater: (message: Message) => Message): void;
+  update(
+    predicate: (message: Message) => boolean,
+    updater: (message: Message) => Message
+  ): Message | undefined;
 }

--- a/src/widgets/partyroom-chat-panel/ui/chat-item.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/chat-item.component.tsx
@@ -8,7 +8,7 @@ import { galmuriFont } from '@/shared/ui/foundation/fonts';
 import AuthorityHeadset from './authority-headset.component';
 
 type ChatItemProps = {
-  message: ChatMessage.Model;
+  message: Extract<ChatMessage.Model, { from: 'user' }>;
 };
 
 const ChatItem = forwardRef<HTMLDivElement, ChatItemProps>(({ message }, ref) => {

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -37,11 +37,7 @@ export default function PartyroomChatPanel() {
         {chatMessages.map((message, i) => {
           if (message.from === 'system') {
             return (
-              <Typography
-                key={message.messageId}
-                type='caption1'
-                className='text-red-200 p-2 pl-[58px]'
-              >
+              <Typography type='caption1' className='text-red-200 p-2 pl-[58px]'>
                 {message.content}
               </Typography>
             );

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -37,7 +37,11 @@ export default function PartyroomChatPanel() {
         {chatMessages.map((message, i) => {
           if (message.from === 'system') {
             return (
-              <Typography type='caption1' className='text-red-200 p-2 pl-[58px]'>
+              <Typography
+                key={message.messageId}
+                type='caption1'
+                className='text-red-200 p-2 pl-[58px]'
+              >
                 {message.content}
               </Typography>
             );

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Crew, useCurrentPartyroomChat } from '@/entities/current-partyroom';
-import { ChatMessage } from '@/entities/current-partyroom';
 import { useAdjustGrade } from '@/features/partyroom/adjust-grade';
 import { useDeleteChatMessage, useImposePenalty } from '@/features/partyroom/impose-penalty';
 import { useChatMessagesScrollManager } from '@/features/partyroom/list-chat-messages';
@@ -36,10 +35,10 @@ export default function PartyroomChatPanel() {
     <div ref={containerRef} className='flexCol gap-1'>
       <div ref={scrollContainerRef} className='flex-[1_0_0] flexCol gap-4 overflow-y-auto py-4'>
         {chatMessages.map((message, i) => {
-          if (message.removed) {
+          if (message.from === 'system') {
             return (
               <Typography type='caption1' className='text-red-200 p-2 pl-[58px]'>
-                {message.message.content}
+                {message.content}
               </Typography>
             );
           }
@@ -49,7 +48,7 @@ export default function PartyroomChatPanel() {
 
           return (
             <DisplayOptionMenuOnHoverListener
-              key={ChatMessage.uniqueId(message)}
+              key={message.message.messageId}
               disabled={isMe}
               menuPositionStyle='top-[8px] right-[12px]'
               menuItemPanelSize='sm'


### PR DESCRIPTION
### Summary

zustand store에서 관리하던 updateMessage를 chat 클래스에 위임하고,  불필요해진 state들을 store 에서제거합니다.
![2024-10-09_19-30-27](https://github.com/user-attachments/assets/a3405fa6-333b-4830-86b1-668534c14a73)


### Todo

<!-- 해당 기능을 마무리하기 위해 작업해야할 남은 작업을 적어주세요. -->

N/A

### Issue

<!-- 작업중에 발생한 이슈를 공유해주세요. -->

N/A

### Reference

<!--
  개발하시면서 도움이 되었던 참고자료들을 이곳에 적어주세요.
  다른 팀원들에게 큰 도움이 됩니다. :)
-->

N/A
