### PR TITLE
feat: 추가된 에러 코드 반영, 파티룸 입장 시 에러 발생하면 무조건 로비로 보내기

### DIFF
--- a/src/entities/partyroom-info/ui/form.component.tsx
+++ b/src/entities/partyroom-info/ui/form.component.tsx
@@ -53,7 +53,7 @@ export default function PartyroomMutationForm({ defaultValues, onSubmit, submitT
       onSubmit={handleSubmit(() => onSubmit(form.getValues(), form))}
       className={cn('flexCol items-center justify-between mx-auto pl-[26px] pr-[40px]', {
         'child-form-labels:w-[100px]': lang === Language.Ko,
-        'child-form-labels:w-[120px]': lang === Language.En,
+        'child-form-labels:w-[128px]': lang === Language.En,
       })}
     >
       <div className='w-full items-end gap-12 flexCol'>

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -4,7 +4,7 @@ import {
 } from '@/entities/partyroom-client';
 import PartyroomsService from '@/shared/api/http/services/partyrooms';
 import { MotionType } from '@/shared/api/http/types/@enums';
-import { PartyroomReaction } from '@/shared/api/http/types/partyrooms';
+import { EnterResponse, PartyroomReaction } from '@/shared/api/http/types/partyrooms';
 import silent from '@/shared/lib/functions/silent';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -14,13 +14,14 @@ export function useEnterPartyroom(partyroomId: number) {
   const client = usePartyroomClient();
   const handleEvent = useHandlePartyroomSubscriptionEvent();
   const { useCurrentPartyroom } = useStores();
-  const initPartyroom = useCurrentPartyroom((state) => state.init);
-  const { mutateAsync: enterAsync } = useEnterPartyroomMutation();
+  const [initPartyroom, markExitedOnBackend] = useCurrentPartyroom((state) => [
+    state.init,
+    state.markExitedOnBackend,
+  ]);
+  const { mutate: enter } = useEnterPartyroomMutation();
   const router = useAppRouter();
 
-  const enterAndSetup = async () => {
-    const enterResponse = await enterAsync({ partyroomId });
-
+  const setup = async (enterResponse: EnterResponse) => {
     const [setUpInfo, notice] = await Promise.all([
       PartyroomsService.getSetupInfo({ partyroomId }),
       PartyroomsService.getNotice({ partyroomId }), // 공지사항은 현재 설계상 enter 시점엔 rest api로 받아오고, 이후 공지 변경이 있을 땐 웹 소켓 이벤트로 수신합니다.
@@ -54,14 +55,25 @@ export function useEnterPartyroom(partyroomId: number) {
   return () => {
     client.onConnect(
       () => {
-        silent(enterAndSetup(), {
-          onSuccess: () => {
-            client.subscribe(partyroomId, handleEvent);
-          },
-          onError: () => {
-            router.push('/parties'); // 에러 발생 시 무조건 로비로 이동
-          },
-        });
+        enter(
+          { partyroomId },
+          {
+            onSuccess: (enterResponse) => {
+              silent(setup(enterResponse), {
+                onSuccess: () => {
+                  client.subscribe(partyroomId, handleEvent);
+                },
+                onError: () => {
+                  router.push('/parties'); // 에러 발생 시 로비로 이동
+                },
+              });
+            },
+            onError: () => {
+              markExitedOnBackend(); // enter 자체가 안됐으니, 페이지 벗어날 때 exit api 호출 방지
+              router.push('/parties'); // 에러 발생 시 로비로 이동
+            },
+          }
+        );
       },
       { once: true }
     );

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -5,23 +5,18 @@ import {
 import PartyroomsService from '@/shared/api/http/services/partyrooms';
 import { MotionType } from '@/shared/api/http/types/@enums';
 import { PartyroomReaction } from '@/shared/api/http/types/partyrooms';
-import { errorLog } from '@/shared/lib/functions/log/logger';
-import withDebugger from '@/shared/lib/functions/log/with-debugger';
 import silent from '@/shared/lib/functions/silent';
+import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
-import { useDialog } from '@/shared/ui/components/dialog';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
 
-const logger = withDebugger(0);
-const errorLogger = logger(errorLog);
-
 export function useEnterPartyroom(partyroomId: number) {
-  const { openErrorDialog } = useDialog();
   const client = usePartyroomClient();
   const handleEvent = useHandlePartyroomSubscriptionEvent();
   const { useCurrentPartyroom } = useStores();
   const initPartyroom = useCurrentPartyroom((state) => state.init);
   const { mutateAsync: enterAsync } = useEnterPartyroomMutation();
+  const router = useAppRouter();
 
   const enterAndSetup = async () => {
     const enterResponse = await enterAsync({ partyroomId });
@@ -63,9 +58,8 @@ export function useEnterPartyroom(partyroomId: number) {
           onSuccess: () => {
             client.subscribe(partyroomId, handleEvent);
           },
-          onError: (e) => {
-            errorLogger(e);
-            openErrorDialog('Oops! Something went wrong. Please try again later.');
+          onError: () => {
+            router.push('/parties'); // 에러 발생 시 무조건 로비로 이동
           },
         });
       },

--- a/src/shared/api/get-error-message.ts
+++ b/src/shared/api/get-error-message.ts
@@ -1,14 +1,42 @@
 import { isAxiosError } from 'axios';
+import { ErrorCode } from '@/shared/api/http/types/@shared';
+import type { Dictionary } from '@/shared/lib/localization/i18n.context';
 
-export const getErrorMessage = (err: unknown): string => {
+export function getErrorMessage(err: unknown, t?: Dictionary): string {
   if (typeof err === 'string') {
     return err;
   }
+
   if (isAxiosError(err)) {
+    if (t) {
+      const errorCode = err.response?.data?.errorCode;
+      const friendlyMessage = tryConvertErrorCodeToFriendlyMessage(errorCode, t);
+
+      if (friendlyMessage) {
+        return friendlyMessage;
+      }
+    }
+
     return err.response?.data?.message ?? err.message;
   }
+
   if (err instanceof Error) {
     return err.message;
   }
   return 'Unknown error occurred';
-};
+}
+
+/**
+ * 임시 코드. 좀 더 확실한 전역 에러 핸들링 기법 필요
+ */
+function tryConvertErrorCodeToFriendlyMessage(
+  errorCode: ErrorCode,
+  t: Dictionary
+): string | undefined {
+  const friendlyMessages: Partial<Record<ErrorCode, string>> = {
+    [ErrorCode.NOT_FOUND_ROOM]: t.partyroom.ec.shut_down,
+    [ErrorCode.ALREADY_TERMINATED]: t.partyroom.ec.shut_down,
+  };
+
+  return friendlyMessages[errorCode];
+}

--- a/src/shared/api/http/types/@shared.ts
+++ b/src/shared/api/http/types/@shared.ts
@@ -1,9 +1,41 @@
-export interface Empty {}
-
 // TODO: generate from BE enum
 export enum ErrorCode {
-  REQUIRED_WALLET_CONNECT = 'BR001',
-  PLAYLIST_MAXIMUM_COUNT_EXCEED = 'BR002',
+  REQUIRED_WALLET_CONNECT = 'BR001', // FIXME: BE 측에서 에러 코드 복구되면 수정 - https://pfplay.slack.com/archives/C051N8A0ZSB/p1735470840734989
+  PLAYLIST_MAXIMUM_COUNT_EXCEED = 'BR002', // FIXME: BE 측에서 에러 코드 복구되면 수정 - https://pfplay.slack.com/archives/C051N8A0ZSB/p1735470840734989
+
+  // SessionException
+  UNAUTHORIZED_SESSION = 'SESS-001', // 허가되지 않은 세션 요청
+
+  // CrewException
+  NOT_FOUND_ACTIVE_ROOM = 'CRW-001', // 내 활성화된 방을 찾을 수 없음
+  INVALID_ACTIVE_ROOM = 'CRW-002', // 내 활성화된 방이 유효하지 않음
+
+  // DjException
+  ALREADY_REGISTERED = 'DJ-001', // 이미 DJ로 등록됨
+  QUEUE_CLOSED = 'DJ-002', // DJ 대기열이 닫혀 있음
+  EMPTY_PLAYLIST = 'DJ-003', // 비어있는 재생목록은 등록할 수 없음
+
+  // GradeException
+  MANAGER_GRADE_REQUIRED = 'GRD-001', // 이 작업을 수행하려면 관리자 등급이 필요함
+  UNABLE_TO_SET_HOST = 'GRD-002', // 호스트로 설정할 수 없음
+  GRADE_INSUFFICIENT_FOR_OPERATION = 'GRD-003', // 현재 등급으로는 요청한 작업을 수행하기에 부족함
+  GRADE_EXCEEDS_ALLOWED_THRESHOLD = 'GRD-004', // 지정된 등급이 허용된 임계값을 초과함
+  GUEST_ONLY_POSSIBLE_LISTENER = 'GRD-005', // 게스트는 청취자 역할만 가능함
+
+  // PartyroomException
+  NOT_FOUND_ROOM = 'PTR-001', // 파티룸을 찾을 수 없음
+  ALREADY_TERMINATED = 'PTR-002', // 이미 종료된 파티룸
+  EXCEEDED_LIMIT = 'PTR-003', // 입장 제한을 초과함
+  ACTIVE_ANOTHER_ROOM = 'PTR-004', // 이미 다른 파티룸에 활성화되어 있음
+  CACHE_MISS_SESSION = 'PTR-005', // 세션 ID에 대한 캐시 데이터가 없음
+  RESTRICTED_AUTHORITY = 'PTR-006', // 권한이 제한됨
+  ALREADY_HOST = 'PTR-007', // 이미 다른 파티룸의 호스트임
+
+  // PenaltyException
+  PERMANENT_EXPULSION = 'PNT-001', // 영구적으로 추방된 사용자
+
+  // PlaylistMusicException
+  DUPLICATE_MUSIC_IN_PLAYLIST = 'PLM-001', // 재생목록에 이미 존재하는 음악은 추가할 수 없음
 }
 
 export type APIError = {


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

* 파티룸 enter 중 에러 발생 시 무조건 로비로 돌려보냄
* 백엔드에 추가된 에러 코드들 enum에 반영

### Todo

<!-- 해당 기능을 마무리하기 위해 작업해야할 남은 작업을 적어주세요. -->

전역 에러(queryCache, mutationCache) 핸들러와 지역 에러간 좀 더 세밀한 핸들링이 필요합니다.

지금의 에러 처리 코드는 임시입니다. (시간상)
