### PR TITLE
refactor: 서비스 메서드 모두 프로토타입 메서드로 변경

### DIFF
--- a/src/entities/me/api/use-fetch-me.query.ts
+++ b/src/entities/me/api/use-fetch-me.query.ts
@@ -8,7 +8,7 @@ import {
 import type { UseQueryOptions } from '@tanstack/react-query/src/types';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { ONE_HOUR } from '@/shared/config/time';
 import * as Me from '../model/me.model';
@@ -24,8 +24,8 @@ export function useSuspenseFetchMe(): UseSuspenseQueryResult<Me.Model, AxiosErro
 export const queryOptions: UseQueryOptions<Me.Model, AxiosError<APIError>> = {
   queryKey: [QueryKeys.Me],
   queryFn: async () => {
-    const meInfo = await UsersService.getMyInfo();
-    const meProfileSummary = await UsersService.getMyProfileSummary();
+    const meInfo = await usersService.getMyInfo();
+    const meProfileSummary = await usersService.getMyProfileSummary();
 
     return {
       ...meInfo,

--- a/src/features/edit-profile-avatar/api/use-fetch-avatar-bodies.query.ts
+++ b/src/features/edit-profile-avatar/api/use-fetch-avatar-bodies.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { AvatarBody } from '@/shared/api/http/types/users';
 import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
@@ -9,7 +9,7 @@ import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 export function useFetchAvatarBodies() {
   return useQuery<AvatarBody[], AxiosError<APIError>>({
     queryKey: [QueryKeys.AvatarBodies],
-    queryFn: () => UsersService.getMyAvatarBodies(),
+    queryFn: () => usersService.getMyAvatarBodies(),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });

--- a/src/features/edit-profile-avatar/api/use-fetch-avatar-bodies.query.ts
+++ b/src/features/edit-profile-avatar/api/use-fetch-avatar-bodies.query.ts
@@ -9,7 +9,7 @@ import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 export function useFetchAvatarBodies() {
   return useQuery<AvatarBody[], AxiosError<APIError>>({
     queryKey: [QueryKeys.AvatarBodies],
-    queryFn: UsersService.getMyAvatarBodies,
+    queryFn: () => UsersService.getMyAvatarBodies(),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });

--- a/src/features/edit-profile-avatar/api/use-fetch-avatar-faces.query.ts
+++ b/src/features/edit-profile-avatar/api/use-fetch-avatar-faces.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { AvatarFace } from '@/shared/api/http/types/users';
 import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
@@ -9,7 +9,7 @@ import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 export function useFetchAvatarFaces() {
   return useQuery<AvatarFace[], AxiosError<APIError>>({
     queryKey: [QueryKeys.AvatarFaces],
-    queryFn: () => UsersService.getMyAvatarFaces(),
+    queryFn: () => usersService.getMyAvatarFaces(),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });

--- a/src/features/edit-profile-avatar/api/use-fetch-avatar-faces.query.ts
+++ b/src/features/edit-profile-avatar/api/use-fetch-avatar-faces.query.ts
@@ -9,7 +9,7 @@ import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 export function useFetchAvatarFaces() {
   return useQuery<AvatarFace[], AxiosError<APIError>>({
     queryKey: [QueryKeys.AvatarFaces],
-    queryFn: UsersService.getMyAvatarFaces,
+    queryFn: () => UsersService.getMyAvatarFaces(),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
   });

--- a/src/features/edit-profile-avatar/api/use-update-my-avatar.mutation.ts
+++ b/src/features/edit-profile-avatar/api/use-update-my-avatar.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { AvatarBody } from '@/shared/api/http/types/users';
 
@@ -11,15 +11,15 @@ export function useUpdateMyAvatar() {
   return useMutation<void, AxiosError<APIError>, { body: AvatarBody; faceUri?: string }>({
     mutationFn: async ({ body, faceUri }) => {
       if (!body.combinable) {
-        await UsersService.updateMyAvatarBody({ avatarBodyUri: body.resourceUri });
+        await usersService.updateMyAvatarBody({ avatarBodyUri: body.resourceUri });
         return;
       }
       if (!faceUri) {
         throw new Error('faceUri is required when the body is combinable');
       }
       await Promise.all([
-        UsersService.updateMyAvatarBody({ avatarBodyUri: body.resourceUri }),
-        UsersService.updateMyAvatarFace({ avatarFaceUri: faceUri }),
+        usersService.updateMyAvatarBody({ avatarBodyUri: body.resourceUri }),
+        usersService.updateMyAvatarFace({ avatarFaceUri: faceUri }),
       ]);
     },
     onSuccess: () => {

--- a/src/features/edit-profile-avatar/api/use-update-my-walllet.mutation.ts
+++ b/src/features/edit-profile-avatar/api/use-update-my-walllet.mutation.ts
@@ -9,7 +9,7 @@ export function useUpdateMyWallet() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UpdateMyWalletRequest>({
-    mutationFn: UsersService.updateMyWallet,
+    mutationFn: (request) => UsersService.updateMyWallet(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Me],

--- a/src/features/edit-profile-avatar/api/use-update-my-walllet.mutation.ts
+++ b/src/features/edit-profile-avatar/api/use-update-my-walllet.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { UpdateMyWalletRequest } from '@/shared/api/http/types/users';
 
@@ -9,7 +9,7 @@ export function useUpdateMyWallet() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UpdateMyWalletRequest>({
-    mutationFn: (request) => UsersService.updateMyWallet(request),
+    mutationFn: (request) => usersService.updateMyWallet(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Me],

--- a/src/features/edit-profile-bio/api/use-update-my-bio.mutation.ts
+++ b/src/features/edit-profile-bio/api/use-update-my-bio.mutation.ts
@@ -9,7 +9,7 @@ export const useUpdateMyBio = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UpdateMyBioRequest>({
-    mutationFn: UsersService.updateMyBio,
+    mutationFn: (request) => UsersService.updateMyBio(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Me],

--- a/src/features/edit-profile-bio/api/use-update-my-bio.mutation.ts
+++ b/src/features/edit-profile-bio/api/use-update-my-bio.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { UpdateMyBioRequest } from '@/shared/api/http/types/users';
 
@@ -9,7 +9,7 @@ export const useUpdateMyBio = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UpdateMyBioRequest>({
-    mutationFn: (request) => UsersService.updateMyBio(request),
+    mutationFn: (request) => usersService.updateMyBio(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Me],

--- a/src/features/partyroom/adjust-grade/api/use-adjust-grade.mutation.ts
+++ b/src/features/partyroom/adjust-grade/api/use-adjust-grade.mutation.ts
@@ -9,7 +9,7 @@ export function useAdjustGrade() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, AdjustGradePayload>({
-    mutationFn: PartyroomsService.adjustGrade,
+    mutationFn: (request) => PartyroomsService.adjustGrade(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Crews],

--- a/src/features/partyroom/adjust-grade/api/use-adjust-grade.mutation.ts
+++ b/src/features/partyroom/adjust-grade/api/use-adjust-grade.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { AdjustGradePayload } from '@/shared/api/http/types/partyrooms';
 
@@ -9,7 +9,7 @@ export function useAdjustGrade() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, AdjustGradePayload>({
-    mutationFn: (request) => PartyroomsService.adjustGrade(request),
+    mutationFn: (request) => partyroomsService.adjustGrade(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Crews],

--- a/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
+++ b/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import {
   CreatePartyroomPayload,
@@ -9,6 +9,6 @@ import {
 
 export default function useCreatePartyroom() {
   return useMutation<CreatePartyroomResponse, AxiosError<APIError>, CreatePartyroomPayload>({
-    mutationFn: (request) => PartyroomsService.create(request),
+    mutationFn: (request) => partyroomsService.create(request),
   });
 }

--- a/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
+++ b/src/features/partyroom/create/api/use-create-partyroom.mutation.ts
@@ -9,6 +9,6 @@ import {
 
 export default function useCreatePartyroom() {
   return useMutation<CreatePartyroomResponse, AxiosError<APIError>, CreatePartyroomPayload>({
-    mutationFn: PartyroomsService.create,
+    mutationFn: (request) => PartyroomsService.create(request),
   });
 }

--- a/src/features/partyroom/edit/api/use-edit-partyroom.mutation.ts
+++ b/src/features/partyroom/edit/api/use-edit-partyroom.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { EditPartyroomPayload } from '@/shared/api/http/types/partyrooms';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -15,7 +15,7 @@ export default function useEditPartyroom() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return await PartyroomsService.edit({
+      return await partyroomsService.edit({
         partyroomId,
         ...payload,
       });

--- a/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
+++ b/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
@@ -6,6 +6,6 @@ import { EnterPayload, EnterResponse } from '@/shared/api/http/types/partyrooms'
 
 export function useEnterPartyroom() {
   return useMutation<EnterResponse, AxiosError<APIError>, EnterPayload>({
-    mutationFn: PartyroomsService.enter,
+    mutationFn: (request) => PartyroomsService.enter(request),
   });
 }

--- a/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
+++ b/src/features/partyroom/enter/api/use-enter-partyroom.mutation.ts
@@ -1,11 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { EnterPayload, EnterResponse } from '@/shared/api/http/types/partyrooms';
 
 export function useEnterPartyroom() {
   return useMutation<EnterResponse, AxiosError<APIError>, EnterPayload>({
-    mutationFn: (request) => PartyroomsService.enter(request),
+    mutationFn: (request) => partyroomsService.enter(request),
   });
 }

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -2,7 +2,7 @@ import {
   useHandlePartyroomSubscriptionEvent,
   usePartyroomClient,
 } from '@/entities/partyroom-client';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { MotionType } from '@/shared/api/http/types/@enums';
 import { EnterResponse, PartyroomReaction } from '@/shared/api/http/types/partyrooms';
 import silent from '@/shared/lib/functions/silent';
@@ -23,8 +23,8 @@ export function useEnterPartyroom(partyroomId: number) {
 
   const setup = async (enterResponse: EnterResponse) => {
     const [setUpInfo, notice] = await Promise.all([
-      PartyroomsService.getSetupInfo({ partyroomId }),
-      PartyroomsService.getNotice({ partyroomId }), // 공지사항은 현재 설계상 enter 시점엔 rest api로 받아오고, 이후 공지 변경이 있을 땐 웹 소켓 이벤트로 수신합니다.
+      partyroomsService.getSetupInfo({ partyroomId }),
+      partyroomsService.getNotice({ partyroomId }), // 공지사항은 현재 설계상 enter 시점엔 rest api로 받아오고, 이후 공지 변경이 있을 땐 웹 소켓 이벤트로 수신합니다.
     ]);
 
     // TODO: crews 작업 시 crews 캐시 데이터 세팅해주기

--- a/src/features/partyroom/evaluate-current-playback/api/use-evaluate-current-playback.mutation.ts
+++ b/src/features/partyroom/evaluate-current-playback/api/use-evaluate-current-playback.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { ReactionType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { ReactionResponse } from '@/shared/api/http/types/partyrooms';
@@ -18,7 +18,7 @@ export function useEvaluateCurrentPlayback() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return await PartyroomsService.reaction({
+      return await partyroomsService.reaction({
         partyroomId,
         reactionType,
       });

--- a/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
+++ b/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { ExitPayload } from '@/shared/api/http/types/partyrooms';
 
@@ -9,7 +9,7 @@ export function useExitPartyroom() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, ExitPayload>({
-    mutationFn: (request) => PartyroomsService.exit(request),
+    mutationFn: (request) => partyroomsService.exit(request),
     onSuccess: () => {
       /**
        * TODO: 파티 룸 관련 캐시 모두 제거 (crews, djingQueue, etc...)

--- a/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
+++ b/src/features/partyroom/exit/api/use-exit-partyroom.mutation.ts
@@ -9,7 +9,7 @@ export function useExitPartyroom() {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, ExitPayload>({
-    mutationFn: PartyroomsService.exit,
+    mutationFn: (request) => PartyroomsService.exit(request),
     onSuccess: () => {
       /**
        * TODO: 파티 룸 관련 캐시 모두 제거 (crews, djingQueue, etc...)

--- a/src/features/partyroom/get-summary/api/use-fetch-partyroom-detail-summary.query.tsx
+++ b/src/features/partyroom/get-summary/api/use-fetch-partyroom-detail-summary.query.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { PartyroomDetailSummary } from '@/shared/api/http/types/partyrooms';
 import { FIVE_MINUTES } from '@/shared/config/time';
@@ -9,7 +9,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export default function useFetchPartyroomDetailSummary(partyroomId: number, enabled: boolean) {
   return useQuery<PartyroomDetailSummary, AxiosError<APIError>>({
     queryKey: [QueryKeys.PartyroomDetailSummary, partyroomId],
-    queryFn: () => PartyroomsService.getPartyroomDetailSummary({ partyroomId }),
+    queryFn: () => partyroomsService.getPartyroomDetailSummary({ partyroomId }),
     staleTime: 0,
     gcTime: FIVE_MINUTES,
     refetchOnWindowFocus: true,

--- a/src/features/partyroom/grab-current-playback/api/use-grab-current-playback.mutation.ts
+++ b/src/features/partyroom/grab-current-playback/api/use-grab-current-playback.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { ReactionType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import type { ReactionResponse } from '@/shared/api/http/types/partyrooms';
@@ -16,7 +16,7 @@ export function useGrabCurrentPlayback() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return await PartyroomsService.reaction({
+      return await partyroomsService.reaction({
         partyroomId,
         reactionType: ReactionType.GRAB,
       });

--- a/src/features/partyroom/impose-penalty/api/use-impose-penalty.mutation.tsx
+++ b/src/features/partyroom/impose-penalty/api/use-impose-penalty.mutation.tsx
@@ -1,11 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { ImposePenaltyPayload } from '@/shared/api/http/types/partyrooms';
 
 export default function useImposePenaltyMutation() {
   return useMutation<void, AxiosError<APIError>, ImposePenaltyPayload>({
-    mutationFn: (payload) => PartyroomsService.imposePenalty(payload),
+    mutationFn: (payload) => partyroomsService.imposePenalty(payload),
   });
 }

--- a/src/features/partyroom/list-djing-queue/api/use-fetch-djing-queue.query.ts
+++ b/src/features/partyroom/list-djing-queue/api/use-fetch-djing-queue.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { GetDjingQueuePayload, DjingQueue } from '@/shared/api/http/types/partyrooms';
 import { FIVE_MINUTES } from '@/shared/config/time';
@@ -9,7 +9,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export default function useFetchDjingQueue(payload: GetDjingQueuePayload, enabled?: boolean) {
   return useQuery<DjingQueue, AxiosError<APIError>>({
     queryKey: [QueryKeys.DjingQueue, payload.partyroomId],
-    queryFn: () => PartyroomsService.getDjingQueue(payload),
+    queryFn: () => partyroomsService.getDjingQueue(payload),
     staleTime: 0,
     gcTime: FIVE_MINUTES,
     enabled,

--- a/src/features/partyroom/list-playback-history/api/use-fetch-playback-history.query.ts
+++ b/src/features/partyroom/list-playback-history/api/use-fetch-playback-history.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { PlaybackHistoryItem } from '@/shared/api/http/types/partyrooms';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -15,7 +15,7 @@ export default function useFetchPlaybackHistory() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return PartyroomsService.getPlaybackHistory({ partyroomId });
+      return partyroomsService.getPlaybackHistory({ partyroomId });
     },
   });
 }

--- a/src/features/partyroom/list/api/use-fetch-general-partyrooms.query.ts
+++ b/src/features/partyroom/list/api/use-fetch-general-partyrooms.query.ts
@@ -10,7 +10,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export const useFetchGeneralPartyrooms = () => {
   return useQuery<PartyroomSummary[], AxiosError<APIError>, PartyroomSummary[]>({
     queryKey: [QueryKeys.PartyroomList],
-    queryFn: PartyroomsService.getList,
+    queryFn: () => PartyroomsService.getList(),
     select: (data) => data.filter((partyroom) => partyroom.stageType === StageType.GENERAL),
     staleTime: 0,
     gcTime: FIVE_MINUTES,

--- a/src/features/partyroom/list/api/use-fetch-general-partyrooms.query.ts
+++ b/src/features/partyroom/list/api/use-fetch-general-partyrooms.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { StageType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
@@ -10,7 +10,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export const useFetchGeneralPartyrooms = () => {
   return useQuery<PartyroomSummary[], AxiosError<APIError>, PartyroomSummary[]>({
     queryKey: [QueryKeys.PartyroomList],
-    queryFn: () => PartyroomsService.getList(),
+    queryFn: () => partyroomsService.getList(),
     select: (data) => data.filter((partyroom) => partyroom.stageType === StageType.GENERAL),
     staleTime: 0,
     gcTime: FIVE_MINUTES,

--- a/src/features/partyroom/list/api/use-fetch-main-partyroom.query.ts
+++ b/src/features/partyroom/list/api/use-fetch-main-partyroom.query.ts
@@ -10,7 +10,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export const useSuspenseFetchMainPartyroom = () => {
   return useSuspenseQuery<PartyroomSummary[], AxiosError<APIError>, PartyroomSummary>({
     queryKey: [QueryKeys.PartyroomList],
-    queryFn: PartyroomsService.getList,
+    queryFn: () => PartyroomsService.getList(),
     select: (data) => {
       // NOTE: 메인 파티룸은 항상 존재한다고 가정
       return data.find((partyroom) => partyroom.stageType === StageType.MAIN) as PartyroomSummary;

--- a/src/features/partyroom/list/api/use-fetch-main-partyroom.query.ts
+++ b/src/features/partyroom/list/api/use-fetch-main-partyroom.query.ts
@@ -1,7 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { StageType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
@@ -10,7 +10,7 @@ import { FIVE_MINUTES } from '@/shared/config/time';
 export const useSuspenseFetchMainPartyroom = () => {
   return useSuspenseQuery<PartyroomSummary[], AxiosError<APIError>, PartyroomSummary>({
     queryKey: [QueryKeys.PartyroomList],
-    queryFn: () => PartyroomsService.getList(),
+    queryFn: () => partyroomsService.getList(),
     select: (data) => {
       // NOTE: 메인 파티룸은 항상 존재한다고 가정
       return data.find((partyroom) => partyroom.stageType === StageType.MAIN) as PartyroomSummary;

--- a/src/features/partyroom/lock-djing-queue/api/use-lock-djing-queue.mutation.ts
+++ b/src/features/partyroom/lock-djing-queue/api/use-lock-djing-queue.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { QueueStatus } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -15,7 +15,7 @@ export default function useLockDjingQueue() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return await PartyroomsService.changeDjQueueStatus({
+      return await partyroomsService.changeDjQueueStatus({
         partyroomId,
         queueStatus: QueueStatus.CLOSE,
       });

--- a/src/features/partyroom/share-link/api/use-get-partyroom-id-by-domain.mutation.ts
+++ b/src/features/partyroom/share-link/api/use-get-partyroom-id-by-domain.mutation.ts
@@ -9,6 +9,6 @@ import {
 
 export default function useGetPartyroomIdByDomain() {
   return useMutation<GetRoomIdByDomainResponse, AxiosError<APIError>, GetRoomIdByDomainPayload>({
-    mutationFn: PartyroomsService.getRoomIdByDomain,
+    mutationFn: (request) => PartyroomsService.getRoomIdByDomain(request),
   });
 }

--- a/src/features/partyroom/share-link/api/use-get-partyroom-id-by-domain.mutation.ts
+++ b/src/features/partyroom/share-link/api/use-get-partyroom-id-by-domain.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import {
   GetRoomIdByDomainResponse,
@@ -9,6 +9,6 @@ import {
 
 export default function useGetPartyroomIdByDomain() {
   return useMutation<GetRoomIdByDomainResponse, AxiosError<APIError>, GetRoomIdByDomainPayload>({
-    mutationFn: (request) => PartyroomsService.getRoomIdByDomain(request),
+    mutationFn: (request) => partyroomsService.getRoomIdByDomain(request),
   });
 }

--- a/src/features/partyroom/skip-playback/api/use-skip-playback.mutation.tsx
+++ b/src/features/partyroom/skip-playback/api/use-skip-playback.mutation.tsx
@@ -9,7 +9,7 @@ export const useSkipPlayback = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, SkipPlaybackPayload>({
-    mutationFn: DjsService.skipPlayback,
+    mutationFn: (request) => DjsService.skipPlayback(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],

--- a/src/features/partyroom/skip-playback/api/use-skip-playback.mutation.tsx
+++ b/src/features/partyroom/skip-playback/api/use-skip-playback.mutation.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import DjsService from '@/shared/api/http/services/djs';
+import { djsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { SkipPlaybackPayload } from '@/shared/api/http/types/djs';
 
@@ -9,7 +9,7 @@ export const useSkipPlayback = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, SkipPlaybackPayload>({
-    mutationFn: (request) => DjsService.skipPlayback(request),
+    mutationFn: (request) => djsService.skipPlayback(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],

--- a/src/features/partyroom/unlock-djing-queue/api/use-unlock-djing-queue.mutation.ts
+++ b/src/features/partyroom/unlock-djing-queue/api/use-unlock-djing-queue.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PartyroomsService from '@/shared/api/http/services/partyrooms';
+import { partyroomsService } from '@/shared/api/http/services';
 import { QueueStatus } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -15,7 +15,7 @@ export default function useUnlockDjingQueue() {
       if (!partyroomId) {
         throw new Error('partyroomId is not found. maybe you are not in the partyroom.');
       }
-      return await PartyroomsService.changeDjQueueStatus({
+      return await partyroomsService.changeDjQueueStatus({
         partyroomId,
         queueStatus: QueueStatus.OPEN,
       });

--- a/src/features/playlist/add-musics/api/use-add-playlist-music.mutation.ts
+++ b/src/features/playlist/add-musics/api/use-add-playlist-music.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { AddPlaylistMusicRequestBody } from '@/shared/api/http/types/playlists';
 
 export const useAddPlaylistMusic = () => {
@@ -8,7 +8,7 @@ export const useAddPlaylistMusic = () => {
 
   return useMutation({
     mutationFn: ({ listId, ...params }: AddPlaylistMusicRequestBody & { listId: number }) => {
-      return PlaylistsService.addMusicToPlaylist(listId, params);
+      return playlistsService.addMusicToPlaylist(listId, params);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({

--- a/src/features/playlist/add-musics/api/use-search-musics.query.ts
+++ b/src/features/playlist/add-musics/api/use-search-musics.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { MusicListItem, SearchMusicsResponse } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES } from '@/shared/config/time';
@@ -10,7 +10,7 @@ export const useSearchMusics = (search: string) => {
   return useQuery<SearchMusicsResponse, AxiosError<APIError>, MusicListItem[]>({
     queryKey: [QueryKeys.Musics, search],
     queryFn: () =>
-      PlaylistsService.searchMusics({
+      playlistsService.searchMusics({
         q: search,
         platform: 'youtube',
       }),

--- a/src/features/playlist/add/api/use-create-playlist.mutation.ts
+++ b/src/features/playlist/add/api/use-create-playlist.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import {
   CreatePlaylistRequestBody,
@@ -12,7 +12,7 @@ export const useCreatePlaylist = () => {
   const queryClient = useQueryClient();
 
   return useMutation<CreatePlaylistResponse, AxiosError<APIError>, CreatePlaylistRequestBody>({
-    mutationFn: (request) => PlaylistsService.createPlaylist(request),
+    mutationFn: (request) => playlistsService.createPlaylist(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],

--- a/src/features/playlist/add/api/use-create-playlist.mutation.ts
+++ b/src/features/playlist/add/api/use-create-playlist.mutation.ts
@@ -12,7 +12,7 @@ export const useCreatePlaylist = () => {
   const queryClient = useQueryClient();
 
   return useMutation<CreatePlaylistResponse, AxiosError<APIError>, CreatePlaylistRequestBody>({
-    mutationFn: PlaylistsService.createPlaylist,
+    mutationFn: (request) => PlaylistsService.createPlaylist(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],

--- a/src/features/playlist/edit/api/use-update-playlist.mutation.ts
+++ b/src/features/playlist/edit/api/use-update-playlist.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { UpdatePlaylistRequestBody } from '@/shared/api/http/types/playlists';
 
 export const useUpdatePlaylist = () => {
@@ -8,7 +8,7 @@ export const useUpdatePlaylist = () => {
 
   return useMutation({
     mutationFn: ({ listId, ...params }: UpdatePlaylistRequestBody & { listId: number }) =>
-      PlaylistsService.updatePlaylist(listId, params),
+      playlistsService.updatePlaylist(listId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],

--- a/src/features/playlist/list-musics/api/use-fetch-playlist-musics.query.ts
+++ b/src/features/playlist/list-musics/api/use-fetch-playlist-musics.query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { APIError, PaginationResponse } from '@/shared/api/http/types/@shared';
 import { type PlaylistMusic } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES } from '@/shared/config/time';
@@ -13,7 +13,7 @@ export const useFetchPlaylistMusics = (listId: number) => {
       /**
        * TODO: 페이지네이션 무시하고 music 최대 개수 일괄 조회 중. 추후 개선할 것. 100개라 페이지네이션 자체가 필요 없을 수도?
        */
-      PlaylistsService.getMusicsFromPlaylist(listId, {
+      playlistsService.getMusicsFromPlaylist(listId, {
         pageNumber: 0,
         pageSize: MUSICS_COUNT_LIMIT_PER_1_PLAYLIST,
       }),

--- a/src/features/playlist/list/api/use-fetch-playlists.query.ts
+++ b/src/features/playlist/list/api/use-fetch-playlists.query.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { PlaylistType } from '@/shared/api/http/types/@enums';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { GetPlaylistsResponse, Playlist } from '@/shared/api/http/types/playlists';
@@ -27,7 +27,7 @@ export default function useFetchPlaylists() {
 
   return useQuery<GetPlaylistsResponse, AxiosError<APIError>, Playlist[]>({
     queryKey: [QueryKeys.Playlist],
-    queryFn: () => PlaylistsService.getPlaylists(),
+    queryFn: () => playlistsService.getPlaylists(),
     select: ({ playlists }) => overwriteGrabPlaylistName(playlists, t),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,

--- a/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
+++ b/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import {
   RemovePlaylistMusicRequestBody,
@@ -16,7 +16,7 @@ export const useRemovePlaylistMusics = () => {
     AxiosError<APIError>,
     RemovePlaylistMusicRequestBody
   >({
-    mutationFn: (request) => PlaylistsService.removeMusicsFromPlaylist(request),
+    mutationFn: (request) => playlistsService.removeMusicsFromPlaylist(request),
     onSuccess: (data) => {
       data.listIds.forEach((listId) => {
         queryClient.invalidateQueries({

--- a/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
+++ b/src/features/playlist/remove-musics/api/use-remove-playlist-music.mutation.ts
@@ -16,7 +16,7 @@ export const useRemovePlaylistMusics = () => {
     AxiosError<APIError>,
     RemovePlaylistMusicRequestBody
   >({
-    mutationFn: PlaylistsService.removeMusicsFromPlaylist,
+    mutationFn: (request) => PlaylistsService.removeMusicsFromPlaylist(request),
     onSuccess: (data) => {
       data.listIds.forEach((listId) => {
         queryClient.invalidateQueries({

--- a/src/features/playlist/remove/api/use-remove-playlist.mutation.ts
+++ b/src/features/playlist/remove/api/use-remove-playlist.mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import PlaylistsService from '@/shared/api/http/services/playlists';
+import { playlistsService } from '@/shared/api/http/services';
 
 export const useRemovePlaylist = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (listIds: number[]) => PlaylistsService.removePlaylist({ listIds }),
+    mutationFn: (listIds: number[]) => playlistsService.removePlaylist({ listIds }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],

--- a/src/features/sign-in/by-google/lib/use-sign-in-for-dev.hook.tsx
+++ b/src/features/sign-in/by-google/lib/use-sign-in-for-dev.hook.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useGetMyServiceEntry } from '@/entities/me';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Dialog, useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
@@ -27,7 +27,7 @@ export default function useSignInForDev() {
             <Dialog.Button
               color='secondary'
               onClick={async () => {
-                await UsersService.temporary_SignInFullCrew();
+                await usersService.temporary_SignInFullCrew();
                 onClose?.();
                 router.push(await getMyServiceEntry());
               }}
@@ -36,7 +36,7 @@ export default function useSignInForDev() {
             </Dialog.Button>
             <Dialog.Button
               onClick={async () => {
-                await UsersService.temporary_SignInAssociateCrew();
+                await usersService.temporary_SignInAssociateCrew();
                 onClose?.();
                 router.push(await getMyServiceEntry());
               }}

--- a/src/features/sign-in/by-google/lib/use-sign-in.hook.tsx
+++ b/src/features/sign-in/by-google/lib/use-sign-in.hook.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 
 export default function useSignIn() {
   return useCallback(() => {
-    UsersService.signIn({
+    usersService.signIn({
       oauth2Provider: 'google',
     });
   }, []);

--- a/src/features/sign-in/by-guest/api/use-sign-in.mutation.ts
+++ b/src/features/sign-in/by-guest/api/use-sign-in.mutation.ts
@@ -5,6 +5,6 @@ import { APIError } from '@/shared/api/http/types/@shared';
 
 export default function useSignIn() {
   return useMutation<void, AxiosError<APIError>, void>({
-    mutationFn: UsersService.signInGuest,
+    mutationFn: (request) => UsersService.signInGuest(request),
   });
 }

--- a/src/features/sign-in/by-guest/api/use-sign-in.mutation.ts
+++ b/src/features/sign-in/by-guest/api/use-sign-in.mutation.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 
 export default function useSignIn() {
   return useMutation<void, AxiosError<APIError>, void>({
-    mutationFn: (request) => UsersService.signInGuest(request),
+    mutationFn: () => usersService.signInGuest(),
   });
 }

--- a/src/features/sign-out/api/use-sign-out.mutation.ts
+++ b/src/features/sign-out/api/use-sign-out.mutation.ts
@@ -6,7 +6,7 @@ export default function useSignOut() {
   const markExitedOnBackend = useStores().useCurrentPartyroom((state) => state.markExitedOnBackend);
 
   return useMutation({
-    mutationFn: UsersService.signOut,
+    mutationFn: (request) => UsersService.signOut(request),
     onSettled: () => {
       markExitedOnBackend();
       location.href = '/';

--- a/src/features/sign-out/api/use-sign-out.mutation.ts
+++ b/src/features/sign-out/api/use-sign-out.mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
-import UsersService from '@/shared/api/http/services/users';
+import { usersService } from '@/shared/api/http/services';
 import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function useSignOut() {
   const markExitedOnBackend = useStores().useCurrentPartyroom((state) => state.markExitedOnBackend);
 
   return useMutation({
-    mutationFn: (request) => UsersService.signOut(request),
+    mutationFn: () => usersService.signOut(),
     onSettled: () => {
       markExitedOnBackend();
       location.href = '/';

--- a/src/shared/api/http/client/client.ts
+++ b/src/shared/api/http/client/client.ts
@@ -23,7 +23,7 @@ axiosInstance.interceptors.response.use(
 );
 
 export default class HTTPClient {
-  protected axiosInstance = axiosInstance;
+  protected readonly axiosInstance = axiosInstance;
 
   protected get<T>(...args: Parameters<AxiosInstance['get']>) {
     return this.axiosInstance.get<T, T>(...args);

--- a/src/shared/api/http/client/client.ts
+++ b/src/shared/api/http/client/client.ts
@@ -22,7 +22,7 @@ axiosInstance.interceptors.response.use(
   flow([logError, emitError, processError])
 );
 
-export default class HTTPClient {
+export default abstract class HTTPClient {
   protected readonly axiosInstance = axiosInstance;
 
   protected get<T>(...args: Parameters<AxiosInstance['get']>) {

--- a/src/shared/api/http/services/djs.ts
+++ b/src/shared/api/http/services/djs.ts
@@ -12,21 +12,21 @@ import HTTPClient from '../client/client';
 class DjsService extends HTTPClient implements DjsClient {
   private ROUTE_V1 = 'v1/partyrooms';
 
-  public registerMeToQueue = ({ partyroomId, ...body }: RegisterMeToQueuePayload) => {
+  public registerMeToQueue({ partyroomId, ...body }: RegisterMeToQueuePayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/djs`, body);
-  };
+  }
 
-  public unregisterMeFromQueue = ({ partyroomId }: UnregisterMeFromQueuePayload) => {
+  public unregisterMeFromQueue({ partyroomId }: UnregisterMeFromQueuePayload) {
     return this.delete<void>(`${this.ROUTE_V1}/${partyroomId}/djs/me`);
-  };
+  }
 
-  public unregisterDjFromQueue = ({ partyroomId, djId }: UnregisterDjFromQueuePayload) => {
+  public unregisterDjFromQueue({ partyroomId, djId }: UnregisterDjFromQueuePayload) {
     return this.delete<void>(`${this.ROUTE_V1}/${partyroomId}/djs/${djId}`);
-  };
+  }
 
-  public skipPlayback = ({ partyroomId }: SkipPlaybackPayload) => {
+  public skipPlayback({ partyroomId }: SkipPlaybackPayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/playback/skip`);
-  };
+  }
 }
 
 const instance = new DjsService();

--- a/src/shared/api/http/services/djs.ts
+++ b/src/shared/api/http/services/djs.ts
@@ -9,7 +9,7 @@ import {
 import HTTPClient from '../client/client';
 
 @Singleton
-class DjsService extends HTTPClient implements DjsClient {
+export default class DjsService extends HTTPClient implements DjsClient {
   private ROUTE_V1 = 'v1/partyrooms';
 
   public registerMeToQueue({ partyroomId, ...body }: RegisterMeToQueuePayload) {
@@ -28,6 +28,3 @@ class DjsService extends HTTPClient implements DjsClient {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/playback/skip`);
   }
 }
-
-const instance = new DjsService();
-export default instance;

--- a/src/shared/api/http/services/index.ts
+++ b/src/shared/api/http/services/index.ts
@@ -1,0 +1,9 @@
+import DjsService from './djs';
+import PartyroomsService from './partyrooms';
+import PlaylistsService from './playlists';
+import UsersService from './users';
+
+export const djsService = new DjsService();
+export const partyroomsService = new PartyroomsService();
+export const playlistsService = new PlaylistsService();
+export const usersService = new UsersService();

--- a/src/shared/api/http/services/partyrooms.ts
+++ b/src/shared/api/http/services/partyrooms.ts
@@ -31,7 +31,7 @@ import type {
 import HTTPClient from '../client/client';
 
 @Singleton
-class PartyroomsService extends HTTPClient implements PartyroomsClient {
+export default class PartyroomsService extends HTTPClient implements PartyroomsClient {
   private ROUTE_V1 = 'v1/partyrooms';
 
   public create(payload: CreatePartyroomPayload) {
@@ -98,6 +98,3 @@ class PartyroomsService extends HTTPClient implements PartyroomsClient {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/crews/${crewId}/penalties`, body);
   }
 }
-
-const instance = new PartyroomsService();
-export default instance;

--- a/src/shared/api/http/services/partyrooms.ts
+++ b/src/shared/api/http/services/partyrooms.ts
@@ -34,69 +34,69 @@ import HTTPClient from '../client/client';
 class PartyroomsService extends HTTPClient implements PartyroomsClient {
   private ROUTE_V1 = 'v1/partyrooms';
 
-  public create = (payload: CreatePartyroomPayload) => {
+  public create(payload: CreatePartyroomPayload) {
     return this.post<CreatePartyroomResponse>(this.ROUTE_V1, payload);
-  };
+  }
 
-  public edit = ({ partyroomId, ...body }: EditPartyroomPayload) => {
+  public edit({ partyroomId, ...body }: EditPartyroomPayload) {
     return this.put<void>(`${this.ROUTE_V1}/${partyroomId}`, body);
-  };
+  }
 
-  public getList = () => {
+  public getList() {
     return this.get<PartyroomSummary[]>(`${this.ROUTE_V1}`);
-  };
+  }
 
-  public getPartyroomDetailSummary = ({ partyroomId }: GetPartyroomDetailSummaryPayload) => {
+  public getPartyroomDetailSummary({ partyroomId }: GetPartyroomDetailSummaryPayload) {
     return this.get<PartyroomDetailSummary>(`${this.ROUTE_V1}/${partyroomId}/summary`);
-  };
+  }
 
-  public getSetupInfo = ({ partyroomId }: GetSetupInfoPayload) => {
+  public getSetupInfo({ partyroomId }: GetSetupInfoPayload) {
     return this.get<GetSetUpInfoResponse>(`${this.ROUTE_V1}/${partyroomId}/setup`);
-  };
+  }
 
-  public getCrews = ({ partyroomId }: GetCrewsPayload) => {
+  public getCrews({ partyroomId }: GetCrewsPayload) {
     return this.get<PartyroomCrewSummary[]>(`${this.ROUTE_V1}/${partyroomId}/crews`);
-  };
+  }
 
-  public getDjingQueue = ({ partyroomId }: GetDjingQueuePayload) => {
+  public getDjingQueue({ partyroomId }: GetDjingQueuePayload) {
     return this.get<DjingQueue>(`${this.ROUTE_V1}/${partyroomId}/dj-queue`);
-  };
+  }
 
-  public changeDjQueueStatus = ({ partyroomId, ...body }: ChangeDjQueueStatusPayload) => {
+  public changeDjQueueStatus({ partyroomId, ...body }: ChangeDjQueueStatusPayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue`, body);
-  };
+  }
 
-  public getNotice = ({ partyroomId }: GetNoticePayload) => {
+  public getNotice({ partyroomId }: GetNoticePayload) {
     return this.get<GetNoticeResponse>(`${this.ROUTE_V1}/${partyroomId}/notice`);
-  };
+  }
 
-  public getPlaybackHistory = ({ partyroomId }: GetPlaybackHistoryPayload) => {
+  public getPlaybackHistory({ partyroomId }: GetPlaybackHistoryPayload) {
     return this.get<PlaybackHistoryItem[]>(`${this.ROUTE_V1}/${partyroomId}/playbacks/histories`);
-  };
+  }
 
-  public enter = ({ partyroomId }: EnterPayload) => {
+  public enter({ partyroomId }: EnterPayload) {
     return this.post<EnterResponse>(`${this.ROUTE_V1}/${partyroomId}/enter`);
-  };
+  }
 
-  public exit = ({ partyroomId }: ExitPayload) => {
+  public exit({ partyroomId }: ExitPayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/exit`);
-  };
+  }
 
-  public reaction = ({ partyroomId, ...body }: ReactionPayload) => {
+  public reaction({ partyroomId, ...body }: ReactionPayload) {
     return this.post<ReactionResponse>(`${this.ROUTE_V1}/${partyroomId}/playbacks/reaction`, body);
-  };
+  }
 
-  public adjustGrade = ({ partyroomId, crewId, ...body }: AdjustGradePayload) => {
+  public adjustGrade({ partyroomId, crewId, ...body }: AdjustGradePayload) {
     return this.put<void>(`${this.ROUTE_V1}/${partyroomId}/crews/${crewId}/grade`, body);
-  };
+  }
 
-  public getRoomIdByDomain = ({ domain }: GetRoomIdByDomainPayload) => {
+  public getRoomIdByDomain({ domain }: GetRoomIdByDomainPayload) {
     return this.get<GetRoomIdByDomainResponse>(`${this.ROUTE_V1}/link/${domain}/enter`);
-  };
+  }
 
-  public imposePenalty = ({ partyroomId, crewId, ...body }: ImposePenaltyPayload) => {
+  public imposePenalty({ partyroomId, crewId, ...body }: ImposePenaltyPayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/crews/${crewId}/penalties`, body);
-  };
+  }
 }
 
 const instance = new PartyroomsService();

--- a/src/shared/api/http/services/playlists.ts
+++ b/src/shared/api/http/services/playlists.ts
@@ -24,47 +24,44 @@ import type {
 class PlaylistsService extends HTTPClient implements PlaylistsClient {
   private ROUTE_V1 = 'v1/playlists';
 
-  public getPlaylists = () => {
+  public getPlaylists() {
     return this.get<GetPlaylistsResponse>(`${this.ROUTE_V1}`);
-  };
+  }
 
-  public getMusicsFromPlaylist = (
-    playlistId: Playlist['id'],
-    params?: GetPlaylistMusicsParameters
-  ) => {
+  public getMusicsFromPlaylist(playlistId: Playlist['id'], params?: GetPlaylistMusicsParameters) {
     return this.get<PaginationResponse<PlaylistMusic>>(`${this.ROUTE_V1}/${playlistId}/musics`, {
       params,
     });
-  };
+  }
 
-  public searchMusics = (params: SearchMusicsRequest) => {
+  public searchMusics(params: SearchMusicsRequest) {
     return this.get<SearchMusicsResponse>(`v1/music-search`, { params });
-  };
+  }
 
-  public createPlaylist = (params: CreatePlaylistRequestBody) => {
+  public createPlaylist(params: CreatePlaylistRequestBody) {
     return this.post<CreatePlaylistResponse>(`${this.ROUTE_V1}`, params);
-  };
+  }
 
-  public updatePlaylist = (playlistId: Playlist['id'], params: UpdatePlaylistRequestBody) => {
+  public updatePlaylist(playlistId: Playlist['id'], params: UpdatePlaylistRequestBody) {
     return this.patch<UpdatePlaylistResponse>(`${this.ROUTE_V1}/${playlistId}`, params);
-  };
+  }
 
-  public addMusicToPlaylist = (playlistId: Playlist['id'], params: AddPlaylistMusicRequestBody) => {
+  public addMusicToPlaylist(playlistId: Playlist['id'], params: AddPlaylistMusicRequestBody) {
     return this.post<void>(`${this.ROUTE_V1}/${playlistId}/musics`, params);
-  };
+  }
 
-  public removePlaylist = (params: RemovePlaylistRequestBody) => {
+  public removePlaylist(params: RemovePlaylistRequestBody) {
     return this.delete<RemovePlaylistResponse>(`${this.ROUTE_V1}`, {
       data: params,
     });
-  };
+  }
 
-  public removeMusicsFromPlaylist = (params: RemovePlaylistMusicRequestBody) => {
+  public removeMusicsFromPlaylist(params: RemovePlaylistMusicRequestBody) {
     const { playlistId, ...data } = params;
     return this.delete<RemovePlaylistMusicResponse>(`${this.ROUTE_V1}/${playlistId}/musics`, {
       data,
     });
-  };
+  }
 }
 
 const instance = new PlaylistsService();

--- a/src/shared/api/http/services/playlists.ts
+++ b/src/shared/api/http/services/playlists.ts
@@ -21,7 +21,7 @@ import type {
 } from '../types/playlists';
 
 @Singleton
-class PlaylistsService extends HTTPClient implements PlaylistsClient {
+export default class PlaylistsService extends HTTPClient implements PlaylistsClient {
   private ROUTE_V1 = 'v1/playlists';
 
   public getPlaylists() {
@@ -63,6 +63,3 @@ class PlaylistsService extends HTTPClient implements PlaylistsClient {
     });
   }
 }
-
-const instance = new PlaylistsService();
-export default instance;

--- a/src/shared/api/http/services/users.ts
+++ b/src/shared/api/http/services/users.ts
@@ -19,68 +19,68 @@ import type {
 class UsersService extends HTTPClient implements UsersClient {
   private ROUTE_V1 = 'v1/users';
 
-  public signIn = (request: SignInRequest) => {
+  public signIn(request: SignInRequest) {
     if (typeof window === 'undefined') return;
 
     const url = new URL(`${this.axiosInstance.defaults.baseURL}${this.ROUTE_V1}/members/sign`);
     url.searchParams.append('oauth2Provider', request.oauth2Provider);
 
     window.location.href = url.toString();
-  };
+  }
 
-  public signInGuest = () => {
+  public signInGuest() {
     return this.post<void>(`${this.ROUTE_V1}/guests/sign`);
-  };
+  }
 
-  public signOut = () => {
+  public signOut() {
     return this.post<void>(`${this.ROUTE_V1}/logout`);
-  };
+  }
 
-  public temporary_SignInFullCrew = () => {
+  public temporary_SignInFullCrew() {
     return this.post<void>(`${this.ROUTE_V1}/members/sign/temporary/full-member`);
-  };
+  }
 
-  public temporary_SignInAssociateCrew = () => {
+  public temporary_SignInAssociateCrew() {
     return this.post<void>(`${this.ROUTE_V1}/members/sign/temporary/associate-member`);
-  };
+  }
 
-  public getMyInfo = () => {
+  public getMyInfo() {
     return this.get<GetMyInfoResponse>(`${this.ROUTE_V1}/me/info`);
-  };
+  }
 
-  public getUserProfileSummary = (request: GetUserProfileSummaryRequest) => {
+  public getUserProfileSummary(request: GetUserProfileSummaryRequest) {
     return this.get<GetUserProfileSummaryResponse>(
       `${this.ROUTE_V1}/${request.uid}/profile/summary`
     );
-  };
+  }
 
-  public getMyProfileSummary = () => {
+  public getMyProfileSummary() {
     return this.get<GetMyProfileSummaryResponse>(`${this.ROUTE_V1}/me/profile/summary`);
-  };
+  }
 
-  public getMyAvatarBodies = () => {
+  public getMyAvatarBodies() {
     return this.get<AvatarBody[]>(`${this.ROUTE_V1}/me/profile/avatar/bodies`);
-  };
+  }
 
-  public getMyAvatarFaces = () => {
+  public getMyAvatarFaces() {
     return this.get<AvatarFace[]>(`${this.ROUTE_V1}/me/profile/avatar/faces`);
-  };
+  }
 
-  public updateMyWallet = (request: UpdateMyWalletRequest) => {
+  public updateMyWallet(request: UpdateMyWalletRequest) {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/wallet`, request);
-  };
+  }
 
-  public updateMyBio = (request: UpdateMyBioRequest) => {
+  public updateMyBio(request: UpdateMyBioRequest) {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/bio`, request);
-  };
+  }
 
-  public updateMyAvatarFace = (request: UpdateMyAvatarFaceRequest) => {
+  public updateMyAvatarFace(request: UpdateMyAvatarFaceRequest) {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/avatar/face`, request);
-  };
+  }
 
-  public updateMyAvatarBody = (request: UpdateMyAvatarBodyRequest) => {
+  public updateMyAvatarBody(request: UpdateMyAvatarBodyRequest) {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/avatar/body`, request);
-  };
+  }
 }
 
 const instance = new UsersService();

--- a/src/shared/api/http/services/users.ts
+++ b/src/shared/api/http/services/users.ts
@@ -16,7 +16,7 @@ import type {
 } from '../types/users';
 
 @Singleton
-class UsersService extends HTTPClient implements UsersClient {
+export default class UsersService extends HTTPClient implements UsersClient {
   private ROUTE_V1 = 'v1/users';
 
   public signIn(request: SignInRequest) {
@@ -82,6 +82,3 @@ class UsersService extends HTTPClient implements UsersClient {
     return this.put<void>(`${this.ROUTE_V1}/me/profile/avatar/body`, request);
   }
 }
-
-const instance = new UsersService();
-export default instance;

--- a/src/widgets/partyroom-djing-dialog/api/use-register-me-to-queue.mutation.ts
+++ b/src/widgets/partyroom-djing-dialog/api/use-register-me-to-queue.mutation.ts
@@ -9,7 +9,7 @@ export const useRegisterMeToQueue = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, RegisterMeToQueuePayload>({
-    mutationFn: DjsService.registerMeToQueue,
+    mutationFn: (request) => DjsService.registerMeToQueue(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],

--- a/src/widgets/partyroom-djing-dialog/api/use-register-me-to-queue.mutation.ts
+++ b/src/widgets/partyroom-djing-dialog/api/use-register-me-to-queue.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import DjsService from '@/shared/api/http/services/djs';
+import { djsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { RegisterMeToQueuePayload } from '@/shared/api/http/types/djs';
 
@@ -9,7 +9,7 @@ export const useRegisterMeToQueue = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, RegisterMeToQueuePayload>({
-    mutationFn: (request) => DjsService.registerMeToQueue(request),
+    mutationFn: (request) => djsService.registerMeToQueue(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],

--- a/src/widgets/partyroom-djing-dialog/api/use-unregister-me-from-queue.mutation.ts
+++ b/src/widgets/partyroom-djing-dialog/api/use-unregister-me-from-queue.mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import DjsService from '@/shared/api/http/services/djs';
+import { djsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { UnregisterMeFromQueuePayload } from '@/shared/api/http/types/djs';
 
@@ -9,7 +9,7 @@ export const useUnregisterMeFromQueue = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UnregisterMeFromQueuePayload>({
-    mutationFn: (request) => DjsService.unregisterMeFromQueue(request),
+    mutationFn: (request) => djsService.unregisterMeFromQueue(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],

--- a/src/widgets/partyroom-djing-dialog/api/use-unregister-me-from-queue.mutation.ts
+++ b/src/widgets/partyroom-djing-dialog/api/use-unregister-me-from-queue.mutation.ts
@@ -9,7 +9,7 @@ export const useUnregisterMeFromQueue = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, AxiosError<APIError>, UnregisterMeFromQueuePayload>({
-    mutationFn: DjsService.unregisterMeFromQueue,
+    mutationFn: (request) => DjsService.unregisterMeFromQueue(request),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

1. ts 데코레이터는 프로토타입 메서드에 대해서만 동작하고, 인스턴스 메서드에 대해선 동작하지 않습니다. 서비스 메서드에 MockResolve, [SkipGlobalErrorHandling](https://github.com/pfplay/pfplay-web/pull/232/commits/c942cfe2a0c66d610bd6b9c86c709e183994deb7) 등의 데코레이터를 적용하기 위해, 모두 프로토타입 메서드로 변경합니다.
2. 프로토타입 메서드는 인스턴스 메서드와 달리 직접 참조할 시 내부 this 참조가 깨집니다. 이를 방지하기 위해 queryFn, mutationFn에서 메서드를 직점 참조하여 주입하는 부분을 모두 화살표함수로 한 번 래핑합니다. (다음 PR에서, 이 문제를 방지하는 룰을 추가합니다)
3. 서비스 클래스 인스턴스는 생성자가 아니기에 파스칼케이스 >> 카멜케이스로 변경합니다.

### Todo

<!-- 해당 기능을 마무리하기 위해 작업해야할 남은 작업을 적어주세요. -->

2번에 대한 eslint 룰 작성
