### PR TITLE
feat: 파티룸 내에서 페이지 이동 없이 아바타 설정 가능하도록 작업

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import '@rainbow-me/rainbowkit/styles.css';
 import '@/shared/ui/foundation/globals.css';
 
 import { PropsWithChildren } from 'react';
-import StoresProvider from '@/app/_providers/stores.provider';
 import { MeHydration } from '@/entities/me';
 import { DomId } from '@/shared/config/dom-id';
 import { Language } from '@/shared/lib/localization/constants';
@@ -17,6 +16,8 @@ import { DialogProvider } from '@/shared/ui/components/dialog';
 import { pretendardVariable } from '@/shared/ui/foundation/fonts';
 import PartyroomConnectionProvider from './_providers/partyroom-connection.provider';
 import ReactQueryProvider from './_providers/react-query.provider';
+import StoresProvider from './_providers/stores.provider';
+import { WalletProvider } from './_providers/wallet.provider';
 
 export const metadata: Metadata = {
   title: 'PFPlay',
@@ -37,11 +38,13 @@ const RootLayout = async ({ children }: PropsWithChildren) => {
           <LangProvider lang={lang as Language}>
             <I18nProvider dictionary={dictionary}>
               <StoresProvider>
-                <DialogProvider>
-                  <MeHydration>
-                    <PartyroomConnectionProvider>{children}</PartyroomConnectionProvider>
-                  </MeHydration>
-                </DialogProvider>
+                <WalletProvider>
+                  <DialogProvider>
+                    <MeHydration>
+                      <PartyroomConnectionProvider>{children}</PartyroomConnectionProvider>
+                    </MeHydration>
+                  </DialogProvider>
+                </WalletProvider>
               </StoresProvider>
             </I18nProvider>
           </LangProvider>

--- a/src/app/parties/(lobby)/page.tsx
+++ b/src/app/parties/(lobby)/page.tsx
@@ -1,13 +1,20 @@
+'use client';
 import { PartyroomCreateCard } from '@/features/partyroom/create';
 import { MainPartyroomCard, PartyroomList } from '@/features/partyroom/list';
 import SuspenseWithErrorBoundary from '@/shared/api/suspense-with-error-boundary.component';
 import { cn } from '@/shared/lib/functions/cn';
+import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { Sidebar } from '@/widgets/sidebar';
 
 const PartyLobbyPage = () => {
+  const router = useAppRouter();
+
   return (
     <>
       <Sidebar
+        onClickAvatarSetting={() => {
+          router.push('/settings/avatar');
+        }}
         className={cn([
           'flexCol justify-between gap-10 px-1 py-6 bg-[#0E0E0E] rounded',
           'fixed z-10 bottom-8 right-8 transform',

--- a/src/app/parties/(room)/[id]/page.tsx
+++ b/src/app/parties/(room)/[id]/page.tsx
@@ -13,6 +13,7 @@ import { PartyroomChatPanel } from '@/widgets/partyroom-chat-panel';
 import { PartyroomDetailTrigger } from '@/widgets/partyroom-detail';
 import { PartyroomDisplayBoard } from '@/widgets/partyroom-display-board';
 import { DjingDialog } from '@/widgets/partyroom-djing-dialog';
+import { useOpenEditProfileAvatarDialog } from '@/widgets/partyroom-edit-profile-avatar-dialog';
 import { PartyroomParticipantPanel } from '@/widgets/partyroom-participant-panel';
 import { Sidebar } from '@/widgets/sidebar';
 
@@ -25,6 +26,7 @@ const PartyroomPage = () => {
     onClose: closeDjingDialog,
   } = useDisclosure();
 
+  const openEditProfileAvatarDialog = useOpenEditProfileAvatarDialog();
   const { useCurrentPartyroom } = useStores();
   const crewsCount = useCurrentPartyroom((state) => state.crews.length);
 
@@ -51,6 +53,7 @@ const PartyroomPage = () => {
           icon: (size, className) => <PFDj width={size} height={size} className={className} />,
           text: t.dj.title.dj_queue,
         }}
+        onClickAvatarSetting={openEditProfileAvatarDialog}
       />
 
       {/* 오른쪽 채팅창 */}

--- a/src/app/settings/avatar/page.tsx
+++ b/src/app/settings/avatar/page.tsx
@@ -1,15 +1,22 @@
 'use client';
+import { useRouter } from 'next/navigation';
 import { AvatarEditDone, ProfileAvatarEditPanel } from '@/features/edit-profile-avatar';
 import { BackButton } from '@/shared/ui/components/back-button';
 import { Button } from '@/shared/ui/components/button';
 
 export default function AvatarSettingsPage() {
+  const router = useRouter();
+
   return (
     <div className='absolute-user-form-section'>
       <ProfileAvatarEditPanel
         titleRender={(text) => <BackButton text={text} />}
         actions={
-          <AvatarEditDone>
+          <AvatarEditDone
+            onSuccess={() => {
+              router.push('/parties');
+            }}
+          >
             {({ done, canSubmit, loading }) => (
               <Button
                 onClick={done}

--- a/src/app/settings/avatar/page.tsx
+++ b/src/app/settings/avatar/page.tsx
@@ -1,61 +1,29 @@
 'use client';
-import {
-  AvatarBodyList,
-  AvatarEditDone,
-  AvatarFaceList,
-  SelectedAvatar,
-  SelectedAvatarStateProvider,
-} from '@/features/edit-profile-avatar';
-import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { AvatarEditDone, ProfileAvatarEditPanel } from '@/features/edit-profile-avatar';
 import { BackButton } from '@/shared/ui/components/back-button';
 import { Button } from '@/shared/ui/components/button';
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@/shared/ui/components/tab';
 
 export default function AvatarSettingsPage() {
-  const t = useI18n();
-
   return (
     <div className='absolute-user-form-section'>
-      <div className='h-full flexRow justify-start max-w-screen-desktop mx-auto gap-5 p-10 px-[60px]'>
-        <SelectedAvatarStateProvider>
-          <div className='flexCol items-start gap-10'>
-            <BackButton text={t.settings.para.what_wear} />
-            <SelectedAvatar />
-          </div>
-          <div className='flex-1 h-full flexCol'>
-            <TabGroup className='flex-1 flexCol'>
-              <TabList className='w-full flexRow'>
-                <Tab tabTitle='body' variant='line' />
-                <Tab tabTitle='face' variant='line' />
-                <div className='flex-1 border-b-[1px] border-b-gray-400' />
-              </TabList>
-              <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>
-                {/* FIXME: 각 패널 overflow auto 안 먹고 있음 */}
-                <TabPanel tabIndex={0} className='flex-1 flexCol pt-6'>
-                  <AvatarBodyList />
-                </TabPanel>
-                <TabPanel tabIndex={1} className='flex-1 flexCol pt-4'>
-                  <AvatarFaceList />
-                </TabPanel>
-              </TabPanels>
-            </TabGroup>
-
-            <AvatarEditDone>
-              {({ done, canSubmit, loading }) => (
-                <Button
-                  onClick={done}
-                  disabled={!canSubmit}
-                  loading={loading}
-                  className='self-end px-[88.5px] shrink-0'
-                  size='xl'
-                >
-                  Let&apos;s get in
-                </Button>
-              )}
-            </AvatarEditDone>
-          </div>
-        </SelectedAvatarStateProvider>
-      </div>
+      <ProfileAvatarEditPanel
+        titleRender={(text) => <BackButton text={text} />}
+        actions={
+          <AvatarEditDone>
+            {({ done, canSubmit, loading }) => (
+              <Button
+                onClick={done}
+                disabled={!canSubmit}
+                loading={loading}
+                className='px-[88.5px]'
+                size='xl'
+              >
+                Let&apos;s get in
+              </Button>
+            )}
+          </AvatarEditDone>
+        }
+      />
     </div>
   );
 }

--- a/src/app/settings/avatar/page.tsx
+++ b/src/app/settings/avatar/page.tsx
@@ -6,13 +6,12 @@ import {
   SelectedAvatar,
   SelectedAvatarStateProvider,
 } from '@/features/edit-profile-avatar';
-import { cn } from '@/shared/lib/functions/cn';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { BackButton } from '@/shared/ui/components/back-button';
 import { Button } from '@/shared/ui/components/button';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@/shared/ui/components/tab';
 
-const AvatarSettingsPage = () => {
+export default function AvatarSettingsPage() {
   const t = useI18n();
 
   return (
@@ -23,18 +22,19 @@ const AvatarSettingsPage = () => {
             <BackButton text={t.settings.para.what_wear} />
             <SelectedAvatar />
           </div>
-          <div className='w-full h-full flexCol'>
-            <TabGroup>
-              <TabList className={cn('w-full flexRow')}>
+          <div className='flex-1 h-full flexCol'>
+            <TabGroup className='flex-1 flexCol'>
+              <TabList className='w-full flexRow'>
                 <Tab tabTitle='body' variant='line' />
                 <Tab tabTitle='face' variant='line' />
                 <div className='flex-1 border-b-[1px] border-b-gray-400' />
               </TabList>
               <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>
-                <TabPanel tabIndex={0} className='flex-1 flexCol pt-6 overflow-hidden'>
+                {/* FIXME: 각 패널 overflow auto 안 먹고 있음 */}
+                <TabPanel tabIndex={0} className='flex-1 flexCol pt-6'>
                   <AvatarBodyList />
                 </TabPanel>
-                <TabPanel tabIndex={1} className='flex-1 flexCol pt-4 overflow-hidden'>
+                <TabPanel tabIndex={1} className='flex-1 flexCol pt-4'>
                   <AvatarFaceList />
                 </TabPanel>
               </TabPanels>
@@ -46,10 +46,10 @@ const AvatarSettingsPage = () => {
                   onClick={done}
                   disabled={!canSubmit}
                   loading={loading}
-                  className='self-end px-[88.5px]'
+                  className='self-end px-[88.5px] shrink-0'
                   size='xl'
                 >
-                  {`Let's get in`}
+                  Let&apos;s get in
                 </Button>
               )}
             </AvatarEditDone>
@@ -58,6 +58,4 @@ const AvatarSettingsPage = () => {
       </div>
     </div>
   );
-};
-
-export default AvatarSettingsPage;
+}

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,13 +1,12 @@
 import { PropsWithChildren } from 'react';
 import { Header } from '@/widgets/layouts';
-import { WalletProvider } from '../_providers/wallet.provider';
 
 const SettingsLayout = ({ children }: PropsWithChildren) => {
   return (
-    <WalletProvider>
+    <>
       <Header />
       <main>{children}</main>
-    </WalletProvider>
+    </>
   );
 };
 

--- a/src/features/edit-profile-avatar/index.ts
+++ b/src/features/edit-profile-avatar/index.ts
@@ -1,6 +1,2 @@
-export { default as SelectedAvatarStateProvider } from './lib/selected-avatar-state.provider';
-
-export { default as AvatarBodyList } from './ui/avatar-body-list.component';
-export { default as AvatarFaceList } from './ui/avatar-face-list.component';
-export { default as SelectedAvatar } from './ui/selected-avatar.component';
+export { default as ProfileAvatarEditPanel } from './ui/profile-avatar-edit-panel.component';
 export { default as AvatarEditDone } from './ui/done.component';

--- a/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
@@ -6,7 +6,7 @@ const AvatarBodyList = () => {
   const { data: bodies = [] } = useFetchAvatarBodies();
 
   return (
-    <div className='grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 overflow-y-auto'>
+    <div className='flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max'>
       {bodies.map((body) => (
         <AvatarBodyListItem key={body.id} meta={body} />
       ))}

--- a/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
@@ -6,7 +6,7 @@ const AvatarBodyList = () => {
   const { data: bodies = [] } = useFetchAvatarBodies();
 
   return (
-    <div className='flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max'>
+    <div className='flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max overflow-auto'>
       {bodies.map((body) => (
         <AvatarBodyListItem key={body.id} meta={body} />
       ))}

--- a/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
@@ -23,7 +23,7 @@ const AvatarFaceList = () => {
   })();
 
   return (
-    <div ref={containerRef} className='flexCol gap-4 overflow-hidden'>
+    <div ref={containerRef} className='flex-1 flexCol gap-4 overflow-hidden'>
       <div className='flexRow justify-end items-center gap-3'>
         <SuspenseWithErrorBoundary>
           <ConnectWalletButton />
@@ -31,7 +31,7 @@ const AvatarFaceList = () => {
       </div>
       <div
         className={cn(
-          'relative flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5',
+          'relative flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max',
           {
             'overflow-y-auto': combinable,
             'overflow-hidden': !combinable,
@@ -49,9 +49,9 @@ const AvatarFaceList = () => {
         ))}
 
         {!combinable && (
-          <div className='absolute inset-0 flexColCenter gap-[16px] bg-dim text-white cursor-not-allowed select-none'>
+          <div className='absolute inset-0 flexColCenter gap-[16px] px-2 text-center bg-dim text-white cursor-not-allowed select-none'>
             <PFInfoOutline width={48} height={48} />
-            <Typography type='title2' as='p'>
+            <Typography type='title2' as='p' overflow='break-words'>
               {t.settings.ec.integrated_body}
             </Typography>
           </div>

--- a/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
@@ -31,7 +31,7 @@ const AvatarFaceList = () => {
       </div>
       <div
         className={cn(
-          'relative flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max',
+          'relative flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max overflow-auto',
           {
             'overflow-y-auto': combinable,
             'overflow-hidden': !combinable,

--- a/src/features/edit-profile-avatar/ui/done.component.tsx
+++ b/src/features/edit-profile-avatar/ui/done.component.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import { ReactElement } from 'react';
 import { useUpdateMyAvatar } from '../api/use-update-my-avatar.mutation';
 import { useSelectedAvatarState } from '../lib/selected-avatar-state.context';
@@ -11,10 +10,10 @@ type ChildrenProps = {
 
 type Props = {
   children: (props: ChildrenProps) => ReactElement;
+  onSuccess?: () => void;
 };
 
-export default function EditDone({ children }: Props) {
-  const router = useRouter();
+export default function EditDone({ children, onSuccess }: Props) {
   const { body, faceUri } = useSelectedAvatarState();
   const canSubmit = !!body && (!body.combinable || !!faceUri);
   const { mutate: updateAvatar, isPending } = useUpdateMyAvatar();
@@ -22,14 +21,7 @@ export default function EditDone({ children }: Props) {
   const done = async () => {
     if (!canSubmit) return;
 
-    updateAvatar(
-      { body, faceUri },
-      {
-        onSuccess: () => {
-          router.push('/parties');
-        },
-      }
-    );
+    updateAvatar({ body, faceUri }, { onSuccess });
   };
 
   return children({

--- a/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
+++ b/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
@@ -30,7 +30,7 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
           <SelectedAvatar />
         </div>
         <div className='flex-1 h-full flexCol gap-2'>
-          <TabGroup className='flex-1 flexCol'>
+          <TabGroup className='flex-1 flexCol overflow-hidden'>
             <TabList className='w-full flexRow'>
               <Tab tabTitle='body' variant='line' className='w-auto' />
               <Tab tabTitle='face' variant='line' className='w-auto' />
@@ -38,10 +38,10 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
             </TabList>
             <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>
               {/* FIXME: 각 패널 overflow auto 안 먹고 있음 */}
-              <TabPanel tabIndex={0} className='flex-1 flexCol pt-6'>
+              <TabPanel tabIndex={0} className='flex-1 flexCol mt-6 overflow-auto'>
                 <AvatarBodyList />
               </TabPanel>
-              <TabPanel tabIndex={1} className='flex-1 flexCol pt-4'>
+              <TabPanel tabIndex={1} className='flex-1 flexCol mt-4 overflow-auto'>
                 <AvatarFaceList />
               </TabPanel>
             </TabPanels>

--- a/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
+++ b/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
@@ -27,7 +27,6 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
       <SelectedAvatarStateProvider>
         <div className='flexCol items-start gap-10'>
           {titleRender(t.settings.para.what_wear)}
-          {/*<Typography type='title2'>{t.settings.para.what_wear}</Typography>*/}
           <SelectedAvatar />
         </div>
         <div className='flex-1 h-full flexCol gap-2'>

--- a/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
+++ b/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+import { useVerticalStretch } from '@/shared/lib/hooks/use-vertical-stretch.hook';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@/shared/ui/components/tab';
+import AvatarBodyList from './avatar-body-list.component';
+import AvatarFaceList from './avatar-face-list.component';
+import SelectedAvatar from './selected-avatar.component';
+import SelectedAvatarStateProvider from '../lib/selected-avatar-state.provider';
+
+type Props = {
+  titleRender: (text: string) => ReactNode;
+  /**
+   * 제출 버튼, 취소 버튼 등
+   */
+  actions: ReactNode;
+};
+
+export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) {
+  const t = useI18n();
+  const containerRef = useVerticalStretch();
+
+  return (
+    <div
+      ref={containerRef}
+      className='flexRow justify-start max-w-screen-desktop mx-auto gap-5 p-10 px-[60px]'
+    >
+      <SelectedAvatarStateProvider>
+        <div className='flexCol items-start gap-10'>
+          {titleRender(t.settings.para.what_wear)}
+          {/*<Typography type='title2'>{t.settings.para.what_wear}</Typography>*/}
+          <SelectedAvatar />
+        </div>
+        <div className='flex-1 h-full flexCol gap-2'>
+          <TabGroup className='flex-1 flexCol'>
+            <TabList className='w-full flexRow'>
+              <Tab tabTitle='body' variant='line' />
+              <Tab tabTitle='face' variant='line' />
+              <div className='flex-1 border-b-[1px] border-b-gray-400' />
+            </TabList>
+            <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>
+              {/* FIXME: 각 패널 overflow auto 안 먹고 있음 */}
+              <TabPanel tabIndex={0} className='flex-1 flexCol pt-6'>
+                <AvatarBodyList />
+              </TabPanel>
+              <TabPanel tabIndex={1} className='flex-1 flexCol pt-4'>
+                <AvatarFaceList />
+              </TabPanel>
+            </TabPanels>
+          </TabGroup>
+
+          <div className='self-end shrink-0 flex gap-3'>{actions}</div>
+        </div>
+      </SelectedAvatarStateProvider>
+    </div>
+  );
+}

--- a/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
+++ b/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
@@ -33,8 +33,8 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
         <div className='flex-1 h-full flexCol gap-2'>
           <TabGroup className='flex-1 flexCol'>
             <TabList className='w-full flexRow'>
-              <Tab tabTitle='body' variant='line' />
-              <Tab tabTitle='face' variant='line' />
+              <Tab tabTitle='body' variant='line' className='w-auto' />
+              <Tab tabTitle='face' variant='line' className='w-auto' />
               <div className='flex-1 border-b-[1px] border-b-gray-400' />
             </TabList>
             <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>

--- a/src/features/edit-profile-bio/ui/v2-view.component.tsx
+++ b/src/features/edit-profile-bio/ui/v2-view.component.tsx
@@ -5,7 +5,6 @@ import { Avatar } from '@/entities/avatar';
 import { Me, useSuspenseFetchMe } from '@/entities/me';
 import { ActivityType } from '@/shared/api/http/types/@enums';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
-import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { Button } from '@/shared/ui/components/button';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFEdit } from '@/shared/ui/icons';
@@ -17,13 +16,7 @@ type V2ViewModeProps = {
 
 const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps) => {
   const t = useI18n();
-  const router = useAppRouter();
   const { data: me } = useSuspenseFetchMe();
-
-  const handleClickAvatarEditButton = () => {
-    router.push('/settings/avatar');
-    onAvatarSettingClick?.();
-  };
 
   return (
     <div className='gap-5 flexRow'>
@@ -40,8 +33,8 @@ const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps)
           )}
         </div>
 
-        <Button size='sm' variant='outline' onClick={handleClickAvatarEditButton}>
-          {t.settings.btn.addi_connection}
+        <Button size='sm' variant='outline' onClick={onAvatarSettingClick}>
+          {t.lobby.title.ava_settings}
         </Button>
       </div>
       <div className='justify-between flex-1 flexCol'>

--- a/src/shared/ui/components/tab/tab.component.tsx
+++ b/src/shared/ui/components/tab/tab.component.tsx
@@ -64,7 +64,7 @@ const Tab = (props: TabProps) => {
 
 const getCommentTabStyle = (selected: boolean) => {
   return cn(
-    'w-full flexRowCenter gap-[6px] outline-none border-b-[1px] border-gray-400',
+    'flexRowCenter gap-[6px] outline-none border-b-[1px] border-gray-400',
     selected && 'text-red-300 border-red-300  [&>svg]:fill-red-300 [&>svg]:stroke-red-300'
   );
 };

--- a/src/shared/ui/components/tab/tab.component.tsx
+++ b/src/shared/ui/components/tab/tab.component.tsx
@@ -64,7 +64,7 @@ const Tab = (props: TabProps) => {
 
 const getCommentTabStyle = (selected: boolean) => {
   return cn(
-    'flexRowCenter gap-[6px] outline-none border-b-[1px] border-gray-400',
+    'w-full flexRowCenter gap-[6px] outline-none border-b-[1px] border-gray-400',
     selected && 'text-red-300 border-red-300  [&>svg]:fill-red-300 [&>svg]:stroke-red-300'
   );
 };

--- a/src/widgets/partyroom-edit-profile-avatar-dialog/index.ts
+++ b/src/widgets/partyroom-edit-profile-avatar-dialog/index.ts
@@ -1,0 +1,1 @@
+export { default as useOpenEditProfileAvatarDialog } from './ui/use-open-edit-profile-avatar-dialog.hook';

--- a/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
+++ b/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
@@ -12,7 +12,7 @@ export default function useOpenEditProfileAvatarDialog() {
   return () => {
     return openDialog((onOk, onCancel) => ({
       classNames: {
-        container: 'w-[1680px]',
+        container: 'w-[1680px] h-[800px] p-0 bg-gray-900',
       },
       Body: (
         <ProfileAvatarEditPanel

--- a/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
+++ b/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
@@ -1,0 +1,54 @@
+import { AvatarEditDone, ProfileAvatarEditPanel } from '@/features/edit-profile-avatar';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { renderBr } from '@/shared/lib/localization/split-render';
+import { Button } from '@/shared/ui/components/button';
+import { useDialog } from '@/shared/ui/components/dialog';
+import { Typography } from '@/shared/ui/components/typography';
+
+export default function useOpenEditProfileAvatarDialog() {
+  const t = useI18n();
+  const { openDialog, openConfirmDialog } = useDialog();
+
+  return () => {
+    return openDialog((onOk, onCancel) => ({
+      classNames: {
+        container: 'w-[1680px]',
+      },
+      Body: (
+        <ProfileAvatarEditPanel
+          titleRender={(text) => <Typography type='title2'>{text}</Typography>}
+          actions={
+            <>
+              <Button
+                size='lg'
+                color='secondary'
+                onClick={onCancel}
+                className='w-[200px] max-w-full'
+              >
+                {t.common.btn.cancel}
+              </Button>
+              <AvatarEditDone onSuccess={onOk}>
+                {({ done, canSubmit, loading }) => (
+                  <Button
+                    size='lg'
+                    onClick={done}
+                    disabled={!canSubmit}
+                    loading={loading}
+                    className='w-[200px] max-w-full'
+                  >
+                    {t.common.btn.save}
+                  </Button>
+                )}
+              </AvatarEditDone>
+            </>
+          }
+        />
+      ),
+      closeConfirm: () => {
+        return openConfirmDialog({
+          content: renderBr(t.party.para.stop_editing),
+        });
+      },
+    }));
+  };
+}

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -1,4 +1,3 @@
-'use client';
 import { ReactNode } from 'react';
 import { useSuspenseFetchMe } from '@/entities/me';
 import { ProfileEditFormV2 } from '@/features/edit-profile-bio';
@@ -10,16 +9,17 @@ import Profile from '@/shared/ui/components/profile/profile.component';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFHeadset } from '@/shared/ui/icons';
 
-interface SidebarProps {
+type SidebarProps = {
   className: string;
+  onClickAvatarSetting: () => void;
   extraButton?: {
     onClick: () => void;
     icon: (size: number, className: string) => ReactNode;
     text: string;
   };
-}
+};
 
-const Sidebar = ({ className, extraButton }: SidebarProps) => {
+export default function Sidebar({ className, onClickAvatarSetting, extraButton }: SidebarProps) {
   const t = useI18n();
   const { data: me } = useSuspenseFetchMe();
   const { openDialog } = useDialog();
@@ -42,13 +42,19 @@ const Sidebar = ({ className, extraButton }: SidebarProps) => {
       classNames: {
         container: 'w-[620px] h-[391px] py-7 px-10 bg-black',
       },
-      Body: <ProfileEditFormV2 onClickAvatarSetting={onCancel} />,
+      Body: (
+        <ProfileEditFormV2
+          onClickAvatarSetting={() => {
+            onClickAvatarSetting();
+            onCancel?.();
+          }}
+        />
+      ),
     }));
   };
 
   return (
     <aside className={className}>
-      {/* TODO: 프로필 이미지로 변경, href 추가 */}
       <button onClick={handleClickProfileButton} className='gap-2 cursor-pointer flexColCenter'>
         <Profile size={48} src={me.avatarIconUri} />
         <Typography type='caption1' className='text-gray-200'>
@@ -72,6 +78,4 @@ const Sidebar = ({ className, extraButton }: SidebarProps) => {
       )}
     </aside>
   );
-};
-
-export default Sidebar;
+}


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

* 파티룸 내에서 사이드바에 프로필 모달 열고 아바타 세팅 클릭 시, 세팅 페이지로 이동하지 않고 다이얼로그만 띄우게 합니다.
* 프로필 세팅 패널 내 스크롤 안 먹히던 문제 등 스타일 이슈들을 함께 수정합니다

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e8bcdeef-fa71-4177-845d-c97cf28bd007">