### PR TITLE
feat: 로그아웃 하거나 패널티로 쫓겨나는 등 백단에서 exit 처리 된 경우 exit api 호출하지 않도록 설정

### DIFF
--- a/src/entities/current-partyroom/lib/alerts/use-penalty-alert.hook.tsx
+++ b/src/entities/current-partyroom/lib/alerts/use-penalty-alert.hook.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback } from 'react';
 import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { replaceVar } from '@/shared/lib/localization/split-render';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Dialog, useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
 import useAlert from './use-alert.hook';
@@ -25,13 +26,13 @@ export default function usePenaltyAlert() {
 function useOpenPenaltyAlertDialog() {
   const t = useI18n();
   const { openDialog } = useDialog();
+  const markExitedOnBackend = useStores().useCurrentPartyroom((state) => state.markExitedOnBackend);
 
   const afterConfirm = (penaltyType: PenaltyType) => {
     switch (penaltyType) {
       case PenaltyType.ONE_TIME_EXPULSION:
       case PenaltyType.PERMANENT_EXPULSION:
-        // TODO: 강제 퇴출 시 백단에서 exit 처리가 되기에, 파티룸 페이지에 걸린 unload 이벤트 리스너에 의해 떠날 때 exit이 호출되고 이 때 404 에러 얼럿이 뜰거임. 예외 처리 필요
-        // @see https://pfplay.slack.com/archives/C03Q28EAU66/p1728818068967889?thread_ts=1728817067.685869&cid=C03Q28EAU66
+        markExitedOnBackend();
         location.href = '/parties';
     }
   };

--- a/src/entities/current-partyroom/model/current-partyroom.model.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.model.ts
@@ -12,7 +12,17 @@ type MyPartyroomInfo = {
 };
 
 export type Model = {
+  /**
+   * 파티룸 아이디
+   */
   id?: number;
+
+  /**
+   * 파티룸에서 나갈 때 exit api를 기본적으로 호출하나,
+   * 로그아웃했거나 강퇴되거나 등의 이유로 파티룸에서 나가는 경우에는 호출하지 않아야 하기에 그럴 때 체크하는 용도로 사용합니다.
+   */
+  exitedOnBackend: boolean;
+  markExitedOnBackend: () => void;
 
   /**
    * 내 파티룸 정보

--- a/src/entities/current-partyroom/model/current-partyroom.store.ts
+++ b/src/entities/current-partyroom/model/current-partyroom.store.ts
@@ -11,6 +11,13 @@ export const createCurrentPartyroomStore = () => {
   return create<CurrentPartyroom.Model>((set, _, api) => ({
     id: undefined,
 
+    exitedOnBackend: false,
+    markExitedOnBackend: () => {
+      return set({
+        exitedOnBackend: true,
+      });
+    },
+
     me: undefined,
     updateMe: (next) => {
       return set((state) => {

--- a/src/features/partyroom/exit/lib/use-exit-partyroom.ts
+++ b/src/features/partyroom/exit/lib/use-exit-partyroom.ts
@@ -5,15 +5,16 @@ import { useExitPartyroom as useExitPartyroomMutation } from '../api/use-exit-pa
 export function useExitPartyroom(partyroomId: number) {
   const client = usePartyroomClient();
   const { useCurrentPartyroom } = useStores();
-  const resetPartyroomStore = useCurrentPartyroom((state) => state.reset);
+  const [resetPartyroomStore] = useCurrentPartyroom((state) => [state.reset]);
   const { mutate: exit } = useExitPartyroomMutation();
 
   return () => {
-    exit({ partyroomId });
+    const { exitedOnBackend } = useCurrentPartyroom.getState();
+    if (!exitedOnBackend) {
+      exit({ partyroomId });
+    }
 
-    // NOTE: mutation을 들고 있는 컴포넌트가 언마운트 되면 onSuccess가 실행되지 않으므로,
-    // 이하 로직을 exit의 onSuccess에 넣으면 안됩니다
     client.unsubscribeCurrentRoom();
-    resetPartyroomStore();
+    resetPartyroomStore(); // NOTE: exitedOnBackend 플래그 체크 이전에 호출되면 안됩니다.
   };
 }

--- a/src/features/sign-out/api/use-sign-out.mutation.ts
+++ b/src/features/sign-out/api/use-sign-out.mutation.ts
@@ -1,10 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import UsersService from '@/shared/api/http/services/users';
+import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function useSignOut() {
+  const markExitedOnBackend = useStores().useCurrentPartyroom((state) => state.markExitedOnBackend);
+
   return useMutation({
     mutationFn: UsersService.signOut,
     onSettled: () => {
+      markExitedOnBackend();
       location.href = '/';
     },
   });


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

로그아웃 하거나 패널티로 쫓겨나는 등 백단에서 exit 처리 된 경우, exit api를 클라이언트에서 또 호출하면 에러가 나므로
전역 플래그를 둬서 예외 처리 합니다.