### PR TITLE
fix(analytics): amplitude user_id < 5자면 SDK reset + opt-out (B1)

### DIFF
--- a/src/shared/lib/analytics/index.test.ts
+++ b/src/shared/lib/analytics/index.test.ts
@@ -98,14 +98,50 @@ describe('analytics module', () => {
   });
 
   describe('setUserId', () => {
-    test('forwards uid to amplitude.setUserId', () => {
-      setUserId('uid-123');
-      expect(amplitude.setUserId).toHaveBeenCalledWith('uid-123');
+    test('forwards uid to amplitude.setUserId (TSID-shaped, ≥5 chars)', () => {
+      setUserId('840855859502003195');
+      expect(amplitude.setUserId).toHaveBeenCalledWith('840855859502003195');
+      expect(amplitude.reset).not.toHaveBeenCalled();
     });
 
-    test('translates null to undefined for amplitude.setUserId', () => {
+    test('translates null to undefined (sign-out)', () => {
       setUserId(null);
       expect(amplitude.setUserId).toHaveBeenCalledWith(undefined);
+      expect(amplitude.reset).not.toHaveBeenCalled();
+    });
+
+    test('translates undefined to undefined (sign-out)', () => {
+      setUserId(undefined);
+      expect(amplitude.setUserId).toHaveBeenCalledWith(undefined);
+    });
+
+    test('uid < 5 chars (super-admin V5 placeholder "1") triggers SDK reset + opt-out', () => {
+      setUserId('1');
+      expect(amplitude.setUserId).not.toHaveBeenCalled();
+      expect(amplitude.reset).toHaveBeenCalledTimes(1);
+    });
+
+    test('opt-out blocks subsequent track and identify', () => {
+      setUserId('1');
+      track('User Signed In', { auth_type: 'member' });
+      identify({ set: { authority_tier: 'FM' } });
+      expect(amplitude.track).not.toHaveBeenCalled();
+      expect(amplitude.identify).not.toHaveBeenCalled();
+    });
+
+    test('valid uid after opt-out re-enables tracking', () => {
+      setUserId('1');
+      setUserId('840855859502003195');
+      track('User Signed In', { auth_type: 'member' });
+      expect(amplitude.track).toHaveBeenCalledTimes(1);
+      expect(amplitude.setUserId).toHaveBeenLastCalledWith('840855859502003195');
+    });
+
+    test('null uid after opt-out re-enables tracking (sign-out path)', () => {
+      setUserId('1');
+      setUserId(null);
+      track('Session Started');
+      expect(amplitude.track).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -6,6 +6,17 @@ let sdk: AmplitudeModule | null = null;
 let sdkLoadPromise: Promise<AmplitudeModule> | null = null;
 let pendingActions: Array<(sdk: AmplitudeModule) => void> = [];
 let initialized = false;
+// amplitude HTTP V2 API rejects user_id < 5 chars. super-admin V5 placeholder
+// (user_account.id = 1) trips this. Set on invalid setUserId — until next valid
+// setUserId or resetAnalyticsUser, all track/identify become no-ops to avoid 400s.
+let optedOut = false;
+
+const AMPLITUDE_USER_ID_MIN_LENGTH = 5;
+
+function isValidAmplitudeUserId(userId: string | null | undefined): boolean {
+  if (typeof userId !== 'string') return false;
+  return userId.length >= AMPLITUDE_USER_ID_MIN_LENGTH;
+}
 
 function getApiKey(): string | undefined {
   return process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
@@ -53,7 +64,7 @@ export function initAnalytics(): void {
 }
 
 export function track<E extends EventName>(event: E, properties?: EventPropertyMap[E]): void {
-  if (!isEnabled()) return;
+  if (!isEnabled() || optedOut) return;
   callSdk((sdk) => {
     sdk.track(event, properties as Record<string, unknown> | undefined);
   });
@@ -61,13 +72,32 @@ export function track<E extends EventName>(event: E, properties?: EventPropertyM
 
 export function setUserId(userId: string | null | undefined): void {
   if (!isEnabled()) return;
+
+  // null/undefined = sign-out 등 식별 해제. opt-out 해제 + amplitude reset.
+  if (userId === null || userId === undefined) {
+    optedOut = false;
+    callSdk((sdk) => {
+      sdk.setUserId(undefined);
+    });
+    return;
+  }
+
+  if (!isValidAmplitudeUserId(userId)) {
+    optedOut = true;
+    callSdk((sdk) => {
+      sdk.reset();
+    });
+    return;
+  }
+
+  optedOut = false;
   callSdk((sdk) => {
-    sdk.setUserId(userId ?? undefined);
+    sdk.setUserId(userId);
   });
 }
 
 export function identify(ops: UserPropertyOps): void {
-  if (!isEnabled()) return;
+  if (!isEnabled() || optedOut) return;
 
   callSdk((sdk) => {
     const id = new sdk.Identify();
@@ -95,6 +125,7 @@ export function identify(ops: UserPropertyOps): void {
 
 export function resetAnalyticsUser(): void {
   if (!isEnabled()) return;
+  optedOut = false;
   callSdk((sdk) => {
     sdk.reset();
   });
@@ -105,6 +136,7 @@ export function __resetForTests(): void {
   sdk = null;
   sdkLoadPromise = null;
   pendingActions = [];
+  optedOut = false;
 }
 
 /**


### PR DESCRIPTION
## Summary

amplitude HTTP V2 API 가 user_id 5자 미만을 reject (400). super-admin V5 placeholder (user_account.id = 1) 가 1자라 super-admin 화면 활동마다 amplitude 400 발생.

본 PR 은 즉시 fix (B1, 길이 검증). 추가 admin 콘솔에서 만들어진 admin 의 일괄 opt-out 은 별도 PR (B2, backend me API isAdmin 추가) 로 진행 예정.

## Changes

`src/shared/lib/analytics/index.ts`:
- `setUserId(uid)` 분기:
  - `null/undefined` (sign-out): opt-out 해제 + `amplitude.setUserId(undefined)`
  - 5자 미만 (super-admin "1"): `amplitude.reset()` + 모듈 `optedOut = true`
  - 5자 이상 (TSID 18-19자, 일반/추가 admin 모두 포함): 정상 setUserId
- `track / identify`: `optedOut` 면 no-op
- `resetAnalyticsUser`: opt-out 해제

## Backend ID 규칙 검토 결과

| 케이스 | user_id | 길이 | 본 PR 적용 후 |
|---|---|---|---|
| 일반 sign-up | TSID | 18-19자 | 정상 tracking |
| 콘솔에서 admin 추가 | `new UserId()` = TSID | 18-19자 | **정상 tracking (= 일반 사용자)** |
| Super-admin V5 placeholder | SQL hardcode `1` | 1자 | **opt-out (fix됨)** |

`UserId()` constructor 가 `TsidGenerator.nextId()` 사용 (`common/.../UserId.java`). 따라서 길이 검증으로는 super-admin 만 잡힘. 추가 admin 일괄 opt-out 은 명시적 admin flag 가 필요해 별도 PR 로 분리.

## Test

- [x] analytics 19/19 PASS (super-admin opt-out, sign-out, valid uid 재활성화 등 신규 케이스 포함)
- [x] 전체 1183/1183 PASS
- [x] tsc clean
- [ ] dev/stg 배포 후 super-admin 으로 화면 들어가서 amplitude 4xx 사라졌는지 DevTools Network 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)