### PR TITLE
e2e: Enhance E2E workflow with debug job and conditions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,25 +1,37 @@
 name: E2E Tests
-
 # 사전 조건:
 #   - Vercel GitHub App이 이 저장소에 연결되어 있어야 한다.
 #   - Vercel 프로젝트의 Preview 환경 변수에 NEXT_PUBLIC_ENABLE_DEV_LOGIN=true 설정 필요.
 #       (개발용 테스트가 Vercel preview에서도 노출되도록)
 #   - Production에는 dev login 우회 플로우가 없으므로 Preview 배포에서만 실행한다.
 on:
-  deployment_status: # 테스트는 Vercel 배포 완료 후 트리거 (push 직후엔 빌드 중인 서버 대상으로 테스트가 실행될 수 있기 때문)
-
-env:
-  E2E_BASE_URL: ${{ github.event.deployment_status.target_url }} # 방금 배포된 URL
+  # 테스트는 Vercel 배포 완료 후 트리거 (push 직후엔 빌드 중인 서버 대상으로 테스트가 실행될 수 있기 때문)
+  deployment_status 
 
 jobs:
+  debug-deployment:
+    name: Debug deployment payload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print deployment values
+        run: |
+          echo 'deployment.environment = ${{ github.event.deployment.environment }}'
+          echo 'deployment_status.state = ${{ github.event.deployment_status.state }}'
+          echo 'deployment_status.target_url = ${{ github.event.deployment_status.target_url }}'
+          echo '${{ toJson(github.event) }}'
+
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: debug-deployment
     # Vercel Preview 배포가 성공한 경우에만 실행 (Production / pending / error / failure 시 스킵)
     if: >
       github.event.deployment_status.state == 'success' &&
       github.event.deployment.environment == 'Preview'
+    env:
+      E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -37,10 +49,9 @@ jobs:
           key: playwright-${{ hashFiles('**/yarn.lock') }}
 
       - run: npx playwright install --with-deps chromium
-
       - run: yarn test:e2e --project=e2e
 
-      - uses: actions/upload-artifact@v4 # 테스트 결과 업로드
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ name: E2E Tests
 #   - Production에는 dev login 우회 플로우가 없으므로 Preview 배포에서만 실행한다.
 on:
   # 테스트는 Vercel 배포 완료 후 트리거 (push 직후엔 빌드 중인 서버 대상으로 테스트가 실행될 수 있기 때문)
-  deployment_status 
+  deployment_status
 
 jobs:
   debug-deployment:
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: debug-deployment
+    environment: Preview
     # Vercel Preview 배포가 성공한 경우에만 실행 (Production / pending / error / failure 시 스킵)
     if: >
       github.event.deployment_status.state == 'success' &&
@@ -50,6 +51,8 @@ jobs:
 
       - run: npx playwright install --with-deps chromium
       - run: yarn test:e2e --project=e2e
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,11 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: debug-deployment
-    environment: Preview
+    environment: Preview – pfplay-web
     # Vercel Preview 배포가 성공한 경우에만 실행 (Production / pending / error / failure 시 스킵)
+    # dev-8226s-projects Vercel 계정 배포만 대상으로 함 (pfplay 계정 배포는 환경변수 미설정으로 제외)
     if: >
       github.event.deployment_status.state == 'success' &&
-      startsWith(github.event.deployment.environment, 'Preview')
+      startsWith(github.event.deployment.environment, 'Preview') &&
+      contains(github.event.deployment_status.target_url, 'dev-8226s-projects')
     env:
       E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
     # Vercel Preview 배포가 성공한 경우에만 실행 (Production / pending / error / failure 시 스킵)
     if: >
       github.event.deployment_status.state == 'success' &&
-      github.event.deployment.environment == 'Preview'
+      startsWith(github.event.deployment.environment, 'Preview')
     env:
       E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,39 +1,42 @@
 name: E2E Tests
+
 # 사전 조건:
-#   - Vercel GitHub App이 이 저장소에 연결되어 있어야 한다.
-#   - Vercel 프로젝트의 Preview 환경 변수에 NEXT_PUBLIC_ENABLE_DEV_LOGIN=true 설정 필요.
-#       (개발용 테스트가 Vercel preview에서도 노출되도록)
-#   - Production에는 dev login 우회 플로우가 없으므로 Preview 배포에서만 실행한다.
+#   - Vercel GitHub App(dev-8226s-projects 계정)이 이 저장소에 연결되어 있어야 한다.
+#   - Vercel 프로젝트 Preview 환경 변수에 NEXT_PUBLIC_ENABLE_DEV_LOGIN=true 설정 필요.
+#   - GitHub Environment 'Preview – pfplay-web'에 VERCEL_AUTOMATION_BYPASS_SECRET 설정 필요.
+#
+# 실행 조건:
+#   - development 브랜치가 Vercel에 배포 완료된 시점에만 실행
+#   - 백엔드 스테이징 서버가 stg.pfplay.xyz origin만 허용하므로 E2E_BASE_URL을 고정
+#   - feature 브랜치 Preview 배포는 백엔드 CORS 미허용으로 실행 불가
 on:
