### PR TITLE
fix(websocket): STOMP heartbeat 옵트인 + 커스텀 4s→15s + 60초→30초 정정

### DIFF
--- a/.github/workflows/vercel-build-check.yml
+++ b/.github/workflows/vercel-build-check.yml
@@ -13,4 +13,6 @@ jobs:
       - name: Build
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: npx vercel build --yes
+        # vercel@53.3.0 이 broken transitive dep (@vercel/cli-config 404) 으로
+        # publish 됨. 안전한 직전 stable 로 pin — vercel 측 fix 후 풀거나 신규 stable 로 bump.
+        run: npx vercel@53.2.0 build --yes

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -15,15 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # vercel@53.3.0 이 broken transitive dep (@vercel/cli-config 404) 으로
+      # publish 됨. 안전한 직전 stable 로 pin — vercel 측 fix 후 풀거나 신규 stable 로 bump.
       - name: Deploy to Vercel Preview
         id: deploy
         run: |
-          URL=$(npx vercel deploy --scope dev-8226s-projects --yes --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(npx vercel@53.2.0 deploy --scope dev-8226s-projects --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$URL" >> $GITHUB_OUTPUT
 
       - name: Alias Preview Domain
         run: |
-          npx vercel alias set ${{ steps.deploy.outputs.url }} stg.pfplay.xyz --scope dev-8226s-projects --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel@53.2.0 alias set ${{ steps.deploy.outputs.url }} stg.pfplay.xyz --scope dev-8226s-projects --token=${{ secrets.VERCEL_TOKEN }}
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # vercel@53.3.0 이 broken transitive dep (@vercel/cli-config 404) 으로
+      # publish 됨. 안전한 직전 stable 로 pin — vercel 측 fix 후 풀거나 신규 stable 로 bump.
       - name: Deploy to Vercel Production
-        run: npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel@53.2.0 deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -51,12 +51,12 @@
 - **개선 방향**: `useShallow` 적용, `useAvatarCluster` 반환값 useMemo, `registerAvatar` useCallback, `djQueueCrewIds` useMemo
 - **상세 분석**: [AVATARS_RENDER_PERFORMANCE.md](./AVATARS_RENDER_PERFORMANCE.md)
 
-### TD-004: STOMP 하트비트 커스텀 구현 → 내장 기능 전환
+### TD-004: STOMP 하트비트 — 두 heartbeat 책임 분리 영구화
 
-- **파일**: `src/shared/api/websocket/client.ts:158-183`
-- **현상**: GCP 60초 타임아웃 우회를 위해 4초 간격 커스텀 heartbeat(`/pub/heartbeat`)를 `setInterval`로 구현. STOMP 프로토콜 내장 heartbeat를 사용하지 않음
-- **개선 방향**: STOMP built-in heartbeat로 마이그레이션 (Slack 논의 참조)
-- **참고**: 코드 내 주석에 마이그레이션 계획 기재됨
+- **파일**: `src/shared/api/websocket/client.ts:158-187`
+- **현상**: GCP 30초 타임아웃 우회를 위해 15초 간격 커스텀 heartbeat(`/pub/heartbeat`)를 `setInterval`로 구현. 별도로 STOMP 내장 heartbeat(`heartbeatIncoming/Outgoing`)도 활성화하여 silent disconnect 감지에 사용
+- **개선 방향**: STOMP built-in heartbeat을 LB keep-alive와 별개의 disconnect 감지(presence) 책임으로 추가 활성화. 기존 커스텀 heartbeat은 LB keep-alive 책임자로 영구 유지. 두 heartbeat 영구 공존
+- **참고**: backend spec `pfplay-platform/docs/superpowers/specs/2026-05-09-presence-grace-window-design.md` § STOMP heartbeat resolved
 
 ### TD-005: TODO/FIXME 41개 미해결
 

--- a/src/shared/api/websocket/client.test.ts
+++ b/src/shared/api/websocket/client.test.ts
@@ -210,4 +210,44 @@ describe('SocketClient', () => {
       });
     });
   });
