### PR TITLE
fix: 게스트 로그인 시 401 나면서 진입화면으로 팅기는 문제

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePrefetchMe } from '@/entities/me';
 import { SignInByGoogleButtonForDev, useSignInByGoogle } from '@/features/sign-in/by-google';
 import { useSignInByGuest } from '@/features/sign-in/by-guest';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
@@ -13,10 +14,12 @@ export default function SignInPage() {
   const t = useI18n();
   const router = useAppRouter();
 
+  const prefetchMe = usePrefetchMe();
   const signInByGoogle = useSignInByGoogle();
   const signInByGuest = useSignInByGuest({
     onClickSignInByGoogle: signInByGoogle,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await prefetchMe();
       router.push('/parties');
     },
   });

--- a/src/entities/me/api/use-prefetch-me.query.ts
+++ b/src/entities/me/api/use-prefetch-me.query.ts
@@ -1,0 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { queryOptions } from '@/entities/me/api/use-fetch-me.query';
+
+export default function usePrefetchMe() {
+  const queryClient = useQueryClient();
+
+  return async () => {
+    await queryClient.prefetchQuery(queryOptions);
+  };
+}

--- a/src/entities/me/index.ts
+++ b/src/entities/me/index.ts
@@ -1,5 +1,6 @@
 export * as Me from './model/me.model';
 export { useFetchMe, useSuspenseFetchMe } from './api/use-fetch-me.query';
+export { default as usePrefetchMe } from './api/use-prefetch-me.query';
 export { useFetchMeAsync } from './api/use-fetch-me-async';
 export { useGetMyServiceEntry } from './api/use-get-my-service-entry';
 export { default as MeHydration } from './ui/hydration.component';


### PR DESCRIPTION
### Summary

<!-- PR에 대해서 간단하게 소개 부탁드립니다. -->

게스트 로그인 시에만 특정 컴포넌트의 me 호출에서 401이 나서 / 로 돌아가는데,

명확히 어떤 컴포넌트에서 me가 호출되며 원인이 뭔지 나중에 파봐야 합니다.

일단 페이지 이동 전 prefetch로 해결합니다