### PR TITLE
fix: 파티룸 입장 후 브라우저 탭을 60초 이상 백그라운드에 두면 채팅 수신이 안되는 문제

### DIFF
--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -1,5 +1,5 @@
 import { IMessage } from '@stomp/stompjs';
-import SocketClient from '@/shared/api/websocket/client';
+import SocketClient, { OnConnectOptions } from '@/shared/api/websocket/client';
 
 /**
  * Socket Client를 캡슐화하여 최소한의 인터페이스만을 노출하며,
@@ -21,8 +21,8 @@ export default class PartyroomClient {
     return this.socketClient.connected;
   }
 
-  public whenConnected(callback: () => void) {
-    this.socketClient.registerConnectListener(callback);
+  public onConnect(callback: () => void, options?: OnConnectOptions) {
+    this.socketClient.onConnect(callback, options);
   }
 
   public subscribe(partyroomId: number, handler: (message: IMessage) => void) {

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -7,6 +7,7 @@ import { MotionType } from '@/shared/api/http/types/@enums';
 import { PartyroomReaction } from '@/shared/api/http/types/partyrooms';
 import { errorLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
+import silent from '@/shared/lib/functions/silent';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
@@ -22,48 +23,54 @@ export function useEnterPartyroom(partyroomId: number) {
   const initPartyroom = useCurrentPartyroom((state) => state.init);
   const { mutateAsync: enterAsync } = useEnterPartyroomMutation();
 
-  const enter = async () => {
-    try {
-      const enterResponse = await enterAsync({ partyroomId });
+  const enterAndSetup = async () => {
+    const enterResponse = await enterAsync({ partyroomId });
 
-      const [setUpInfo, notice] = await Promise.all([
-        PartyroomsService.getSetupInfo({ partyroomId }),
-        PartyroomsService.getNotice({ partyroomId }), // 공지사항은 현재 설계상 enter 시점엔 rest api로 받아오고, 이후 공지 변경이 있을 땐 웹 소켓 이벤트로 수신합니다.
-      ]);
+    const [setUpInfo, notice] = await Promise.all([
+      PartyroomsService.getSetupInfo({ partyroomId }),
+      PartyroomsService.getNotice({ partyroomId }), // 공지사항은 현재 설계상 enter 시점엔 rest api로 받아오고, 이후 공지 변경이 있을 땐 웹 소켓 이벤트로 수신합니다.
+    ]);
 
-      // TODO: crews 작업 시 crews 캐시 데이터 세팅해주기
-      // queryClient.setQueryData([QueryKeys.PartyroomCrews, partyroomId], setUpInfo.crews);
+    // TODO: crews 작업 시 crews 캐시 데이터 세팅해주기
+    // queryClient.setQueryData([QueryKeys.PartyroomCrews, partyroomId], setUpInfo.crews);
 
-      const motionTypeMap = crewIdToMotionTypeMap(setUpInfo.display.reaction?.motion);
+    const motionTypeMap = crewIdToMotionTypeMap(setUpInfo.display.reaction?.motion);
 
-      initPartyroom(
-        omitNullables({
-          id: partyroomId,
-          me: {
-            crewId: enterResponse.crewId,
-            gradeType: enterResponse.gradeType,
-          },
-          playbackActivated: setUpInfo.display.playbackActivated,
-          playback: setUpInfo.display.playback,
-          reaction: setUpInfo.display.reaction,
-          crews: setUpInfo.crews.map((crew) => ({
-            ...crew,
-            motionType: motionTypeMap.get(crew.crewId) ?? MotionType.NONE,
-          })),
-          currentDj: setUpInfo.display.currentDj,
-          notice: notice.content ?? '',
-        })
-      );
-
-      client.subscribe(partyroomId, handleEvent);
-    } catch (e) {
-      errorLogger(e);
-      openErrorDialog('Oops! Something went wrong. Please try again later.');
-    }
+    initPartyroom(
+      omitNullables({
+        id: partyroomId,
+        me: {
+          crewId: enterResponse.crewId,
+          gradeType: enterResponse.gradeType,
+        },
+        playbackActivated: setUpInfo.display.playbackActivated,
+        playback: setUpInfo.display.playback,
+        reaction: setUpInfo.display.reaction,
+        crews: setUpInfo.crews.map((crew) => ({
+          ...crew,
+          motionType: motionTypeMap.get(crew.crewId) ?? MotionType.NONE,
+        })),
+        currentDj: setUpInfo.display.currentDj,
+        notice: notice.content ?? '',
+      })
+    );
   };
 
   return () => {
-    client.whenConnected(enter);
+    client.onConnect(
+      () => {
+        silent(enterAndSetup(), {
+          onSuccess: () => {
+            client.subscribe(partyroomId, handleEvent);
+          },
+          onError: (e) => {
+            errorLogger(e);
+            openErrorDialog('Oops! Something went wrong. Please try again later.');
+          },
+        });
+      },
+      { once: true }
+    );
   };
 }
 

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -33,10 +33,16 @@ export default class SocketClient {
     });
   }
 
+  /**
+   * 커넥션이 맺혔는지 여부를 반환합니다.
+   */
   public get connected() {
     return this.client.connected;
   }
 
