### PR TITLE
feat: dialog를 현재 리액트 렌더 컨텍스트 밖에서 띄우는 기능 개발

### DIFF
--- a/src/app/_providers/react-query.provider.tsx
+++ b/src/app/_providers/react-query.provider.tsx
@@ -6,6 +6,8 @@ import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experime
 import { getErrorMessage } from '@/shared/api/get-error-message';
 import isAuthError from '@/shared/api/is-auth-error';
 import { FIVE_MINUTES } from '@/shared/config/time';
+import { Dialog } from '@/shared/ui/components/dialog';
+import { Typography } from '@/shared/ui/components/typography';
 
 /**
  * @see https://github.com/TanStack/query/issues/6116#issuecomment-1904051005
@@ -64,17 +66,11 @@ function getQueryClient() {
   return clientQueryClient;
 }
 
-/**
- * TODO: will - alert >> errorDialog 변경
- * 이 파일 내에서 useDialog를 사용하려면 app/logout.tsx 내 provider의 위게를 변경하여 QueryClientProvider를 DialogProvider 내부로 이동해야 하는데,
- * 이러면 다이얼로그 body 내에서 react-query를 사용할 수 없음 (Error: No QueryClient set, use QueryClientProvider to set one)
- * dialog를 provider가 아닌 다른 방식으로 제공하는걸 검토해봐야 할 듯
- */
 function handleBubbledError(error: unknown) {
-  const errorMessage = `[ERROR]\n${getErrorMessage(error)}`;
+  const errorMessage = getErrorMessage(error);
 
   if (typeof window === 'undefined') {
-    console.error(errorMessage);
+    console.error(`[ERROR] ${errorMessage}`);
     return;
   }
 
@@ -86,5 +82,20 @@ function handleBubbledError(error: unknown) {
   }
 
   console.error(error);
-  alert(errorMessage);
+
+  const { destroy } = Dialog.open({
+    title: 'Error',
+    Body: () => (
+      <>
+        <Typography type='caption1' className='text-gray-50'>
+          {errorMessage}
+        </Typography>
+
+        <Dialog.ButtonGroup>
+          <Dialog.Button onClick={() => destroy()}>Close</Dialog.Button>
+        </Dialog.ButtonGroup>
+      </>
+    ),
+    onClose: () => destroy(),
+  });
 }

--- a/src/shared/lib/react/render.ts
+++ b/src/shared/lib/react/render.ts
@@ -1,0 +1,97 @@
+// @reference https://github.com/react-component/util/blob/master/src/React/render.ts
+
+import type { ReactElement } from 'react';
+import * as ReactDOM from 'react-dom';
+import type { Root } from 'react-dom/client';
+
+// Let compiler not to search module usage
+const clonedReactDOM = {
+  ...ReactDOM,
+} as typeof ReactDOM & {
+  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?: {
+    usingClientEntryPoint?: boolean;
+  };
+  createRoot?: CreateRoot;
+};
+
+type CreateRoot = (container: ContainerType) => Root;
+
+const { version, render: reactRender, unmountComponentAtNode } = clonedReactDOM;
+
+let createRoot: CreateRoot | undefined;
+try {
+  const mainVersion = Number((version || '').split('.')[0]);
+  if (mainVersion >= 18) {
+    createRoot = clonedReactDOM.createRoot;
+  }
+} catch (e) {
+  // Do nothing;
+}
+
+function toggleReactDOMWarning(skip: boolean) {
+  const { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } = clonedReactDOM;
+
+  if (
+    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED &&
+    typeof __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED === 'object'
+  ) {
+    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.usingClientEntryPoint = skip;
+  }
+}
+
+const MARK = '__qfc_react_root__';
+
+// ========================== Render ==========================
+type ContainerType = (Element | DocumentFragment) & {
+  [MARK]?: Root;
+};
+
+function modernRender(node: ReactElement, container: ContainerType) {
+  if (!createRoot) return;
+
+  toggleReactDOMWarning(true);
+  const root = container[MARK] || createRoot(container);
+  toggleReactDOMWarning(false);
+
+  root.render(node);
+
+  container[MARK] = root;
+}
+
+function legacyRender(node: ReactElement, container: ContainerType) {
+  reactRender(node, container);
+}
+
+export function render(node: ReactElement, container: ContainerType) {
+  if (createRoot) {
+    modernRender(node, container);
+    return;
+  }
+
+  legacyRender(node, container);
+}
+
+// ========================= Unmount ==========================
+async function modernUnmount(container: ContainerType) {
+  // Delay to unmount to avoid React 18 sync warning
+  return Promise.resolve().then(() => {
+    container[MARK]?.unmount();
+
+    delete container[MARK];
+
+    return;
+  });
+}
+
+function legacyUnmount(container: ContainerType) {
+  unmountComponentAtNode(container);
+}
+
+export async function unmount(container: ContainerType) {
+  if (createRoot !== undefined) {
+    // Delay to unmount to avoid React 18 sync warning
+    return modernUnmount(container);
+  }
+
+  legacyUnmount(container);
+}