-  # 테스트는 Vercel 배포 완료 후 트리거 (push 직후엔 빌드 중인 서버 대상으로 테스트가 실행될 수 있기 때문)
   deployment_status
 
 jobs:
-  debug-deployment:
-    name: Debug deployment payload
+  log-deployment:
+    name: Log deployment info
     runs-on: ubuntu-latest
     steps:
       - name: Print deployment values
         run: |
-          echo 'deployment.environment = ${{ github.event.deployment.environment }}'
-          echo 'deployment_status.state = ${{ github.event.deployment_status.state }}'
-          echo 'deployment_status.target_url = ${{ github.event.deployment_status.target_url }}'
-          echo '${{ toJson(github.event) }}'
+          echo "state        = ${{ github.event.deployment_status.state }}"
+          echo "target_url   = ${{ github.event.deployment_status.target_url }}"
+          echo "environment  = ${{ github.event.deployment.environment }}"
+          echo "ref          = ${{ github.event.deployment.ref }}"
 
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: debug-deployment
     environment: Preview – pfplay-web
-    # Vercel Preview 배포가 성공한 경우에만 실행 (Production / pending / error / failure 시 스킵)
-    # dev-8226s-projects Vercel 계정 배포만 대상으로 함 (pfplay 계정 배포는 환경변수 미설정으로 제외)
+    # dev-8226s-projects 계정의 development 브랜치 Preview 배포 완료 시에만 실행
+    # target_url 패턴: pfplay-git-development-dev-8226s-projects.vercel.app
     if: >
       github.event.deployment_status.state == 'success' &&
-      startsWith(github.event.deployment.environment, 'Preview') &&
+      contains(github.event.deployment_status.target_url, 'git-development') &&
       contains(github.event.deployment_status.target_url, 'dev-8226s-projects')
     env:
-      E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
+      E2E_BASE_URL: https://stg.pfplay.xyz
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,0 +1,119 @@
+# CI/CD 워크플로우
+
+> Last Update (26.04.25)
+
+GitHub Actions 워크플로우 5개로 구성되며, 브랜치 및 이벤트 종류에 따라 실행 여부가 결정됩니다.
+
+---
+
+## 워크플로우 목록
+
+| 파일                     | 이름               | 트리거                          |
+| ------------------------ | ------------------ | ------------------------------- |
+| `lint-check.yml`         | lint check         | 모든 PR                         |
+| `vercel-build-check.yml` | vercel build check | `development`, `main` 대상 PR   |
+| `vercel-preview.yml`     | vercel preview     | `development` 브랜치 push       |
+| `vercel-production.yml`  | vercel production  | `main` 브랜치 push              |
+| `e2e.yml`                | E2E Tests          | Vercel deployment_status 이벤트 |
+
+---
+
+## 브랜치별 흐름
+
+### feature 브랜치
+
+```
+feature 브랜치 작업
+│
+├─ [push]
+│   └── Vercel GitHub App: feature Preview 자동 배포
+│       └── deployment_status 이벤트 → e2e 조건 불충족 (스킵)
+│           이유: target_url에 'git-development' 미포함
+│
+└─ [PR → development 오픈]
+    ├── lint-check ✅
+    └── vercel-build-check ✅
+```
+
+**실행되는 워크플로우:** lint-check, vercel-build-check (PR 오픈 시)
+
+---
+
+### development 브랜치
+
+```
+feature → development PR 머지 (또는 직접 push)
+│
+├─ vercel-preview ✅
+│   └── CLI로 Vercel Preview 배포 → stg.pfplay.xyz 업데이트
+│
+└─ Vercel GitHub App: development Preview 자동 배포
+    └── deployment_status 이벤트 발행
+        └── e2e 조건 검사
+            ├── state == 'success' ✅
+            ├── target_url contains 'git-development' ✅
+            └── target_url contains 'dev-8226s-projects' ✅
+                → e2e ✅ (E2E_BASE_URL: https://stg.pfplay.xyz)
+```
+
+**실행되는 워크플로우:** vercel-preview, e2e
+
+> **참고:** `vercel-preview`(CLI)와 Vercel GitHub App이 동시에 배포를 실행해 development push마다 Vercel 배포가 2회 발생합니다.
+
+---
+
+### main 브랜치
+
+```
+development → main PR 머지 (또는 직접 push)
+│
+├─ vercel-production ✅
+│   └── CLI로 Vercel Production 배포
+│
+└─ Vercel GitHub App: Production 자동 배포
+    └── deployment_status 이벤트 발행
+        └── e2e 조건 검사
+            └── target_url에 'git-development' 미포함 → e2e 스킵 ✅
+```
+
+**실행되는 워크플로우:** vercel-production
+
+---
+
+## e2e 실행 조건 상세
+
+e2e는 `deployment_status` 이벤트 기반으로 동작합니다.
+
+```yaml
+if: >
+  github.event.deployment_status.state == 'success' &&
+  contains(github.event.deployment_status.target_url, 'git-development') &&
+  contains(github.event.deployment_status.target_url, 'dev-8226s-projects')
+```
+
+| 조건                                  | 의미                           |
+| ------------------------------------- | ------------------------------ |
+| `state == 'success'`                  | 배포 완료 후에만 실행          |
+| `contains(..., 'git-development')`    | development 브랜치 배포만 대상 |
+| `contains(..., 'dev-8226s-projects')` | 올바른 Vercel 계정 배포만 대상 |
+
+**E2E_BASE_URL이 `https://stg.pfplay.xyz`로 고정된 이유:**
+백엔드 스테이징 서버가 `stg.pfplay.xyz` origin만 허용합니다. feature 브랜치의 Vercel Preview URL(`*.vercel.app`)은 CORS 차단으로 API 호출이 불가합니다.
+
+---
+
+## 필요한 설정값
+
+### Vercel
+
+| 계정               | 프로젝트   | 설정                                                                       |
+| ------------------ | ---------- | -------------------------------------------------------------------------- |
+| dev-8226s-projects | pfplay-web | GitHub App 연동, `NEXT_PUBLIC_ENABLE_DEV_LOGIN=true` (Preview 환경변수)    |
+| dev-8226s-projects | pfplay-web | Settings → Deployment Protection → Protection Bypass for Automation 활성화 |
+
+### GitHub
+
+| 위치                                            | 키                                | 값                              |
+| ----------------------------------------------- | --------------------------------- | ------------------------------- |
+| Environments → `Preview – pfplay-web` → Secrets | `VERCEL_AUTOMATION_BYPASS_SECRET` | Vercel Protection Bypass secret |
+| Secrets → Repository                            | `VERCEL_TOKEN`                    | Vercel CLI 배포용 토큰          |