+  /**
+   * 커넥션을 맺습니다.
+   */
   public connect() {
     if (!this.connected) {
       this.client.onConnect = () => {
@@ -49,6 +55,9 @@ export default class SocketClient {
     }
   }
 
+  /**
+   * 커넥션을 끊습니다.
+   */
   public async disconnect() {
     if (this.connected) {
       this.stopHeartbeat();
@@ -58,6 +67,10 @@ export default class SocketClient {
     }
   }
 
+  /**
+   * 커넥션이 맺히면 콜백을 실행합니다.
+   * **이미 커넥션이 맺혔을 경우 즉시 실행됩니다.**
+   */
   public registerConnectListener(listener: () => void) {
     if (this.connected) {
       listener();
@@ -66,6 +79,9 @@ export default class SocketClient {
     }
   }
 
+  /**
+   * 구독을 시작합니다.
+   */
   public subscribe(destination: Destination, callback: messageCallbackType) {
     const subscription = this.client.subscribe(destination, callback);
     this.subscriptions.push({
@@ -74,6 +90,9 @@ export default class SocketClient {
     });
   }
 
+  /**
+   * 구독을 해지합니다.
+   */
   public unsubscribe(destination: Destination) {
     const subscription = this.subscriptions.find(
       (subscription) => subscription.destination === destination
@@ -86,11 +105,17 @@ export default class SocketClient {
     );
   }
 
+  /**
+   * 모든 구독을 해지합니다.
+   */
   public unsubscribeAll() {
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
     this.subscriptions = [];
   }
 
+  /*
+   * 메시지를 전송합니다.
+   */
   public send(destination: Destination, body: unknown) {
     this.client.publish({
       destination,

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -87,12 +87,17 @@ export default class SocketClient {
 
   /**
    * 구독을 시작합니다.
+   * connect 상태가 아니라면, connect 되길 기다린 후 구독됩니다.
+   * reconnect 시 자동으로 재구독됩니다.
    */
   public subscribe(destination: Destination, callback: messageCallbackType) {
-    const subscription = this.client.subscribe(destination, callback);
-    this.subscriptions.push({
-      ...subscription,
-      destination,
+    this.registerConnectListener(() => {
+      const subscription = this.client.subscribe(destination, callback);
+
+      this.subscriptions.push({
+        ...subscription,
+        destination,
+      });
     });
   }
 

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -144,10 +144,15 @@ export default class SocketClient {
    * 메시지를 전송합니다.
    */
   public send(destination: Destination, body: unknown) {
-    this.client.publish({
-      destination,
-      body: JSON.stringify(body),
-    });
+    this.onConnect(
+      () => {
+        this.client.publish({
+          destination,
+          body: JSON.stringify(body),
+        });
+      },
+      { once: true }
+    );
   }
 
   /**

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -26,10 +26,25 @@ export default class SocketClient {
   private heartbeatSubscription: StompSubscription | undefined;
 
   public constructor() {
+    const handleConnect = () => {
+      this.startHeartbeat();
+
+      this.connectListeners.forEach((listener) => listener());
+      this.connectListeners = [];
+    };
+
+    const handleDisconnect = () => {
+      this.stopHeartbeat();
+      this.unsubscribeAll();
+    };
+
     this.client = new Client({
       brokerURL: process.env.NEXT_PUBLIC_API_WS_HOST_NAME as string,
       reconnectDelay: 5000,
       debug: log,
+      onConnect: handleConnect,
+      onWebSocketClose: handleDisconnect,
+      onStompError: handleDisconnect,
     });
   }
 
@@ -44,27 +59,18 @@ export default class SocketClient {
    * 커넥션을 맺습니다.
    */
   public connect() {
-    if (!this.connected) {
-      this.client.onConnect = () => {
-        this.startHeartbeat();
-        this.connectListeners.forEach((listener) => listener());
-        this.connectListeners = [];
-      };
+    if (this.connected) return;
 
-      this.client.activate();
-    }
+    this.client.activate();
   }
 
   /**
    * 커넥션을 끊습니다.
    */
   public async disconnect() {
-    if (this.connected) {
-      this.stopHeartbeat();
-      this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+    if (!this.connected) return;
 
-      await this.client.deactivate();
-    }
+    await this.client.deactivate();
   }
 
   /**
@@ -94,6 +100,8 @@ export default class SocketClient {
    * 구독을 해지합니다.
    */
   public unsubscribe(destination: Destination) {
+    if (!this.connected) return;
+
     const subscription = this.subscriptions.find(
       (subscription) => subscription.destination === destination
     );

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -18,9 +18,21 @@ export interface Subscription extends StompSubscription {
   destination: Destination;
 }
 
+export type OnConnectOptions = {
+  /**
+   * `true`일 시, 최초 connect 시에만 실행되며 reconnect 시에는 실행되지 않습니다.
+   * @default false
+   */
+  once?: boolean;
+};
+type OnConnect = {
+  callback: () => void;
+  options?: OnConnectOptions;
+};
+
 export default class SocketClient {
   private client: Client;
-  private connectListeners: (() => void)[] = [];
+  private onConnectQueue: OnConnect[] = [];
   public subscriptions: Subscription[] = [];
   private heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
   private heartbeatSubscription: StompSubscription | undefined;
@@ -29,8 +41,8 @@ export default class SocketClient {
     const handleConnect = () => {
       this.startHeartbeat();
 
-      this.connectListeners.forEach((listener) => listener());
-      this.connectListeners = [];
+      this.onConnectQueue.forEach(({ callback }) => callback());
+      this.onConnectQueue = this.onConnectQueue.filter(({ options }) => !options?.once);
     };
 
     const handleDisconnect = () => {
@@ -76,13 +88,15 @@ export default class SocketClient {
   /**
    * 커넥션이 맺히면 콜백을 실행합니다.
    * **이미 커넥션이 맺혔을 경우 즉시 실행됩니다.**
+   * 기본적으론 매 연결(reconnect 등)마다 실행되지만, `options.once`가 `true`일 시 최초 connect 시에만 실행됩니다.
    */
-  public registerConnectListener(listener: () => void) {
+  public onConnect(callback: () => void, options?: OnConnectOptions) {
     if (this.connected) {
-      listener();
-    } else {
-      this.connectListeners.push(listener);
+      callback();
+      if (options?.once) return;
     }
+
+    this.onConnectQueue.push({ callback, options });
   }
 
   /**
@@ -91,7 +105,7 @@ export default class SocketClient {
    * reconnect 시 자동으로 재구독됩니다.
    */
   public subscribe(destination: Destination, callback: messageCallbackType) {
-    this.registerConnectListener(() => {
+    this.onConnect(() => {
       const subscription = this.client.subscribe(destination, callback);
 
       this.subscriptions.push({
@@ -157,6 +171,7 @@ export default class SocketClient {
       this.send(DESTINATION.PUB, 'PING');
     }, 4000);
   }
+
   private stopHeartbeat() {
     this.heartbeatSubscription?.unsubscribe();
     clearInterval(this.heartbeatIntervalId);

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -5,7 +5,13 @@ import { specificLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
 
 const logger = withDebugger(0);
-const log = logger(specificLog);
+const log = logger<string>((msg) => {
+  if (msg.includes('/heartbeat')) return; // ignore heartbeat logs
+
+  const hhmmss = new Date().toTimeString().split(' ')[0];
+
+  specificLog(`[${hhmmss}] ${msg}`);
+});
 
 export type Destination = `/${string}`;
 export interface Subscription extends StompSubscription {
@@ -23,12 +29,7 @@ export default class SocketClient {
     this.client = new Client({
       brokerURL: process.env.NEXT_PUBLIC_API_WS_HOST_NAME as string,
       reconnectDelay: 5000,
-      debug: (msg) => {
-        // ignore heartbeat logs
-        if (!msg.includes('/heartbeat')) {
-          log(msg);
-        }
-      },
+      debug: log,
     });
   }
 


### PR DESCRIPTION
### 개요
* 파티룸 입장 후 브라우저 탭을 60초 이상 백그라운드에 두면 채팅 수신이 안되는 문제가 발견되었습니다.
* 크로미움 브라우저에서만 발생하는 문제입니다.
* 60초 동안 오가는 통신 없으면 소켓 커넥션 끊어버리는 GCP 정책이 있고, 기존에 heartbeat 로직을 두어 이를 방지하고 있었습니다.

### 재현
* 크로미움 브라우저에서 파티룸 입장 후, 현재 브라우저 탭을 백그라운드로 돌립니다 (다른 탭이나, 다른 앱을 클릭합니다)
* 60초 이상 대기합니다.
* 탭으로 돌아가서 로그를 확인합니다.

### 현상
* 파티룸 소켓 커넥션이 끊겼다가 재연결 되어 있습니다.
* heartbeat 구독과 채팅 구독은 커넥션이 끊긴 시점에 자동 unsubscribe되었으며, 이후 재구독되지 않았습니다.

### 기대한 것
* 파티룸 소켓 커넥션은 heartbeat에 의해 끊기지 않았어야 합니다.

### 해결
크로미움 브라우저 내부 정책으로, 백그라운드 탭 내에서 수행되는 setInterval은 강제로 주기가 1분으로 설정됩니다. ([참고 스레드](https://pfplay.slack.com/archives/C03Q28EAU66/p1725214284469619))
때문에 heartbeat는 탭이 백그라운드로 전환되면 기대대로 동작하진 않게 되며, 이는 어쩔 수 없습니다.

대신 커넥션이 끊기고 StompClient가 자동으로 reconnect를 수행했을 때, 연결이 끊기기 전 기존 모든 구독을 자동으로 재구독하도록 로직을 수정합니다.

추가로, 연결이 끊긴 시점에 채팅을 전송하는 경우 이를 큐에 저장해뒀다가 연결 직후 전송하도록 하는 기능도 반영합니다.