--- a/src/shared/ui/components/dialog/dialog.stories.tsx
+++ b/src/shared/ui/components/dialog/dialog.stories.tsx
@@ -5,8 +5,7 @@ import { cn } from '@/shared/lib/functions/cn';
 import { delay } from '@/shared/lib/functions/delay';
 import { useDisclosure } from '@/shared/lib/hooks/use-disclosure.hook';
 import { replaceVar } from '@/shared/lib/localization/split-render';
-import Dialog from './dialog.component';
-import { useDialog } from './use-dialog.hook';
+import { Dialog, useDialog } from '.';
 import { Button } from '../button';
 import { FormItem } from '../form-item';
 import { Tag } from '../tag';
@@ -318,4 +317,20 @@ export const CustomStructure: Story = () => {
   };
 
   return <Button onClick={openSimpleDialog}>Click</Button>;
+};
+
+export const StaticOpen: Story = () => {
+  const handleClick = () => {
+    const { destroy } = Dialog.open({
+      title: 'Static Open',
+      Body: () => (
+        <Dialog.ButtonGroup>
+          <Dialog.Button onClick={() => destroy()}>확인</Dialog.Button>
+        </Dialog.ButtonGroup>
+      ),
+      onClose: () => destroy(),
+    });
+  };
+
+  return <Button onClick={handleClick}>Click</Button>;
 };

--- a/src/shared/ui/components/dialog/index.ts
+++ b/src/shared/ui/components/dialog/index.ts
@@ -1,3 +1,10 @@
-export { default as Dialog } from './dialog.component';
+import { default as DialogPrimitive } from './dialog.component';
+import open, { destroyAll } from './open';
+
+export const Dialog = Object.assign(DialogPrimitive, {
+  open,
+  destroyAll,
+});
+
 export { useDialog } from './use-dialog.hook';
 export { DialogProvider } from './dialog.provider';

--- a/src/shared/ui/components/dialog/index.ts
+++ b/src/shared/ui/components/dialog/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { default as DialogPrimitive } from './dialog.component';
 import open, { destroyAll } from './open';
 

--- a/src/shared/ui/components/dialog/open.tsx
+++ b/src/shared/ui/components/dialog/open.tsx
@@ -1,0 +1,73 @@
+// @reference https://github.com/ant-design/ant-design/blob/master/components/modal/confirm.tsx
+
+import { render as reactRender, unmount as reactUnmount } from '@/shared/lib/react/render';
+
+import Dialog, { type DialogProps } from './dialog.component';
+
+type DialogStaticOpenParams = Omit<DialogProps, 'open'>;
+
+const destroyFns: Array<() => void> = [];
+
+export default function open(params: DialogStaticOpenParams): { destroy: () => void } {
+  const container = document.createDocumentFragment();
+
+  const props: DialogProps = {
+    ...params,
+    open: true,
+  };
+
+  let renderTimeoutId: ReturnType<typeof setTimeout>;
+  let destroyTimeoutId: ReturnType<typeof setTimeout>;
+
+  function destroy() {
+    for (let i = 0; i < destroyFns.length; i++) {
+      const fn = destroyFns[i];
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      if (fn === close) {
+        destroyFns.splice(i, 1);
+        break;
+      }
+    }
+
+    reactUnmount(container);
+  }
+
+  function render(props: DialogProps) {
+    clearTimeout(renderTimeoutId);
+
+    /**
+     * https://github.com/ant-design/ant-design/issues/23623
+     *
+     * Sync render blocks React event. Let's make this async.
+     */
+    renderTimeoutId = setTimeout(() => {
+      // const theme = ~~.getTheme(); // NOTE - global.getTheme 등이 있다면 여기서 얻어와서 아래 넣어주기
+
+      reactRender(<Dialog {...props} />, container); // NOTE: theme provider 있으면 감싸기
+    });
+  }
+
+  function close() {
+    render({
+      ...props,
+      open: false,
+    });
+
+    clearTimeout(destroyTimeoutId);
+    setTimeout(() => {
+      destroy();
+    }, 200); // NOTE: dialog leave animation duration
+  }
+
+  render(props);
+
+  destroyFns.push(close);
+
+  return {
+    destroy: close,
+  };
+}
+
+export function destroyAll() {
+  destroyFns.forEach((fn) => fn());
+}


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

> 이 파일 내에서 useDialog를 사용하려면 app/logout.tsx 내 provider의 위게를 변경하여 QueryClientProvider를 DialogProvider 내부로 이동해야 하는데, 이러면 다이얼로그 body 내에서 react-query를 사용할 수 없음 (Error: No QueryClient set, use QueryClientProvider to set one). dialog를 provider가 아닌 다른 방식으로 제공하는걸 검토해봐야 할 듯


위 문제 해결을 위해 dialog를 리액트 렌더 컨텍스트 밖에서 띄우는 기능을 개발하고, 이를 react-query 전역 에러 핸들러에 연결합니다.

<img width="469" alt="스크린샷 2024-11-02 오후 9 46 51" src="https://github.com/user-attachments/assets/c03afa45-58ec-44bb-9b9f-82f144a357b2">

### Reference
https://github.com/ant-design/ant-design/blob/master/components/modal/confirm.tsx