--- a/docs/DOCS_ENTRY.md
+++ b/docs/DOCS_ENTRY.md
@@ -8,6 +8,7 @@
 
 - [docs/README.md](./README.md) - 프로젝트의 전반적인 개요, 설정 방법, 실행 방법 등을 안내합니다. 프로젝트를 처음 시작하거나 전체 구조를 파악하고 싶을 때 읽어보세요.
 - [docs/CONTRIBUTING.md](./CONTRIBUTING.md) - 프로젝트에 기여하는 방법을 안내합니다. 코드 스타일, 브랜치 전략, PR 규칙 등을 확인할 수 있습니다.
+- [docs/CI_CD.md](./CI_CD.md) - GitHub Actions 워크플로우 구성을 설명합니다. feature/development/main 브랜치별 실행 조건, e2e 트리거 조건, 필요한 설정값을 확인할 수 있습니다.
 - [docs/FLOW.md](./FLOW.md) - 프로젝트의 주요 기능 흐름 또는 개발 워크플로우를 설명합니다. 특정 기능의 동작 방식이나 전체적인 서비스 흐름을 이해하고 싶을 때 유용합니다.
 - [docs/REACT_QUERY.md](./REACT_QUERY.md) - 서버 상태 관리를 위한 React Query 라이브러리 사용 가이드. API 데이터 호출, 캐싱, 동기화 등을 효율적으로 처리하고 싶을 때 참고하세요.
 - [docs/TESTING.md](./TESTING.md) - 테스트 작성 가이드. 테스트 기법(유닛/통합), MSW 인프라, 파일 네이밍 컨벤션, 패턴별 코드 예시 등을 확인할 수 있습니다.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -6,7 +6,12 @@ import { ETHEREUM_MOCK_SCRIPT } from './fixtures/ethereum-mock';
 const AUTH_DIR = path.join(__dirname, '.auth');
 
 async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const context = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+      ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+      : {},
+  });
   const page = await context.newPage();
   await page.addInitScript(ETHEREUM_MOCK_SCRIPT);
   await page.goto(`${baseURL}/sign-in`);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
     trace: 'on-first-retry',
     video: 'on-first-retry',
     ignoreHTTPSErrors: true,
+    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+      ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+      : {},
   },
 
   projects: [


### PR DESCRIPTION
### Before

e2e 파이프라인이 development 브랜치에서 감지되지 않음. 


### After                                                                                
  - Vercel Deployment Protection bypass 헤더를 auth context에 직접 적용
    (playwright.config의 extraHTTPHeaders는 수동 생성 context에 미적용)                  
  - GitHub Environment 이름 불일치 수정 → VERCEL_AUTOMATION_BYPASS_SECRET 정상 주입      
  - dev-8226s-projects 계정 URL 필터 추가 (pfplay 계정 배포는 환경변수 미설정)           
  - e2e 실행 시점을 development 브랜치 배포로 한정 (백엔드 CORS 제약)                    
  - E2E_BASE_URL을 stg.pfplay.xyz로 고정                                                 
  - CI/CD 워크플로우 문서화 (docs/CI_CD.md)

