### PR TITLE
fix: 국가 코드 감지 fallback 추가

### DIFF
--- a/src/shared/lib/functions/detect-country-code.test.ts
+++ b/src/shared/lib/functions/detect-country-code.test.ts
@@ -5,48 +5,81 @@ afterEach(() => {
 });
 
 describe('detectCountryCode', () => {
-  test('"ko-KR"이면 "KR"을 반환한다', () => {
-    vi.stubGlobal('navigator', { language: 'ko-KR' });
-    expect(detectCountryCode()).toBe('KR');
+  describe('navigator.language에서 직접 추출', () => {
+    test('"ko-KR"이면 "KR"을 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'ko-KR', languages: ['ko-KR'] });
+      expect(detectCountryCode()).toBe('KR');
+    });
+
+    test('"en-US"이면 "US"를 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'en-US', languages: ['en-US'] });
+      expect(detectCountryCode()).toBe('US');
+    });
+
+    test('"ja-JP"이면 "JP"를 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'ja-JP', languages: ['ja-JP'] });
+      expect(detectCountryCode()).toBe('JP');
+    });
+
+    test('"zh-TW"이면 "TW"를 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'zh-TW', languages: ['zh-TW'] });
+      expect(detectCountryCode()).toBe('TW');
+    });
+
+    test('국가 코드를 대문자로 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'en-gb', languages: ['en-gb'] });
+      expect(detectCountryCode()).toBe('GB');
+    });
   });
 
-  test('"en-US"이면 "US"를 반환한다', () => {
-    vi.stubGlobal('navigator', { language: 'en-US' });
-    expect(detectCountryCode()).toBe('US');
+  describe('navigator.languages fallback', () => {
+    test('language에 지역 코드가 없으면 languages에서 찾는다', () => {
+      vi.stubGlobal('navigator', { language: 'ko', languages: ['ko', 'en-US'] });
+      expect(detectCountryCode()).toBe('US');
+    });
+
+    test('languages의 첫 번째 지역 코드를 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'en', languages: ['en', 'ko-KR', 'ja-JP'] });
+      expect(detectCountryCode()).toBe('KR');
+    });
   });
 
-  test('"ja-JP"이면 "JP"를 반환한다', () => {
-    vi.stubGlobal('navigator', { language: 'ja-JP' });
-    expect(detectCountryCode()).toBe('JP');
+  describe('언어 코드 → 국가 코드 매핑 fallback', () => {
+    test('"ko"만 있으면 매핑으로 "KR"을 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'ko', languages: ['ko', 'en'] });
+      expect(detectCountryCode()).toBe('KR');
+    });
+
+    test('"ja"만 있으면 매핑으로 "JP"를 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'ja', languages: ['ja'] });
+      expect(detectCountryCode()).toBe('JP');
+    });
+
+    test('"vi"만 있으면 매핑으로 "VN"을 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'vi', languages: ['vi'] });
+      expect(detectCountryCode()).toBe('VN');
+    });
+
+    test('매핑에 없는 언어("en")만 있으면 null을 반환한다', () => {
+      vi.stubGlobal('navigator', { language: 'en', languages: ['en'] });
+      expect(detectCountryCode()).toBeNull();
+    });
   });
 
-  test('"zh-TW"이면 "TW"를 반환한다', () => {
-    vi.stubGlobal('navigator', { language: 'zh-TW' });
-    expect(detectCountryCode()).toBe('TW');
-  });
+  describe('edge cases', () => {
+    test('빈 문자열이면 null을 반환한다', () => {
+      vi.stubGlobal('navigator', { language: '', languages: [] });
+      expect(detectCountryCode()).toBeNull();
+    });
 
-  test('국가 코드 없이 언어만 있으면 null을 반환한다 ("ko")', () => {
-    vi.stubGlobal('navigator', { language: 'ko' });
-    expect(detectCountryCode()).toBeNull();
-  });
+    test('navigator가 undefined이면 null을 반환한다 (SSR)', () => {
+      vi.stubGlobal('navigator', undefined);
+      expect(detectCountryCode()).toBeNull();
+    });
 
-  test('국가 코드 없이 언어만 있으면 null을 반환한다 ("en")', () => {
-    vi.stubGlobal('navigator', { language: 'en' });
-    expect(detectCountryCode()).toBeNull();
-  });
-
-  test('빈 문자열이면 null을 반환한다', () => {
-    vi.stubGlobal('navigator', { language: '' });
-    expect(detectCountryCode()).toBeNull();
-  });
-
-  test('navigator가 undefined이면 null을 반환한다 (SSR)', () => {
-    vi.stubGlobal('navigator', undefined);
-    expect(detectCountryCode()).toBeNull();
-  });
-
-  test('국가 코드를 대문자로 반환한다', () => {
-    vi.stubGlobal('navigator', { language: 'en-gb' });
-    expect(detectCountryCode()).toBe('GB');
+    test('languages가 없어도 매핑 fallback이 동작한다', () => {
+      vi.stubGlobal('navigator', { language: 'ko' });
+      expect(detectCountryCode()).toBe('KR');
+    });
   });
 });

