### PR TITLE
refactor: "지갑 연결"을 여러 feature에서 사용하기 위해 프로필 수정 feature에 있던 지갑 관련 기능을 entities로 이동

### DIFF
--- a/src/entities/wallet/api/use-fetch-nfts.query.ts
+++ b/src/entities/wallet/api/use-fetch-nfts.query.ts
@@ -12,8 +12,14 @@ const alchemy = new Alchemy({
   network: Network.ETH_MAINNET,
 });
 
-export function useFetchNfts({ isConnected, address }: { isConnected: boolean; address?: string }) {
-  return useQuery<Nft.RefinedModel[], AxiosError<APIError>>({
+export default function useFetchNfts({
+  isConnected,
+  address,
+}: {
+  isConnected: boolean;
+  address?: string;
+}) {
+  return useQuery<Nft.Model[], AxiosError<APIError>>({
     queryKey: [QueryKeys.Nfts],
     queryFn: async () => {
       const getNfts = withLog(alchemy.nft.getNftsForOwner.bind(alchemy.nft), 'get');

--- a/src/entities/wallet/api/use-update-my-walllet.mutation.ts
+++ b/src/entities/wallet/api/use-update-my-walllet.mutation.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { usersService } from '@/shared/api/http/services';
+import { APIError } from '@/shared/api/http/types/@shared';
+import { UpdateMyWalletRequest } from '@/shared/api/http/types/users';
+
+export default function useUpdateMyWallet() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, AxiosError<APIError>, UpdateMyWalletRequest>({
+    mutationFn: (request) => usersService.updateMyWallet(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.Me],
+      });
+    },
+  });
+}

--- a/src/entities/wallet/index.ts
+++ b/src/entities/wallet/index.ts
@@ -1,0 +1,3 @@
+export * as Nft from './model/nft.model';
+export { default as useNfts } from './lib/use-nfts.hook';
+export { default as ConnectWallet } from './ui/connect-wallet.component';

--- a/src/entities/wallet/lib/use-nfts.hook.ts
+++ b/src/entities/wallet/lib/use-nfts.hook.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 import { QueryKeys } from '@/shared/api/http/query-keys';
-import { useFetchNfts } from '../api/use-fetch-nfts.query';
+import useFetchNfts from '../api/use-fetch-nfts.query';
 
 export default function useNfts() {
   const queryClient = useQueryClient();

--- a/src/entities/wallet/model/nft.model.ts
+++ b/src/entities/wallet/model/nft.model.ts
@@ -3,11 +3,11 @@ import axios from 'axios';
 import { SetOptional } from 'type-fest';
 import { AvatarFace } from '@/shared/api/http/types/users';
 
-export type Model = OwnedNft;
+export type RawModel = OwnedNft;
 
-export type RefinedModel = SetOptional<AvatarFace, 'id' | 'name'>;
+export type Model = SetOptional<AvatarFace, 'id' | 'name'>;
 
-export async function refineList(models: Model[]): Promise<RefinedModel[]> {
+export async function refineList(models: RawModel[]): Promise<Model[]> {
   const refined: OwnedNft[] = [];
 
   const checkedList = await Promise.allSettled(imageHealthCheckMap(models));
@@ -26,7 +26,7 @@ export async function refineList(models: Model[]): Promise<RefinedModel[]> {
   }));
 }
 
-function imageHealthCheckMap(list: Model[]) {
+function imageHealthCheckMap(list: RawModel[]) {
   return list.map(async (nft) => {
     if (!nft.image?.thumbnailUrl) return null;
 

--- a/src/entities/wallet/ui/connect-wallet.component.tsx
+++ b/src/entities/wallet/ui/connect-wallet.component.tsx
@@ -1,0 +1,77 @@
+'use client';
+import Image from 'next/image';
+import { ReactNode, useEffect } from 'react';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { useSuspenseFetchMe } from '@/entities/me';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { PFAdd, PFInfoOutline } from '@/shared/ui/icons';
+import useUpdateMyWallet from '../api/use-update-my-walllet.mutation';
+
+type RendererProps = {
+  recommendedText: string;
+  onClick: () => void;
+  icon?: ReactNode;
+};
+
+type ConnectWalletProps = {
+  wrongNetworkRender?: (props: RendererProps) => ReactNode;
+  notConnectedRender?: (props: RendererProps) => ReactNode;
+  connectedRender?: (props: RendererProps) => ReactNode;
+};
+
+export default function ConnectWallet({
+  wrongNetworkRender,
+  notConnectedRender,
+  connectedRender,
+}: ConnectWalletProps) {
+  const t = useI18n();
+  const { data: me } = useSuspenseFetchMe();
+  const { mutate: updateMyWallet } = useUpdateMyWallet();
+
+  return (
+    <ConnectButton.Custom>
+      {({ account, chain, openAccountModal, openChainModal, openConnectModal }) => {
+        const walletConnected = !!account && !!chain;
+
+        useEffect(() => {
+          if (!walletConnected && !!me.walletAddress) {
+            updateMyWallet({ walletAddress: '' });
+          }
+          if (walletConnected && (!me.walletAddress || me.walletAddress !== account.address)) {
+            updateMyWallet({ walletAddress: account.address });
+          }
+        }, [walletConnected]);
+
+        if (chain?.unsupported) {
+          return wrongNetworkRender?.({
+            recommendedText: 'Wrong Network',
+            onClick: openChainModal,
+            icon: <PFInfoOutline />,
+          });
+        }
+
+        if (!walletConnected) {
+          return notConnectedRender?.({
+            recommendedText: t.settings.btn.addi_connection,
+            onClick: openConnectModal,
+            icon: <PFAdd />,
+          });
+        }
+
+        return connectedRender?.({
+          recommendedText: account.displayName,
+          onClick: openAccountModal,
+          icon: chain.hasIcon && chain.iconUrl && (
+            <Image
+              alt={chain.name ?? 'Chain icon'}
+              src={chain.iconUrl}
+              width={16}
+              height={16}
+              className='rounded-[999px] overflow-hidden'
+            />
+          ),
+        });
+      }}
+    </ConnectButton.Custom>
+  );
+}

--- a/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { FC } from 'react';
+import { Nft } from '@/entities/wallet';
 import { AvatarFace } from '@/shared/api/http/types/users';
 import AvatarListItem from './avatar-list-item.component';
 import { useSelectedAvatarState } from '../lib/selected-avatar-state.context';
-import * as Nft from '../model/nft.model';
 
 interface Props {
-  meta: AvatarFace | Nft.RefinedModel;
+  meta: AvatarFace | Nft.Model;
   hideSelected: boolean;
 }
 

--- a/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
@@ -1,5 +1,5 @@
 'use client';
-import SuspenseWithErrorBoundary from '@/shared/api/http/error/suspense-with-error-boundary.component';
+import { useNfts } from '@/entities/wallet';
 import { cn } from '@/shared/lib/functions/cn';
 import { useVerticalStretch } from '@/shared/lib/hooks/use-vertical-stretch.hook';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
@@ -9,7 +9,6 @@ import AvatarFaceListItem from './avatar-face-list-item.component';
 import ConnectWalletButton from './connect-wallet-button.component';
 import { useFetchAvatarFaces } from '../api/use-fetch-avatar-faces.query';
 import { useSelectedAvatarState } from '../lib/selected-avatar-state.context';
-import useNfts from '../lib/use-nfts.hook';
 
 const AvatarFaceList = () => {
   const t = useI18n();
@@ -25,9 +24,7 @@ const AvatarFaceList = () => {
   return (
     <div ref={containerRef} className='flex-1 flexCol gap-4 overflow-hidden'>
       <div className='flexRow justify-end items-center gap-3'>
-        <SuspenseWithErrorBoundary>
-          <ConnectWalletButton />
-        </SuspenseWithErrorBoundary>
+        <ConnectWalletButton />
       </div>
       <div
         className={cn(

--- a/src/features/edit-profile-avatar/ui/connect-wallet-button.component.tsx
+++ b/src/features/edit-profile-avatar/ui/connect-wallet-button.component.tsx
@@ -1,87 +1,47 @@
 'use client';
-import Image from 'next/image';
-import { useEffect } from 'react';
-import { ConnectButton } from '@rainbow-me/rainbowkit';
-import { useSuspenseFetchMe } from '@/entities/me';
-import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { ConnectWallet } from '@/entities/wallet';
+import SuspenseWithErrorBoundary from '@/shared/api/http/error/suspense-with-error-boundary.component';
 import { Button } from '@/shared/ui/components/button';
-import { PFAdd, PFInfoOutline } from '@/shared/ui/icons';
-import { useUpdateMyWallet } from '../api/use-update-my-walllet.mutation';
 
-const ConnectWalletButton = () => {
-  const t = useI18n();
-  const { data: me } = useSuspenseFetchMe();
-  const { mutate: updateMyWallet } = useUpdateMyWallet();
-
+export default function ConnectWalletButton() {
   return (
-    <ConnectButton.Custom>
-      {({ account, chain, openAccountModal, openChainModal, openConnectModal }) => {
-        const walletConnected = !!account && !!chain;
-
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        useEffect(() => {
-          if (!walletConnected && !!me.walletAddress) {
-            updateMyWallet({ walletAddress: '' });
-          }
-          if (walletConnected && (!me.walletAddress || me.walletAddress !== account.address)) {
-            updateMyWallet({ walletAddress: account.address });
-          }
-        }, [walletConnected]);
-
-        if (chain?.unsupported) {
-          return (
-            <Button
-              variant='outline'
-              color='primary'
-              className='px-[24px]'
-              Icon={<PFInfoOutline />}
-              onClick={openChainModal}
-            >
-              Wrong Network
-            </Button>
-          );
-        }
-
-        return (
-          <>
-            {!walletConnected ? (
-              <Button
-                variant='fill'
-                color='secondary'
-                className='px-[24px]'
-                Icon={<PFAdd />}
-                onClick={openConnectModal}
-              >
-                {t.settings.btn.addi_connection}
-                {/* FIXME: 추가 연결하기 문구는 지갑 이미 연결했을 때만 보여주기 - https://pfplay.slack.com/archives/C03QTFBU8QG/p1719734409860379?thread_ts=1719722146.310099&cid=C03QTFBU8QG */}
-              </Button>
-            ) : (
-              <Button
-                variant='outline'
-                color='secondary'
-                className='px-[24px]'
-                Icon={
-                  chain.hasIcon &&
-                  chain.iconUrl && (
-                    <Image
-                      alt={chain.name ?? 'Chain icon'}
-                      src={chain.iconUrl}
-                      width={16}
-                      height={16}
-                      className='rounded-[999px] overflow-hidden'
-                    />
-                  )
-                }
-                onClick={openAccountModal}
-              >
-                {account.displayName}
-              </Button>
-            )}
-          </>
-        );
-      }}
-    </ConnectButton.Custom>
+    <SuspenseWithErrorBoundary>
+      <ConnectWallet
+        wrongNetworkRender={({ recommendedText, onClick, icon }) => (
+          <Button
+            variant='outline'
+            color='primary'
+            className='px-[24px]'
+            Icon={icon}
+            onClick={onClick}
+          >
+            {recommendedText}
+          </Button>
+        )}
+        notConnectedRender={({ recommendedText, onClick, icon }) => (
+          <Button
+            variant='fill'
+            color='secondary'
+            className='px-[24px]'
+            Icon={icon}
+            onClick={onClick}
+          >
+            {recommendedText}
+          </Button>
+        )}
+        connectedRender={({ recommendedText, onClick, icon }) => (
+          <Button
+            variant='outline'
+            color='secondary'
+            className='px-[24px]'
+            Icon={icon}
+            onClick={onClick}
+          >
+            {recommendedText}
+            {/* FIXME: 지갑 이미 연결했는데 받아온 nft 목록이 없다면 "추가 연결하기" 문구 보여주기 - https://pfplay.slack.com/archives/C03QTFBU8QG/p1719734409860379?thread_ts=1719722146.310099&cid=C03QTFBU8QG */}
+          </Button>
+        )}
+      />
+    </SuspenseWithErrorBoundary>
   );
-};
-
-export default ConnectWalletButton;
+}


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

"지갑 연결"을 여러 feature에서 사용하기 위해 edit-profile-avatar feature에 있던 지갑 관련 기능을 entities로 이동합니다.

ConnectWallet 컴포넌트 뷰를 유연성 있게 확장한게 핵심 변경입니다.