+
+  describe('STOMP 내장 heartbeat 옵트인 (presence disconnect 감지)', () => {
+    test('Client 생성 시 heartbeatIncoming=10s / heartbeatOutgoing=5s 가 설정된다', () => {
+      const sc = new SocketClient();
+      const config = getStompClient(sc).__config;
+      expect(config.heartbeatIncoming).toBe(10_000);
+      expect(config.heartbeatOutgoing).toBe(5_000);
+    });
+  });
+
+  describe('커스텀 heartbeat (LB keep-alive)', () => {
+    test('연결 후 15초 간격으로 /pub/heartbeat 에 PING 을 publish 한다', () => {
+      const sc = new SocketClient();
+      triggerConnect(sc);
+
+      const publish = getStompClient(sc).publish;
+      publish.mockClear();
+
+      vi.advanceTimersByTime(15_000);
+      expect(publish).toHaveBeenCalledWith({
+        destination: '/pub/heartbeat',
+        body: JSON.stringify('PING'),
+      });
+      expect(publish).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(15_000);
+      expect(publish).toHaveBeenCalledTimes(2);
+    });
+
+    test('15초 미만 경과에서는 PING 을 보내지 않는다 (4초 이전 동작 회귀 방지)', () => {
+      const sc = new SocketClient();
+      triggerConnect(sc);
+
+      const publish = getStompClient(sc).publish;
+      publish.mockClear();
+
+      vi.advanceTimersByTime(14_999);
+      expect(publish).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -53,6 +53,11 @@ export default class SocketClient {
     this.client = new Client({
       brokerURL: process.env.NEXT_PUBLIC_API_WS_HOST_NAME as string,
       reconnectDelay: 5000,
+      // STOMP 내장 heartbeat — 양측 옵트인 시에만 동작 (미옵트인 시 협상이 0,0 폴백).
+      // backend WebSocketConfig.setHeartbeatValue([10000, 5000]) 와 매칭.
+      // 모바일 백그라운드 / silent disconnect 를 ~7.5초 안에 감지 — presence grace 모델 전제.
+      heartbeatIncoming: 10_000,
+      heartbeatOutgoing: 5_000,
       debug: log,
       onConnect: handleConnect,
       onWebSocketClose: handleDisconnect,
@@ -156,10 +161,11 @@ export default class SocketClient {
   }
 
   /**
-   * NOTE: 소켓 커넥션 유지를 위해 heartbeat를 전송합니다.
-   * (60초 동안 클라이언트 측 송신이 없다면 백엔드 측 GCP가 연결을 끊어버립니다)
+   * NOTE: GCP HTTP(S) LB keep-alive 용 커스텀 heartbeat.
+   * (30초 동안 클라이언트 측 송신이 없다면 백엔드 측 GCP가 연결을 끊어버립니다)
    *
-   * 후에 Stomp 내장 heartbeat 기능을 사용하도록 변경할 예정
+   * STOMP 내장 heartbeat 와 책임이 다름 — 본 PING/PONG 은 LB keep-alive 전용,
+   * STOMP 내장 heartbeat 는 disconnect 감지(presence) 전용. 두 heartbeat 영구 공존.
    * @see https://pfplay.slack.com/archives/C051N8A0ZSB/p1724609022991849
    */
   private startHeartbeat() {
@@ -172,9 +178,11 @@ export default class SocketClient {
       /* Do nothing */
     });
 
+    // 30초 LB timeout 의 50% 안전 마진 (75% 룰 기준 22.5초까지 안전).
+    // 트래픽 3.75배 감소 (이전 4초 → 15초).
     this.heartbeatIntervalId = setInterval(() => {
       this.send(DESTINATION.PUB, 'PING');
-    }, 4000);
+    }, 15_000);
   }
 
   private stopHeartbeat() {


### PR DESCRIPTION
Closes #283

## Summary

backend PR pfplay/pfplay-platform#197 (partyroom presence grace window) 클라이언트 대응.

## Changes

### 1) STOMP 내장 heartbeat 옵트인

`src/shared/api/websocket/client.ts` — `Client` config 에 추가:
```ts
heartbeatIncoming: 10_000,
heartbeatOutgoing: 5_000,
```

미옵트인 시 CONNECT 협상이 `0,0` 폴백되어 동작 안 함. backend 의 `WebSocketConfig.setHeartbeatValue([10000, 5000])` 와 매칭. 모바일 백그라운드 / silent disconnect 를 ~7.5초 안에 감지 → presence grace 모델 전제조건.

### 2) 커스텀 heartbeat 간격 4s → 15s

`src/shared/api/websocket/client.ts:startHeartbeat`

GCP HTTP(S) LB `timeoutSec=30s` 의 50% 안전 마진 (75% 룰 기준 22.5s 까지 안전). 트래픽 3.75배 감소. 백엔드 변경 불필요.

### 3) 문서 정정 — 60초 → 30초, 4초 → 15초

- `client.ts:158` 주석 (LB timeout 실측치)
- `docs/TECH_DEBT.md` TD-004:
  - **현상**: `60초/4초` → `30초/15초`
  - **개선 방향**: \`STOMP built-in heartbeat 로 마이그레이션\` 가정 폐기 → **두 heartbeat 영구 공존** (LB keep-alive 책임 + presence disconnect 감지 책임 분리)
  - **참고**: backend spec 링크로 교체

## Test plan

- [x] STOMP heartbeat config 옵트인 검증 (10s incoming / 5s outgoing)
- [x] 커스텀 heartbeat 15s 간격 publish 검증 + 14999ms 에서는 미발생 (회귀 방지)
- [x] 1186/1186 PASS
- [x] tsc clean
- [ ] 머지 후 stg/prod 에서 DevTools WebSocket frame 으로 검증
  - CONNECTED frame `heart-beat` 헤더가 `10000,5000` (또는 양측 협상값)
  - 30초 이상 idle 에서 안 끊기는지
  - 모바일 화면 잠금 ~7-8초 후 복귀 → 본인 아바타 깜박임 없음 (silent grace)
  - 모바일 화면 잠금 ~15초 이상 후 복귀 → grace 만료 EXIT 후 재입장

## Follow-up (선택)

TD-004 entry 자체를 `TECH_DEBT.md` 에서 완전 삭제할지 (= 본 PR 로 부채 해소 / 두 heartbeat 공존이 디자인이 됨). 본 PR 에서는 본문만 정정 — 사용자 확인 후 별도 추가 commit 또는 follow-up PR 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)