--- a/src/shared/lib/functions/detect-country-code.ts
+++ b/src/shared/lib/functions/detect-country-code.ts
@@ -1,23 +1,70 @@
 /**
- * navigator.language에서 ISO 3166-1 alpha-2 국가 코드를 추출한다.
+ * 1:1 대응이 명확한 언어 코드 → 국가 코드 매핑.
+ * 여러 나라에서 쓰는 언어(en, es, fr, pt 등)는 의도적으로 제외.
+ */
+const LANG_TO_COUNTRY: Record<string, string> = {
+  ko: 'KR',
+  ja: 'JP',
+  uk: 'UA',
+  vi: 'VN',
+  th: 'TH',
+  he: 'IL',
+  hi: 'IN',
+  bn: 'BD',
+  ka: 'GE',
+  hy: 'AM',
+  km: 'KH',
+  mn: 'MN',
+  my: 'MM',
+  ne: 'NP',
+  si: 'LK',
+  lo: 'LA',
+};
+
+/**
+ * 브라우저 언어 설정에서 ISO 3166-1 alpha-2 국가 코드를 추출한다.
  * 브라우저 환경이 아니거나 추출 불가한 경우 null을 반환한다.
+ *
+ * 탐색 순서:
+ * 1. navigator.language에서 지역 코드 추출 (e.g. "ko-KR" → "KR")
+ * 2. navigator.languages에서 지역 코드가 포함된 항목 탐색
+ * 3. 언어 코드 → 국가 코드 매핑 (e.g. "ko" → "KR")
  *
  * @example
  * // navigator.language === "ko-KR"
  * detectCountryCode() // "KR"
  *
- * // navigator.language === "en"
- * detectCountryCode() // null
+ * // navigator.language === "ko", navigator.languages === ["ko", "en"]
+ * detectCountryCode() // "KR" (fallback via lang-to-country map)
  */
 export function detectCountryCode(): string | null {
   if (typeof navigator === 'undefined' || !navigator?.language) {
     return null;
   }
 
-  const parts = navigator.language.split('-');
-  if (parts.length < 2 || !parts[1]) {
-    return null;
+  // 1. navigator.language에서 직접 추출
+  const fromPrimary = extractCountryCode(navigator.language);
+  if (fromPrimary) return fromPrimary;
+
+  // 2. navigator.languages에서 지역 코드가 포함된 항목 탐색
+  if (navigator.languages) {
+    for (const lang of navigator.languages) {
+      const code = extractCountryCode(lang);
+      if (code) return code;
+    }
   }
 
+  // 3. 언어 코드 → 국가 코드 매핑 (1:1 대응 언어만)
+  const langCode = navigator.language.split('-')[0]?.toLowerCase();
+  if (langCode && LANG_TO_COUNTRY[langCode]) {
+    return LANG_TO_COUNTRY[langCode];
+  }
+
+  return null;
+}
+
+function extractCountryCode(locale: string): string | null {
+  const parts = locale.split('-');
+  if (parts.length < 2 || !parts[1]) return null;
   return parts[1].toUpperCase();
 }


### PR DESCRIPTION
## Summary
- `navigator.language`가 `"ko"`처럼 지역 코드 없이 반환되는 환경에서 국기가 표시되지 않던 버그 수정
- 3단계 fallback: language → languages 배열 → 언어-국가 1:1 매핑 (`ko→KR`, `ja→JP` 등)

## 원인
- 일부 브라우저/OS 환경에서 `navigator.language`가 `"ko"`, `navigator.languages`가 `["ko", "en"]`으로 지역 코드를 포함하지 않음
- 기존 `detectCountryCode()`는 `"ko-KR"` 형식만 처리 → `null` 반환 → countryCode 미전송

## Test plan
- [x] 기존 테스트 업데이트 + fallback 케이스 14개 테스트 통과
- [x] `navigator.language === "ko"` 환경에서 `"KR"` 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)