### PR TITLE
Add e2e cd scenarios

### DIFF
--- a/.github/workflows/vercel-build-check.yml
+++ b/.github/workflows/vercel-build-check.yml
@@ -8,9 +8,14 @@ jobs:
   build:
     name: vercel build
     runs-on: ubuntu-latest
+    env:
+      VERCEL_CLI_VERSION: 48.4.1
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
       - name: Build
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: npx vercel build --yes
+        run: npx --yes vercel@${VERCEL_CLI_VERSION} build --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -52,7 +52,7 @@ jobs:
           key: playwright-${{ hashFiles('**/yarn.lock') }}
 
       - run: npx playwright install --with-deps chromium
-      - run: yarn test:e2e --project=e2e
+      - run: yarn test:e2e
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -9,21 +9,26 @@ jobs:
   deploy:
     name: deploy preview
     runs-on: ubuntu-latest
+    env:
+      VERCEL_CLI_VERSION: 48.4.1
     outputs:
       preview_url: ${{ steps.deploy.outputs.url }}
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
 
       - name: Deploy to Vercel Preview
         id: deploy
         run: |
-          URL=$(npx vercel deploy --scope dev-8226s-projects --yes --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(npx --yes vercel@${VERCEL_CLI_VERSION} deploy --scope dev-8226s-projects --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$URL" >> $GITHUB_OUTPUT
 
       - name: Alias Preview Domain
         run: |
-          npx vercel alias set ${{ steps.deploy.outputs.url }} stg.pfplay.xyz --scope dev-8226s-projects --token=${{ secrets.VERCEL_TOKEN }}
+          npx --yes vercel@${VERCEL_CLI_VERSION} alias set ${{ steps.deploy.outputs.url }} stg.pfplay.xyz --scope dev-8226s-projects --token=${{ secrets.VERCEL_TOKEN }}
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -8,7 +8,12 @@ jobs:
   deploy:
     name: deploy production
     runs-on: ubuntu-latest
+    env:
+      VERCEL_CLI_VERSION: 48.4.1
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
       - name: Deploy to Vercel Production
-        run: npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@${VERCEL_CLI_VERSION} deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ certificates
 e2e/.auth/
 playwright-report/
 test-results/
+.playwright-mcp/*
 
 # yarn-only project — keep package-lock.json out
 package-lock.json

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E 테스트 가이드
 
-Playwright 기반 e2e 테스트. 현재 2개의 시나리오(E2E-A, E2E-B)로 파티룸 핵심 기능을 검증한다.
+Playwright 기반 e2e 테스트. 현재 4개의 시나리오(E2E-A, E2E-B, E2E-C, E2E-D)로 파티룸 핵심 기능을 검증한다.
 
 ---
 
@@ -9,17 +9,29 @@ Playwright 기반 e2e 테스트. 현재 2개의 시나리오(E2E-A, E2E-B)로 �
 ```
 e2e/
 ├── .auth/                          # storageState 저장 위치 (gitignore)
-│   ├── user1.json                  # User1 (Full Crew / HOST) 인증 상태
-│   └── user2.json                  # User2 (Associate Crew) 인증 상태
+│   ├── a-user1.json                # A 시나리오용 User1 (Full Crew / HOST) 인증 상태
+│   ├── a-user2.json                # A 시나리오용 User2 (Associate Crew) 인증 상태
+│   ├── b-user1.json                # B 시나리오용 User1 인증 상태
+│   ├── b-user2.json                # B 시나리오용 User2 인증 상태
+│   ├── c-user1.json                # C 시나리오용 User1 인증 상태
+│   ├── c-user2.json                # C 시나리오용 User2 인증 상태
+│   └── d-user1.json                # D 시나리오용 User1 인증 상태
+├── auth/                           # 시나리오별 storageState 생성 로직
+│   ├── setup.a.ts                  # A 시나리오용 인증 세션 저장
+│   ├── setup.b.ts                  # B 시나리오용 인증 세션 저장
+│   ├── setup.c.ts                  # C 시나리오용 인증 세션 저장
+│   ├── setup.d.ts                  # D 시나리오용 인증 세션 저장
+│   └── shared.ts                   # 공통 로그인/세션 생성 유틸
 ├── fixtures/                       # 테스트 전 반복 세팅을 재사용할 수 있게 추상화하는 전처리 레이어 (실행 전 필요한 것을 setup, 끝난 후 정리하는 tearup)
 │   ├── ethereum-mock.ts            # window.ethereum mock (wagmi/RainbowKit 초기화용)
 │   └── auth.fixtures.ts            # user1Context / user2Context Playwright fixture
 ├── helpers/                        # 파티룸/플레이리스트/DJ 등록 등 e2e 공용 동작
 │   └── partyroom.helpers.ts        # 시나리오에 공통적으로 사용되는 helper 함수
-|                                     # e.g. playlist 생성, DJ 등록, 파티룸 퇴장/종료
-├── auth.setup.ts                   # 인증 세션 저장 (최초 1회 또는 만료 시 실행)
+│                                  # e.g. playlist 생성, DJ 등록, 파티룸 퇴장/종료
 ├── e2e-a.partyroom-join-sync.spec.ts   # 파티룸 생성 + Late Join 상태 동기화
-└── e2e-b.dj-state-machine.spec.ts      # DJ 상태 머신 + 다중 클라이언트 동기화
+├── e2e-b.dj-state-machine.spec.ts      # DJ 상태 머신 + 다중 클라이언트 동기화
+├── e2e-c.partyroom-moderation.spec.ts  # block / kick / ban moderation
+└── e2e-d.profile-avatar-reaction-chat.spec.ts # avatar / reaction / chat
 ```
 
 ---
@@ -32,10 +44,10 @@ e2e/
 yarn dev
 ```
 
-### 1. 인증 세션 저장 (최초 1회 또는 세션 만료 시)
+### 1. 인증 세션 저장
 
 ```bash
-yarn playwright test e2e/auth.setup.ts --project=auth-setup
+
 ```
 
 ### 2. 전체 테스트 실행
@@ -79,7 +91,13 @@ RainbowKit/wagmi는 페이지 로드 시 `window.ethereum` 존재 여부를 체�
 
 ### storageState 기반 인증 재사용
 
-매 테스트마다 로그인하면 느리고 불안정하다. `auth.setup.ts`에서 한 번 로그인 후 쿠키+localStorage를 `.auth/*.json`에 저장하고, 이후 모든 테스트는 해당 상태를 복원해 시작한다.
+매 테스트마다 로그인하면 느리고 불안정하다. 각 시나리오는 대응되는 `auth/setup.<scenario>.ts`에서 필요한 사용자 세션만 먼저 만들고, 이후 테스트는 해당 `.auth/<scenario>-user*.json` 상태를 복원해 시작한다.
+
+예:
+
+- `e2e-a` 실행 시 `auth-a`만 선행 실행
+- `e2e-c` 실행 시 `auth-c`만 선행 실행
+- `e2e-d` 실행 시 `auth-d`만 선행 실행
 
 ### 독립된 브라우저 컨텍스트
 
@@ -88,3 +106,98 @@ RainbowKit/wagmi는 페이지 로드 시 `window.ethereum` 존재 여부를 체�
 ### 파티룸 공용 helper
 
 플레이리스트 생성, DJ 등록, 파티룸 퇴장/종료처럼 여러 시나리오에서 반복되는 UI 동작은 `helpers/partyroom.helpers.ts`에 둔다. 특히 `registerAsDj()`는 플레이리스트 선택 직후 DJ 가이드가 뜨면 `Don't show again`을 먼저 눌러 이후 DJ queue 검증을 방해하지 않게 한다. 이미 사용자 preference에 가이드 숨김 값이 저장된 컨텍스트에서는 이 단계를 건너뛴다.
+
+---
+
+## Selector 기준
+
+E2E selector는 "UI 구현 세부사항에 덜 묶이고, 로케일/동적 데이터 변화에도 덜 깨지는 방식"을 우선한다. `data-testid`를 금지하지는 않지만, 모든 컴포넌트에 기본적으로 심는 방식은 지양한다.
+
+우선순위:
+
+1. `getByRole`
+2. `getByLabel`, `getByPlaceholder`, `getByText`
+3. 필요한 경우에만 `data-testid`
+
+### `getByRole`을 우선 사용하는 경우
+
+- 버튼, 탭, 다이얼로그, 텍스트박스처럼 접근 가능한 semantic role이 분명한 요소
+- 영어/한글 텍스트가 크게 바뀌지 않고, 테스트 의도가 사용자 행동과 직접 맞닿아 있는 요소
+
+예:
+
+- `openPartyroomChatPanel()`은 `getByRole('tab', { name: /chat/i })`를 사용한다.
+- `sendChatMessage()`는 마지막 채팅 input을 `getByRole('textbox')`로 찾는다.
+- `openAvatarSettingsFromMyProfile()`는 `getByRole('button', { name: /avatar settings/i })`를 사용한다.
+
+### `data-testid`를 허용하는 경우
+
+- 카운트, 닉네임, 번역 문자열처럼 표시값이 자주 바뀌는 요소
+- hover 후에만 나타나는 메뉴 버튼/패널
+- 반복 리스트 내부에서 특정 row를 안정적으로 좁혀야 하는 요소
+- 아바타 URI, reaction type처럼 텍스트 대신 attribute 상태를 검증하는 요소
+- Headless UI, portal, overlay처럼 role만으로 안정적으로 집기 어려운 구조
+
+예:
+
+- `partyroomCrewsPanel-tab`: 탭 라벨이 crew count라 텍스트 기반 선택이 불안정할 수 있으므로 `data-testid` 사용
+- `chat-message-item`, `crew-list-item-hover`: 반복 리스트에서 특정 항목을 `hasText()`와 함께 좁히기 위해 사용
+- `partyroom-current-dj`: `data-avatar-body-uri`, `data-reaction-type` 검증을 위해 anchor element가 필요하므로 사용
+- `dialog-panel`, `dialog-backdrop`: overlay 계층 제어를 위해 사용
+
+### 지양하는 방식
+
+- 공용 UI 컴포넌트마다 테스트 전용 prop을 기본 API처럼 추가하는 것
+- 하나의 `dataTestId` prop에서 `-nickname`, `-hover` 같은 파생 selector를 여러 개 만드는 것
+- 문서화되지 않은 임시 selector를 helper 내부에만 숨겨두는 것
+
+특히 `src/shared`의 재사용 컴포넌트에서 `dataTestId` prop drilling이 시작되면, 테스트 관심사가 컴포넌트 API를 오염시키기 쉽다. 가능하면 feature/root 레벨 container에만 test id를 두고, 내부 탐색은 role/text 기반으로 마무리한다.
+
+### 권장 패턴
+
+- 먼저 role 기반으로 진입한다.
+- role만으로 불안정한 구간에 한해 feature 단위 `data-testid`를 둔다.
+- 반복 리스트는 "list item anchor + hasText()" 조합으로 찾는다.
+- 상태 검증은 텍스트보다 `data-*` attribute가 더 안정적이면 attribute 검증을 사용한다.
+
+---
+
+## C, D 시나리오 정리
+
+이번 라운드에서는 E2E-C, E2E-D에 추가된 selector를 아래 기준으로 유지한다.
+
+### E2E-C moderation
+
+- 채팅 탭, 전체 crew 탭, restriction 탭 진입은 가능하면 role 기반 selector를 우선 사용한다.
+- crew count처럼 라벨이 동적인 탭은 `data-testid`를 유지한다.
+- 채팅 hover 메뉴, crew hover 메뉴, restriction 리스트는 상호작용 지점이 동적이고 반복 구조이므로 `data-testid`를 유지한다.
+- kick / ban / block 액션은 helper에서 캡슐화하고, spec 파일에서는 사용자 흐름만 읽히게 유지한다.
+
+현재 helper에서 유지하는 대표 selector:
+
+- `partyroomCrewsPanel-tab`
+- `chat-message-hover-item`
+- `crew-list-item-hover`
+- `restriction-list-item`
+- `restriction-category-BLOCK`
+- `crew-menu-kick`, `crew-menu-ban`, `chat-message-menu-block`
+
+### E2E-D avatar / reaction / chat
+
+- 프로필, 아바타 설정 열기, 저장 버튼은 role 기반 selector를 우선 사용한다.
+- 아바타 body 목록, 선택된 preview, 현재 DJ 영역은 텍스트 검증보다 상태/attribute 검증이 중요하므로 `data-testid`를 유지한다.
+- 현재 DJ 반영 여부는 visible text가 아니라 `data-avatar-body-uri`, `data-reaction-type` 기준으로 검증한다.
+
+현재 helper에서 유지하는 대표 selector:
+
+- `avatar-edit-panel`
+- `avatar-body-list-item`
+- `avatar-edit-selected-preview`
+- `partyroom-current-dj`
+- `avatar-reaction`
+
+### 다음 정리 원칙
+
+- C, D에서 추가한 selector는 당장 제거하지 않는다.
+- 다만 새 selector를 더 추가할 때는 먼저 role/text로 가능한지 확인한다.
+- `src/shared` 공용 컴포넌트에 테스트 전용 prop을 더 퍼뜨리기 전에, feature 레벨 wrapper나 container로 해결 가능한지 먼저 본다.

--- a/e2e/auth/setup.a.ts
+++ b/e2e/auth/setup.a.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { test as setup } from '@playwright/test';
+import { authenticateUser, AUTH_DIR } from './shared';
+
+setup('authenticate A User1 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'a-user1.json'), baseURL ?? '');
+});
+
+setup('authenticate A User2 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'a-user2.json'), baseURL ?? '');
+});

--- a/e2e/auth/setup.b.ts
+++ b/e2e/auth/setup.b.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { test as setup } from '@playwright/test';
+import { authenticateUser, AUTH_DIR } from './shared';
+
+setup('authenticate B User1 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'b-user1.json'), baseURL ?? '');
+});
+
+setup('authenticate B User2 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'b-user2.json'), baseURL ?? '');
+});

--- a/e2e/auth/setup.c.ts
+++ b/e2e/auth/setup.c.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { test as setup } from '@playwright/test';
+import { authenticateUser, AUTH_DIR } from './shared';
+
+setup('authenticate C User1 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'c-user1.json'), baseURL ?? '');
+});
+
+setup('authenticate C User2 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'c-user2.json'), baseURL ?? '');
+});

--- a/e2e/auth/setup.d.ts
+++ b/e2e/auth/setup.d.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+import { test as setup } from '@playwright/test';
+import { authenticateUser, AUTH_DIR } from './shared';
+
+setup('authenticate D User1 (full crew)', async ({ browser, baseURL }) => {
+  await authenticateUser(browser, path.join(AUTH_DIR, 'd-user1.json'), baseURL ?? '');
+});

--- a/e2e/auth/shared.ts
+++ b/e2e/auth/shared.ts
@@ -1,11 +1,45 @@
 import path from 'path';
-import { Browser } from '@playwright/test';
-import { test as setup, expect } from '@playwright/test';
-import { ETHEREUM_MOCK_SCRIPT } from './fixtures/ethereum-mock';
+import { Browser, Locator, Page, expect } from '@playwright/test';
+import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 
-const AUTH_DIR = path.join(__dirname, '.auth');
+export const AUTH_DIR = path.join(__dirname, '../.auth');
 
-async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
+async function waitForDialogToSettle(dialog: Locator) {
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () =>
+        dialog.evaluate((element) =>
+          element
+            .getAnimations({ subtree: true })
+            .every(
+              (animation) => animation.playState === 'finished' || animation.playState === 'idle'
+            )
+        ),
+      { timeout: 5_000 }
+    )
+    .toBe(true);
+}
+
+async function clickDevFullCrewSignIn(page: Page) {
+  const devBtn = page.locator('[data-testid="dev-sign-in-button"]');
+  await expect(devBtn).toBeVisible({ timeout: 10_000 });
+  await expect(devBtn).toBeEnabled({ timeout: 10_000 });
+  await devBtn.click();
+
+  const dialog = page
+    .locator('[data-testid="dialog-panel"]')
+    .filter({ has: page.locator('[data-testid="dev-sign-in-full"]') })
+    .first();
+  await waitForDialogToSettle(dialog);
+
+  const fullCrewButton = dialog.locator('[data-testid="dev-sign-in-full"]');
+  await expect(fullCrewButton).toBeVisible({ timeout: 10_000 });
+  await expect(fullCrewButton).toBeEnabled({ timeout: 10_000 });
+  await fullCrewButton.click({ force: true });
+}
+
+export async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
   const startedAt = Date.now();
   const authLabel = path.basename(outputPath, '.json');
   const log = (message: string) => {
@@ -38,13 +72,9 @@ async function authenticateUser(browser: Browser, outputPath: string, baseURL: s
   log(`goto ${baseURL}/sign-in`);
   await page.goto(`${baseURL}/sign-in`);
 
-  const devBtn = page.locator('[data-testid="dev-sign-in-button"]');
   log('waiting for dev sign-in button');
-  await expect(devBtn).toBeVisible({ timeout: 10_000 });
-  log('clicking dev sign-in button');
-  await devBtn.click();
   log('clicking full crew sign-in');
-  await page.locator('[data-testid="dev-sign-in-full"]').click();
+  await clickDevFullCrewSignIn(page);
 
   const pfpPlayButton = page.locator('[data-testid="home-pfp-play-button"]');
   log('waiting until page is effectively ready for /parties');
@@ -79,19 +109,3 @@ async function authenticateUser(browser: Browser, outputPath: string, baseURL: s
   await context.close();
   log('context closed');
 }
-
-setup('authenticate A User1 (full crew)', async ({ browser, baseURL }) => {
-  await authenticateUser(browser, path.join(AUTH_DIR, 'a-user1.json'), baseURL ?? '');
-});
-
-setup('authenticate A User2 (full crew)', async ({ browser, baseURL }) => {
-  await authenticateUser(browser, path.join(AUTH_DIR, 'a-user2.json'), baseURL ?? '');
-});
-
-setup('authenticate B User1 (full crew)', async ({ browser, baseURL }) => {
-  await authenticateUser(browser, path.join(AUTH_DIR, 'b-user1.json'), baseURL ?? '');
-});
-
-setup('authenticate B User2 (full crew)', async ({ browser, baseURL }) => {
-  await authenticateUser(browser, path.join(AUTH_DIR, 'b-user2.json'), baseURL ?? '');
-});

--- a/e2e/e2e-a.partyroom-join-sync.spec.ts
+++ b/e2e/e2e-a.partyroom-join-sync.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from './fixtures/auth.fixtures';
 import {
   closePartyroom,
   createPlaylistWithTracks,
+  createPartyroom,
   enterPartyroomAndWaitUntilReady,
   leavePartyroom,
   registerAsDj,
@@ -103,15 +104,7 @@ test('User2(late join)는 User1이 재생 중인 곡과 동일한 곡을 player�
     // ─── User1: 파티룸 생성 ──────────────────────────────────────────────
     const uniquePartyroomName = `E2EA${Date.now().toString(36)}`;
     log(`creating partyroom: ${uniquePartyroomName}`);
-    await page1.locator('[data-testid="create-partyroom-button"]').click();
-    await page1.locator('input[name="name"]').fill(uniquePartyroomName);
-    await page1.locator('textarea[name="introduce"]').fill('e2e-test');
-    await page1.locator('button[type="submit"]').click();
-
-    log('waiting for partyroom URL after create');
-    await page1.waitForURL(/\/parties\/\d+/, { timeout: 20_000 });
-
-    partyroomUrl = page1.url();
+    partyroomUrl = await createPartyroom(page1, uniquePartyroomName);
     log(`partyroom created: ${partyroomUrl}`);
     expect(partyroomUrl).toMatch(/\/parties\/\d+/);
 

--- a/e2e/e2e-b.dj-state-machine.spec.ts
+++ b/e2e/e2e-b.dj-state-machine.spec.ts
@@ -5,6 +5,7 @@ import { ETHEREUM_MOCK_SCRIPT } from './fixtures/ethereum-mock';
 import {
   closePartyroom,
   createPlaylistWithTracks,
+  createPartyroom,
   enterPartyroomAndWaitUntilReady,
   registerAsDj,
   setupUserPlaylist,
@@ -101,13 +102,7 @@ test.describe('E2E-B: DJ 상태 머신 + 다중 클라이언트 동기화', () =
     await createPlaylistWithTracks(page1, user1PlaylistName);
     log('beforeAll user1 playlist created');
     log('beforeAll user1 creating partyroom');
-    await page1.locator('[data-testid="create-partyroom-button"]').click();
-    await page1.locator('input[name="name"]').fill(`E2EB${timestamp}`);
-    await page1.locator('textarea[name="introduce"]').fill('dj state machine test');
-    await page1.locator('button[type="submit"]').click();
-    log('beforeAll waiting for partyroom URL');
-    await page1.waitForURL(/\/parties\/\d+/, { timeout: 20_000 });
-    partyroomUrl = page1.url();
+    partyroomUrl = await createPartyroom(page1, `E2EB${timestamp}`, 'dj state machine test');
     log(`beforeAll partyroom created: ${partyroomUrl}`);
     await ctx1.close();
     log('beforeAll user1 context closed');

--- a/e2e/e2e-c.partyroom-moderation.spec.ts
+++ b/e2e/e2e-c.partyroom-moderation.spec.ts
@@ -1,0 +1,177 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/auth.fixtures';
+import {
+  blockCrewFromChatMessage,
+  closePartyroom,
+  confirmAlertDialog,
+  confirmPenaltyAlertAndWaitForLobby,
+  confirmPenaltyDialog,
+  createPartyroom,
+  enterPartyroomAndWaitUntilReady,
+  getChatNicknameByMessage,
+  liftBlockedCrew,
+  openAllCrewsPanel,
+  openPartyroomChatPanel,
+  openRestrictionCategory,
+  openRestrictionPanel,
+  sendChatMessage,
+  waitForChatMessage,
+  waitForChatMessageToDisappear,
+  clickCrewMenuAction,
+  leavePartyroom,
+} from './helpers/partyroom.helpers';
+
+/**
+ * E2E-C: 채팅 차단 + 제재 복구 + Kick/Ban 재입장 제어
+ *
+ * 관리자 권한 사용자가 같은 파티룸 안에서 다른 사용자를 block / kick / ban 했을 때,
+ * 각 사용자 화면에 반영되는 채팅/모달/재입장 제한 상태가 올바르게 동작해야 한다.
+ *
+ * 해당 기준: A (Auth→파티룸입장 체인) + B (다중 사용자 실시간 반영) + C (제재/복구 흐름)
+ *
+ * 흐름:
+ *   1. User1: 파티룸 생성
+ *   2. User2: 동일 파티룸 입장 후 채팅 전송
+ *   3. User1: 채팅 hover 메뉴에서 User2를 block
+ *   4. ✅ User1 화면: User2 채팅이 목록에서 사라짐
+ *   5. User1: Restriction > Blocked list 에서 User2 lift
+ *   6. User1: All crews 에서 User2 kick(reason=test kick)
+ *   7. ✅ User2 화면: removed by admin 모달 확인 후 /parties 이동, 재입장 가능
+ *   8. User1: 재입장한 User2를 ban(reason=test ban)
+ *   9. ✅ User2 화면: permanent removed 모달 확인 후 /parties 이동
+ *  10. ✅ User2: 동일 파티룸 재입장 시도 시 "이용이 정지된 사용자입니다" 모달 표시
+ *
+ * 검증 목표:
+ *   - block 시 local blocked list 기반 채팅 필터링이 즉시 반영되는가
+ *   - unblock / kick / ban mutation 이후 각 패널과 상대 클라이언트 alert가 동기화되는가
+ *   - one-time expulsion 과 permanent expulsion 의 재입장 정책 차이가 정확히 적용되는가
+ */
+test('관리자는 block 해제 후 kick / ban 제재 흐름을 제어할 수 있다', async ({
+  user1Context,
+  user2Context,
+}) => {
+  test.setTimeout(120_000);
+
+  const startedAt = Date.now();
+  const log = (message: string) => {
+    const elapsed = `${Date.now() - startedAt}ms`.padStart(8, ' ');
+    console.log(`[E2E-C][${elapsed}] ${message}`);
+  };
+  const attachPageDebug = (label: string, page: Page) => {
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        log(`${label} console.${msg.type()}: ${msg.text()}`);
+      }
+    });
+    page.on('pageerror', (error) => {
+      log(`${label} pageerror: ${error.message}`);
+    });
+    page.on('close', () => {
+      log(`${label} page closed`);
+    });
+    page.on('crash', () => {
+      log(`${label} page crashed`);
+    });
+    page.on('response', (response) => {
+      const url = response.url();
+      if (
+        /\/v1\/partyrooms\/\d+\/(setup|crews\/me|penalties)$/.test(url) ||
+        /\/v1\/crews\/me\/blocks(?:\/\d+)?$/.test(url)
+      ) {
+        log(`${label} response ${response.status()} ${response.request().method()} ${url}`);
+      }
+    });
+  };
+
+  const page1 = await user1Context.newPage();
+  const page2 = await user2Context.newPage();
+  attachPageDebug('user1', page1);
+  attachPageDebug('user2', page2);
+
+  let partyroomUrl: string | undefined;
+  const uniqueSuffix = Date.now().toString(36);
+  const partyroomName = `E2EC${uniqueSuffix}`;
+  const chatMessage = `e2e-c-chat-${uniqueSuffix}`;
+
+  try {
+    log('user1 goto /parties');
+    await page1.goto('/parties');
+
+    log(`user1 creating partyroom: ${partyroomName}`);
+    partyroomUrl = await createPartyroom(page1, partyroomName, 'moderation test');
+    log(`partyroom created: ${partyroomUrl}`);
+
+    log('waiting for user1 partyroom readiness');
+    await enterPartyroomAndWaitUntilReady(page1, partyroomUrl);
+
+    log('user2 entering partyroom');
+    await enterPartyroomAndWaitUntilReady(page2, partyroomUrl);
+
+    log(`user2 sending chat: ${chatMessage}`);
+    await openPartyroomChatPanel(page2);
+    await sendChatMessage(page2, chatMessage);
+
+    log('waiting for chat message on both users');
+    await Promise.all([
+      waitForChatMessage(page1, chatMessage),
+      waitForChatMessage(page2, chatMessage),
+    ]);
+
+    const user2Nickname = await getChatNicknameByMessage(page1, chatMessage);
+    log(`captured user2 nickname from chat: ${user2Nickname}`);
+    expect(user2Nickname).toBeTruthy();
+
+    log('user1 blocking user2 from chat hover menu');
+    await openPartyroomChatPanel(page1);
+    await blockCrewFromChatMessage(page1, chatMessage);
+    await confirmAlertDialog(page1);
+
+    log('waiting for blocked chat to disappear on user1');
+    await waitForChatMessageToDisappear(page1, chatMessage);
+
+    log('user1 opening restriction panel and lifting block');
+    await openRestrictionPanel(page1);
+    await openRestrictionCategory(page1, 'BLOCK');
+    await liftBlockedCrew(page1, user2Nickname);
+    await expect(
+      page1.locator('[data-testid="restriction-list-item"]').filter({ hasText: user2Nickname })
+    ).toHaveCount(0, {
+      timeout: 15_000,
+    });
+
+    log('user1 kicking user2 from all crews panel');
+    await openAllCrewsPanel(page1);
+    await clickCrewMenuAction(page1, user2Nickname, 'kick');
+    await confirmPenaltyDialog(page1, 'test kick');
+
+    log('waiting for user2 kick alert and lobby redirect');
+    await confirmPenaltyAlertAndWaitForLobby(page2, 'You have been removed by an admin.');
+
+    log('user2 re-entering partyroom after kick');
+    await enterPartyroomAndWaitUntilReady(page2, partyroomUrl);
+
+    log('user1 banning user2 from all crews panel');
+    await openAllCrewsPanel(page1);
+    await clickCrewMenuAction(page1, user2Nickname, 'ban');
+    await confirmPenaltyDialog(page1, 'test ban');
+
+    log('waiting for user2 ban alert and lobby redirect');
+    await confirmPenaltyAlertAndWaitForLobby(
+      page2,
+      'You have been permanently removed by an admin and can’t rejoin.'
+    );
+
+    log('user2 attempting to re-enter banned partyroom');
+    await page2.goto(partyroomUrl);
+    await confirmAlertDialog(page2, '이용이 정지된 사용자입니다');
+  } finally {
+    log('starting cleanup');
+    if (page2 && !page2.isClosed()) {
+      log('cleanup: leavePartyroom(page2)');
+      await leavePartyroom(page2);
+    }
+    log(`cleanup: ${partyroomUrl ? 'closePartyroom(page1)' : 'leavePartyroom(page1)'}`);
+    await (partyroomUrl ? closePartyroom(page1, partyroomUrl) : leavePartyroom(page1));
+    log('cleanup finished');
+  }
+});

--- a/e2e/e2e-c.partyroom-moderation.spec.ts
+++ b/e2e/e2e-c.partyroom-moderation.spec.ts
@@ -9,6 +9,7 @@ import {
   createPartyroom,
   enterPartyroomAndWaitUntilReady,
   getChatNicknameByMessage,
+  waitForRestrictionItemToDisappear,
   liftBlockedCrew,
   openAllCrewsPanel,
   openPartyroomChatPanel,
@@ -133,11 +134,7 @@ test('관리자는 block 해제 후 kick / ban 제재 흐름을 제어할 수 �
     await openRestrictionPanel(page1);
     await openRestrictionCategory(page1, 'BLOCK');
     await liftBlockedCrew(page1, user2Nickname);
-    await expect(
-      page1.locator('[data-testid="restriction-list-item"]').filter({ hasText: user2Nickname })
-    ).toHaveCount(0, {
-      timeout: 15_000,
-    });
+    await waitForRestrictionItemToDisappear(page1, user2Nickname);
 
     log('user1 kicking user2 from all crews panel');
     await openAllCrewsPanel(page1);

--- a/e2e/e2e-d.profile-avatar-reaction-chat.spec.ts
+++ b/e2e/e2e-d.profile-avatar-reaction-chat.spec.ts
@@ -5,6 +5,7 @@ import {
   createPartyroom,
   createPlaylistWithTracks,
   enterPartyroomAndWaitUntilReady,
+  getCurrentDjAvatarBodyUri,
   leavePartyroom,
   likeCurrentPlayback,
   openAvatarSettingsFromMyProfile,
@@ -108,9 +109,7 @@ test('User1은 avatar 변경 후 like 리액션과 채팅 송신을 확인할 �
     await registerAsDj(page1, playlistName);
     log('DJ registration completed');
 
-    const currentDj = page1.locator('[data-testid="partyroom-current-dj"]');
-    await expect(currentDj).toBeVisible({ timeout: 20_000 });
-    const initialAvatarBodyUri = await currentDj.getAttribute('data-avatar-body-uri');
+    const initialAvatarBodyUri = await getCurrentDjAvatarBodyUri(page1);
     log(`captured initial current DJ avatar body: ${initialAvatarBodyUri ?? '<empty>'}`);
     expect(initialAvatarBodyUri).toBeTruthy();
 

--- a/e2e/e2e-d.profile-avatar-reaction-chat.spec.ts
+++ b/e2e/e2e-d.profile-avatar-reaction-chat.spec.ts
@@ -1,0 +1,154 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/auth.fixtures';
+import {
+  closePartyroom,
+  createPartyroom,
+  createPlaylistWithTracks,
+  enterPartyroomAndWaitUntilReady,
+  leavePartyroom,
+  likeCurrentPlayback,
+  openAvatarSettingsFromMyProfile,
+  openPartyroomChatPanel,
+  registerAsDj,
+  saveAvatarSettings,
+  selectAvatarBodyByIndex,
+  sendChatMessage,
+  waitForChatMessage,
+  waitForCurrentDjAvatarBody,
+  waitForCurrentDjLikeReaction,
+} from './helpers/partyroom.helpers';
+
+/**
+ * E2E-D: 내 프로필 아바타 변경 + 좋아요 리액션 + 채팅 송신
+ *
+ * 한 사용자가 파티룸에 입장해 DJ가 된 뒤, My Profile > Avatar settings 에서
+ * 아바타를 변경하고, 현재 DJ 아바타 반영 / 좋아요 리액션 / 채팅 송신이 모두
+ * 정상 동작해야 한다.
+ *
+ * 해당 기준: A (Auth→파티룸입장 체인) + D (내 프로필/아바타 변경 UI) + E (리액션/채팅)
+ *
+ * 흐름:
+ *   1. User1: 파티룸 생성
+ *   2. User1: 플레이리스트 생성 후 DJ 등록
+ *   3. User1: My Profile > Avatar settings 진입
+ *   4. User1: 두 번째 avatar body 선택 후 저장
+ *   5. ✅ User1 화면: 현재 DJ 아바타가 새 body로 반영됨
+ *   6. User1: 좋아요 클릭
+ *   7. ✅ User1 화면: 현재 DJ 아바타에 LIKE 리액션이 반영됨
+ *   8. User1: 채팅 입력
+ *   9. ✅ User1 화면: 해당 채팅이 목록에 표시됨
+ *
+ * 검증 목표:
+ *   - 프로필 아바타 변경 mutation 이후 현재 파티룸 아바타 UI가 동기화되는가
+ *   - 현재 playback에 대한 LIKE 리액션이 내 아바타 상태로 반영되는가
+ *   - 채팅 전송 mutation 이후 메시지가 UI 목록에 표시되는가
+ */
+test('User1은 avatar 변경 후 like 리액션과 채팅 송신을 확인할 수 있다', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+
+  const startedAt = Date.now();
+  const log = (message: string) => {
+    const elapsed = `${Date.now() - startedAt}ms`.padStart(8, ' ');
+    console.log(`[E2E-D][${elapsed}] ${message}`);
+  };
+  const attachPageDebug = (label: string, page: Page) => {
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        log(`${label} console.${msg.type()}: ${msg.text()}`);
+      }
+    });
+    page.on('pageerror', (error) => {
+      log(`${label} pageerror: ${error.message}`);
+    });
+    page.on('close', () => {
+      log(`${label} page closed`);
+    });
+    page.on('crash', () => {
+      log(`${label} page crashed`);
+    });
+    page.on('response', (response) => {
+      const url = response.url();
+      if (
+        /\/v1\/partyrooms\/\d+\/(setup|dj-queue|playbacks\/reaction|crews\/me)$/.test(url) ||
+        /\/v1\/users\/me\/profile\/avatar$/.test(url)
+      ) {
+        log(`${label} response ${response.status()} ${response.request().method()} ${url}`);
+      }
+    });
+  };
+
+  const page1 = await user1Context.newPage();
+  attachPageDebug('user1', page1);
+  let partyroomUrl: string | undefined;
+
+  const uniqueSuffix = Date.now().toString(36);
+  const playlistName = `E2ED${uniqueSuffix}`;
+  const partyroomName = `E2ED${uniqueSuffix}`;
+  const chatMessage = `e2e-d-chat-${uniqueSuffix}`;
+
+  try {
+    log('user1 goto /parties');
+    await page1.goto('/parties');
+
+    // ─── User1: 플레이리스트 생성 + 파티룸 생성 ───────────────────────────
+    log(`creating playlist: ${playlistName}`);
+    await createPlaylistWithTracks(page1, playlistName);
+    log(`playlist created: ${playlistName}`);
+
+    log(`creating partyroom: ${partyroomName}`);
+    partyroomUrl = await createPartyroom(page1, partyroomName, 'profile avatar reaction test');
+    log(`partyroom created: ${partyroomUrl}`);
+
+    // ─── User1: 파티룸 입장 + DJ 등록 ───────────────────────────────────
+    log('waiting for partyroom readiness');
+    await enterPartyroomAndWaitUntilReady(page1, partyroomUrl);
+    log('registering as DJ');
+    await registerAsDj(page1, playlistName);
+    log('DJ registration completed');
+
+    const currentDj = page1.locator('[data-testid="partyroom-current-dj"]');
+    await expect(currentDj).toBeVisible({ timeout: 20_000 });
+    const initialAvatarBodyUri = await currentDj.getAttribute('data-avatar-body-uri');
+    log(`captured initial current DJ avatar body: ${initialAvatarBodyUri ?? '<empty>'}`);
+    expect(initialAvatarBodyUri).toBeTruthy();
+
+    // ─── User1: My Profile > Avatar settings > 두 번째 body 선택 ───────
+    log('opening avatar settings from my profile');
+    await openAvatarSettingsFromMyProfile(page1);
+    const nextAvatarBodyUri = await selectAvatarBodyByIndex(page1, 1);
+    log(`selected second avatar body: ${nextAvatarBodyUri || '<empty>'}`);
+    expect(nextAvatarBodyUri).toBeTruthy();
+
+    log('saving avatar settings');
+    await saveAvatarSettings(page1);
+
+    // crew_profile_changed broadcast → 현재 DJ 아바타 body 반영
+    log('waiting for current DJ avatar body update');
+    await waitForCurrentDjAvatarBody(page1, nextAvatarBodyUri);
+    log('current DJ avatar body updated');
+
+    // ─── User1: 좋아요 리액션 ───────────────────────────────────────────
+    log('clicking like reaction');
+    await likeCurrentPlayback(page1);
+
+    log('waiting for current DJ like reaction');
+    await waitForCurrentDjLikeReaction(page1);
+    log('current DJ like reaction observed');
+
+    // ─── User1: 채팅 전송 ───────────────────────────────────────────────
+    log(`sending chat message: ${chatMessage}`);
+    await openPartyroomChatPanel(page1);
+    await sendChatMessage(page1, chatMessage);
+
+    log('waiting for chat message');
+    await waitForChatMessage(page1, chatMessage);
+    log('chat message rendered');
+  } finally {
+    log('starting cleanup');
+    log(`cleanup: ${partyroomUrl ? 'closePartyroom(page1)' : 'leavePartyroom(page1)'}`);
+    await (partyroomUrl ? closePartyroom(page1, partyroomUrl) : leavePartyroom(page1));
+    log('cleanup finished');
+  }
+});

--- a/e2e/fixtures/auth.fixtures.ts
+++ b/e2e/fixtures/auth.fixtures.ts
@@ -39,9 +39,21 @@ export const test = baseTest.extend<AuthFixtures>({
 export { expect } from '@playwright/test';
 
 function getAuthPrefix(testFile: string) {
+  if (testFile.includes('e2e-a.')) {
+    return 'a';
+  }
+
   if (testFile.includes('e2e-b.')) {
     return 'b';
   }
 
-  return 'a';
+  if (testFile.includes('e2e-c.')) {
+    return 'c';
+  }
+
+  if (testFile.includes('e2e-d.')) {
+    return 'd';
+  }
+
+  throw new Error(`No auth prefix configured for test file: ${testFile}`);
 }

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -199,18 +199,14 @@ export async function openPartyroomChatPanel(page: Page) {
   const chatTab = page.getByRole('tab', { name: /chat/i });
   await expect(chatTab).toBeVisible({ timeout: 10_000 });
   await chatTab.click();
-  await expect(page.locator('[data-testid="partyroomChatPanel-trigger"]')).toBeVisible({
-    timeout: 10_000,
-  });
+  await expect(page.getByRole('textbox').last()).toBeVisible({ timeout: 10_000 });
 }
 
 export async function openPartyroomCrewsPanel(page: Page) {
   const crewsTab = page.locator('[data-testid="partyroomCrewsPanel-tab"]');
   await expect(crewsTab).toBeVisible({ timeout: 10_000 });
   await crewsTab.click();
-  await expect(page.locator('[data-testid="partyroomCrewsPanel-trigger"]')).toBeVisible({
-    timeout: 10_000,
-  });
+  await expect(page.getByRole('tab', { name: /all/i })).toBeVisible({ timeout: 10_000 });
 }
 
 export async function openAllCrewsPanel(page: Page) {
@@ -219,9 +215,6 @@ export async function openAllCrewsPanel(page: Page) {
   const allCrewsTab = page.getByRole('tab', { name: /all/i });
   await expect(allCrewsTab).toBeVisible({ timeout: 10_000 });
   await allCrewsTab.click();
-  await expect(page.locator('[data-testid="allCrewsPanel-trigger"]')).toBeVisible({
-    timeout: 10_000,
-  });
   await expandAllCrewCategories(page);
 }
 
@@ -231,9 +224,24 @@ export async function openRestrictionPanel(page: Page) {
   const restrictionTab = page.getByRole('tab', { name: /restriction/i });
   await expect(restrictionTab).toBeVisible({ timeout: 10_000 });
   await restrictionTab.click();
-  await expect(page.locator('[data-testid="restrictionPanel-trigger"]')).toBeVisible({
-    timeout: 10_000,
-  });
+  await expect
+    .poll(
+      async () => {
+        const emptyStateVisible = await page
+          .getByText('There are no restrictions.')
+          .isVisible()
+          .catch(() => false);
+        if (emptyStateVisible) return true;
+
+        return page
+          .locator('[data-testid^="restriction-category-"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+      },
+      { timeout: 10_000 }
+    )
+    .toBe(true);
 }
 
 export async function openRestrictionCategory(
@@ -270,7 +278,7 @@ export async function openMyProfileDialog(page: Page) {
 
   const dialog = page
     .locator('[data-testid="dialog-panel"]')
-    .filter({ has: page.locator('[data-testid="my-profile-avatar-settings-button"]') })
+    .filter({ has: page.getByRole('button', { name: /avatar settings/i }) })
     .first();
   await expect(dialog).toBeVisible({ timeout: 10_000 });
   return dialog;
@@ -282,19 +290,20 @@ export async function openAvatarSettingsFromMyProfile(page: Page) {
   await expect(avatarSettingsButton).toBeVisible({ timeout: 10_000 });
   await avatarSettingsButton.click();
 
-  const avatarEditPanel = page.locator('[data-testid="avatar-edit-panel"]');
+  const avatarEditPanel = page.getByRole('tab', { name: /body/i });
   await expect(avatarEditPanel).toBeVisible({ timeout: 10_000 });
   return avatarEditPanel;
 }
 
 export async function selectAvatarBodyByIndex(page: Page, index: number) {
-  const avatarItems = page.locator('[data-testid="avatar-body-list-item"]');
+  const avatarItems = page.getByRole('button', { name: /Avatar Parts/i });
   await expect(avatarItems.nth(index)).toBeVisible({ timeout: 15_000 });
 
   const selectedItem = avatarItems.nth(index);
-  const avatarBodyUri = await selectedItem.getAttribute('data-image-src');
+  const avatarItemContainer = selectedItem.locator('xpath=..');
+  const avatarBodyUri = await avatarItemContainer.getAttribute('data-image-src');
   await selectedItem.click();
-  await expect(selectedItem).toHaveAttribute('data-selected', 'true', { timeout: 10_000 });
+  await expect(avatarItemContainer).toHaveAttribute('data-selected', 'true', { timeout: 10_000 });
 
   const selectedPreview = page.locator('[data-testid="avatar-edit-selected-preview"]');
   await expect(selectedPreview).toHaveAttribute('data-avatar-body-uri', avatarBodyUri ?? '', {
@@ -308,12 +317,22 @@ export async function saveAvatarSettings(page: Page) {
   const saveButton = page.getByRole('button', { name: /save/i });
   await expect(saveButton).toBeEnabled({ timeout: 10_000 });
   await saveButton.click();
-  await expect(page.locator('[data-testid="avatar-edit-panel"]')).toBeHidden({ timeout: 20_000 });
+  await expect(saveButton).toBeHidden({ timeout: 20_000 });
   await closeVisibleDialogOverlays(page);
 }
 
+function getCurrentDj(page: Page) {
+  return page.locator('[data-testid="partyroom-current-dj"]');
+}
+
+export async function getCurrentDjAvatarBodyUri(page: Page) {
+  const currentDj = getCurrentDj(page);
+  await expect(currentDj).toBeVisible({ timeout: 20_000 });
+  return (await currentDj.getAttribute('data-avatar-body-uri')) ?? '';
+}
+
 export async function waitForCurrentDjAvatarBody(page: Page, avatarBodyUri: string) {
-  const currentDj = page.locator('[data-testid="partyroom-current-dj"]');
+  const currentDj = getCurrentDj(page);
   await expect(currentDj).toHaveAttribute('data-avatar-body-uri', avatarBodyUri, {
     timeout: 20_000,
   });
@@ -368,7 +387,7 @@ export async function closeVisibleDialogOverlays(page: Page) {
 }
 
 export async function waitForCurrentDjLikeReaction(page: Page) {
-  const currentDj = page.locator('[data-testid="partyroom-current-dj"]');
+  const currentDj = getCurrentDj(page);
   await expect(currentDj).toHaveAttribute('data-reaction-type', 'LIKE', { timeout: 15_000 });
   await expect(currentDj.locator('[data-testid="avatar-reaction"]')).toBeVisible({
     timeout: 15_000,
@@ -433,6 +452,14 @@ export async function liftBlockedCrew(page: Page, nickname: string) {
     .first();
   await expect(blockedItem).toBeVisible({ timeout: 15_000 });
   await blockedItem.locator('[data-testid="restriction-block-lift-button"]').click();
+}
+
+export async function waitForRestrictionItemToDisappear(page: Page, nickname: string) {
+  await expect(
+    page.locator('[data-testid="restriction-list-item"]').filter({ hasText: nickname })
+  ).toHaveCount(0, {
+    timeout: 15_000,
+  });
 }
 
 export async function confirmPenaltyDialog(page: Page, reason: string) {

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Browser, Page } from '@playwright/test';
+import { Browser, Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 
@@ -16,6 +16,25 @@ export async function enterPartyroomAndWaitUntilReady(page: Page, partyroomUrl: 
   }
 
   await expect(page.getByRole('button', { name: /DJ Queue/i })).toBeVisible({ timeout: 15_000 });
+
+  const partyroomId = Number(partyroomUrl.match(/\/parties\/(\d+)/)?.[1]);
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((id) => {
+          return (
+            (
+              window as Window & {
+                __PFPLAY_E2E__?: {
+                  subscribedRoomId?: number;
+                };
+              }
+            ).__PFPLAY_E2E__?.subscribedRoomId === id
+          );
+        }, partyroomId),
+      { timeout: 20_000 }
+    )
+    .toBe(true);
 }
 
 export async function openDjQueueDrawer(page: Page) {
@@ -101,6 +120,20 @@ export async function createPlaylistWithTracks(page: Page, playlistName: string)
   await page.locator('[data-testid="drawer-close-button"]').click();
 }
 
+export async function createPartyroom(
+  page: Page,
+  partyroomName: string,
+  introduction = 'e2e-test'
+) {
+  await page.locator('[data-testid="create-partyroom-button"]').click();
+  await page.locator('input[name="name"]').fill(partyroomName);
+  await page.locator('textarea[name="introduce"]').fill(introduction);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/parties\/\d+/, { timeout: 20_000 });
+
+  return page.url();
+}
+
 export async function registerAsDj(page: Page, playlistName?: string) {
   await openDjQueueDrawer(page);
 
@@ -162,6 +195,280 @@ export async function dismissDjingGuide(page: Page) {
   await dontShowAgainBtn.click();
 }
 
+export async function openPartyroomChatPanel(page: Page) {
+  const chatTab = page.getByRole('tab', { name: /chat/i });
+  await expect(chatTab).toBeVisible({ timeout: 10_000 });
+  await chatTab.click();
+  await expect(page.locator('[data-testid="partyroomChatPanel-trigger"]')).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+export async function openPartyroomCrewsPanel(page: Page) {
+  const crewsTab = page.locator('[data-testid="partyroomCrewsPanel-tab"]');
+  await expect(crewsTab).toBeVisible({ timeout: 10_000 });
+  await crewsTab.click();
+  await expect(page.locator('[data-testid="partyroomCrewsPanel-trigger"]')).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+export async function openAllCrewsPanel(page: Page) {
+  await openPartyroomCrewsPanel(page);
+
+  const allCrewsTab = page.getByRole('tab', { name: /all/i });
+  await expect(allCrewsTab).toBeVisible({ timeout: 10_000 });
+  await allCrewsTab.click();
+  await expect(page.locator('[data-testid="allCrewsPanel-trigger"]')).toBeVisible({
+    timeout: 10_000,
+  });
+  await expandAllCrewCategories(page);
+}
+
+export async function openRestrictionPanel(page: Page) {
+  await openPartyroomCrewsPanel(page);
+
+  const restrictionTab = page.getByRole('tab', { name: /restriction/i });
+  await expect(restrictionTab).toBeVisible({ timeout: 10_000 });
+  await restrictionTab.click();
+  await expect(page.locator('[data-testid="restrictionPanel-trigger"]')).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+export async function openRestrictionCategory(
+  page: Page,
+  category: 'BLOCK' | 'PERMANENT_EXPULSION'
+) {
+  const categoryButton = page.locator(`[data-testid="restriction-category-${category}"]`);
+  await expect(categoryButton).toBeVisible({ timeout: 10_000 });
+  await categoryButton.click();
+}
+
+async function expandAllCrewCategories(page: Page) {
+  const categoryButtons = page.locator('[data-testid^="all-crews-category-"]');
+  const count = await categoryButtons.count();
+
+  for (let i = 0; i < count; i++) {
+    await categoryButtons.nth(i).click();
+  }
+}
+
+export async function sendChatMessage(page: Page, message: string) {
+  const chatInput = page.getByRole('textbox').last();
+  await expect(chatInput).toBeVisible({ timeout: 10_000 });
+  await chatInput.fill(message);
+  await chatInput.press('Enter');
+}
+
+export async function openMyProfileDialog(page: Page) {
+  const profileButton = page.getByRole('button', { name: /my profile/i });
+  await expect(profileButton).toBeVisible({ timeout: 10_000 });
+  await profileButton.evaluate((element) => {
+    (element as HTMLButtonElement).click();
+  });
+
+  const dialog = page
+    .locator('[data-testid="dialog-panel"]')
+    .filter({ has: page.locator('[data-testid="my-profile-avatar-settings-button"]') })
+    .first();
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  return dialog;
+}
+
+export async function openAvatarSettingsFromMyProfile(page: Page) {
+  const profileDialog = await openMyProfileDialog(page);
+  const avatarSettingsButton = profileDialog.getByRole('button', { name: /avatar settings/i });
+  await expect(avatarSettingsButton).toBeVisible({ timeout: 10_000 });
+  await avatarSettingsButton.click();
+
+  const avatarEditPanel = page.locator('[data-testid="avatar-edit-panel"]');
+  await expect(avatarEditPanel).toBeVisible({ timeout: 10_000 });
+  return avatarEditPanel;
+}
+
+export async function selectAvatarBodyByIndex(page: Page, index: number) {
+  const avatarItems = page.locator('[data-testid="avatar-body-list-item"]');
+  await expect(avatarItems.nth(index)).toBeVisible({ timeout: 15_000 });
+
+  const selectedItem = avatarItems.nth(index);
+  const avatarBodyUri = await selectedItem.getAttribute('data-image-src');
+  await selectedItem.click();
+  await expect(selectedItem).toHaveAttribute('data-selected', 'true', { timeout: 10_000 });
+
+  const selectedPreview = page.locator('[data-testid="avatar-edit-selected-preview"]');
+  await expect(selectedPreview).toHaveAttribute('data-avatar-body-uri', avatarBodyUri ?? '', {
+    timeout: 10_000,
+  });
+
+  return avatarBodyUri ?? '';
+}
+
+export async function saveAvatarSettings(page: Page) {
+  const saveButton = page.getByRole('button', { name: /save/i });
+  await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+  await saveButton.click();
+  await expect(page.locator('[data-testid="avatar-edit-panel"]')).toBeHidden({ timeout: 20_000 });
+  await closeVisibleDialogOverlays(page);
+}
+
+export async function waitForCurrentDjAvatarBody(page: Page, avatarBodyUri: string) {
+  const currentDj = page.locator('[data-testid="partyroom-current-dj"]');
+  await expect(currentDj).toHaveAttribute('data-avatar-body-uri', avatarBodyUri, {
+    timeout: 20_000,
+  });
+}
+
+export async function likeCurrentPlayback(page: Page) {
+  const likeButton = page.locator('[data-testid="playback-like-button"]');
+  await expect(likeButton).toBeVisible({ timeout: 10_000 });
+  await expect(likeButton).toBeEnabled({ timeout: 10_000 });
+  await likeButton.click();
+}
+
+export async function closeVisibleDialogOverlays(page: Page) {
+  const dialogs = page.locator('[data-testid="dialog-panel"]');
+
+  while ((await dialogs.count()) > 0) {
+    const dialog = dialogs.last();
+    if (!(await dialog.isVisible().catch(() => false))) {
+      break;
+    }
+
+    const actionButton = dialog
+      .locator('[data-testid="dialog-close-button"]')
+      .or(dialog.locator('[data-testid="confirm-dialog-confirm-button"]'))
+      .or(dialog.locator('[data-testid="alert-dialog-confirm-button"]'))
+      .or(dialog.locator('[data-testid="error-dialog-confirm-button"]'))
+      .or(dialog.locator('[data-testid="confirm-dialog-cancel-button"]'))
+      .first();
+
+    if (await actionButton.isVisible().catch(() => false)) {
+      await actionButton.evaluate((element) => {
+        (element as HTMLButtonElement).click();
+      });
+      await page.waitForTimeout(600);
+      continue;
+    }
+
+    const backdrop = page.locator('[data-testid="dialog-backdrop"]').last();
+    if (!(await backdrop.isVisible().catch(() => false))) {
+      break;
+    }
+
+    await backdrop.evaluate((element) => {
+      (element as HTMLDivElement).click();
+    });
+    await page.waitForTimeout(600);
+  }
+
+  await expect(page.locator('[data-testid="dialog-panel"]:visible')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+}
+
+export async function waitForCurrentDjLikeReaction(page: Page) {
+  const currentDj = page.locator('[data-testid="partyroom-current-dj"]');
+  await expect(currentDj).toHaveAttribute('data-reaction-type', 'LIKE', { timeout: 15_000 });
+  await expect(currentDj.locator('[data-testid="avatar-reaction"]')).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+export function getChatMessageItemByContent(page: Page, message: string) {
+  return page.locator('[data-testid="chat-message-item"]').filter({ hasText: message }).first();
+}
+
+export async function waitForChatMessage(page: Page, message: string) {
+  const chatItem = getChatMessageItemByContent(page, message);
+  await expect(chatItem).toBeVisible({ timeout: 15_000 });
+  return chatItem;
+}
+
+export async function waitForChatMessageToDisappear(page: Page, message: string) {
+  await expect(getChatMessageItemByContent(page, message)).toHaveCount(0, { timeout: 15_000 });
+}
+
+export async function getChatNicknameByMessage(page: Page, message: string) {
+  const chatItem = await waitForChatMessage(page, message);
+  return (
+    (await chatItem.locator('[data-testid="chat-message-nickname"]').textContent())?.trim() ?? ''
+  );
+}
+
+async function hoverAndOpenMenu(target: Locator) {
+  await expect(target).toBeVisible({ timeout: 15_000 });
+  await target.hover({ force: true });
+  const menuButton = target.locator('[data-testid$="menu-button"]');
+  await expect(menuButton).toBeVisible({ timeout: 10_000 });
+  await menuButton.click();
+}
+
+export async function blockCrewFromChatMessage(page: Page, message: string) {
+  const chatItem = page
+    .locator('[data-testid="chat-message-hover-item"]')
+    .filter({ hasText: message })
+    .first();
+  await hoverAndOpenMenu(chatItem);
+  await page.locator('[data-testid="chat-message-menu-block"]').click();
+}
+
+export async function clickCrewMenuAction(
+  page: Page,
+  nickname: string,
+  action: 'kick' | 'ban' | 'block'
+) {
+  const crewItem = page
+    .locator('[data-testid="crew-list-item-hover"]')
+    .filter({ hasText: nickname })
+    .first();
+  await hoverAndOpenMenu(crewItem);
+  await page.locator(`[data-testid="crew-menu-${action}"]`).click();
+}
+
+export async function liftBlockedCrew(page: Page, nickname: string) {
+  const blockedItem = page
+    .locator('[data-testid="restriction-list-item"]')
+    .filter({ hasText: nickname })
+    .first();
+  await expect(blockedItem).toBeVisible({ timeout: 15_000 });
+  await blockedItem.locator('[data-testid="restriction-block-lift-button"]').click();
+}
+
+export async function confirmPenaltyDialog(page: Page, reason: string) {
+  const reasonInput = page.locator('[data-testid="impose-penalty-reason-input"]');
+  await expect(reasonInput).toBeVisible({ timeout: 10_000 });
+  await reasonInput.fill(reason);
+
+  const confirmButton = page.locator('[data-testid="impose-penalty-confirm-button"]');
+  await expect(confirmButton).toBeEnabled({ timeout: 10_000 });
+  await confirmButton.click();
+}
+
+export async function confirmAlertDialog(page: Page, message?: string) {
+  const dialog = message
+    ? page.locator('[data-testid="dialog-panel"]').filter({ hasText: message }).first()
+    : page.locator('[data-testid="dialog-panel"]').first();
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  const confirmButton = dialog
+    .locator('[data-testid="alert-dialog-confirm-button"]')
+    .or(dialog.locator('[data-testid="error-dialog-confirm-button"]'))
+    .or(dialog.getByRole('button', { name: 'Confirm' }))
+    .or(dialog.getByRole('button', { name: '확인' }))
+    .or(dialog.getByRole('button', { name: 'Close' }))
+    .first();
+  await expect(confirmButton).toBeVisible({ timeout: 10_000 });
+  await confirmButton.click();
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
+export async function confirmPenaltyAlertAndWaitForLobby(page: Page, message: string) {
+  const dialog = page.locator('[data-testid="dialog-panel"]').filter({ hasText: message }).first();
+  await expect(dialog).toBeVisible({ timeout: 20_000 });
+  await dialog.locator('[data-testid="penalty-alert-confirm-button"]').click();
+  await page.waitForURL(/\/parties(?:\?.*)?$/, { timeout: 20_000 });
+}
+
 async function isDjingGuideHidden(page: Page) {
   return page.evaluate((key) => {
     const preferences = localStorage.getItem(key);
@@ -205,7 +512,9 @@ export async function closePartyroom(page: Page, partyroomUrl = page.url()) {
   // cleanup 시도. 응답 status 검증 안 함 — 정리 실패가 본 시나리오 검증
   // 결과를 가리지 않게 한다. 성공(200/204), 세션 만료(401), 이미 정리됨
   // (404), playwright client-side artifact 등 어떤 결과든 흡수한다.
-  await page.request.delete(new URL(`v1/partyrooms/${partyroomId}`, API_BASE_URL).toString());
+  await page.request
+    .delete(new URL(`v1/partyrooms/${partyroomId}`, API_BASE_URL).toString())
+    .catch(() => null);
 
   if (!page.isClosed()) {
     await page.goto('/parties');

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -38,15 +38,16 @@ export async function enterPartyroomAndWaitUntilReady(page: Page, partyroomUrl: 
 }
 
 export async function openDjQueueDrawer(page: Page) {
-  const djQueueButton = page.locator('[data-testid="dj-queue-button"]');
+  const djQueueButton = page.getByRole('button', { name: /^dj queue$/i });
   await expect(djQueueButton).toBeVisible({ timeout: 30_000 });
   await expect(djQueueButton).toBeEnabled({ timeout: 40_000 });
 
   await djQueueButton.click({ force: true }); // 알 수 없는 이유로 실패함
   await page.evaluate(() => {
-    const button = document.querySelector(
-      '[data-testid="dj-queue-button"]'
-    ) as HTMLButtonElement | null;
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const button = buttons.find((candidate) =>
+      /dj queue/i.test(candidate.textContent?.trim() ?? '')
+    ) as HTMLButtonElement | undefined;
     button?.click();
   });
 
@@ -98,16 +99,21 @@ async function pickShortTrackIndices(
 }
 
 export async function createPlaylistWithTracks(page: Page, playlistName: string) {
-  await page.locator('[data-testid="playlist-sidebar-button"]').click();
-  await expect(page.locator('[data-testid="add-playlist-button"]')).toBeVisible({ timeout: 5_000 });
-  await page.locator('[data-testid="add-playlist-button"]').click();
-  await expect(page.locator('[role="dialog"] input[name="name"]')).toBeVisible({ timeout: 5_000 });
-  await page.locator('[role="dialog"] input[name="name"]').fill(playlistName);
-  await page.locator('[data-testid="playlist-form-add-button"]').click();
-  await page.locator(`[data-testid="playlist-list-item"]:has-text("${playlistName}")`).click();
-  await page.locator('[data-testid="add-song-button"]').click();
-  await expect(page.locator('[data-testid="music-search-input"]')).toBeVisible({ timeout: 5_000 });
-  await page.locator('[data-testid="music-search-input"]').fill('new jeans');
+  await page.getByRole('button', { name: /^playlist$/i }).click();
+  await expect(page.getByRole('button', { name: /add list/i })).toBeVisible({ timeout: 5_000 });
+  await page.getByRole('button', { name: /add list/i }).click();
+
+  const playlistNameInput = page.locator('[role="dialog"] input[name="name"]');
+  await expect(playlistNameInput).toBeVisible({ timeout: 5_000 });
+  await playlistNameInput.fill(playlistName);
+  await page.getByRole('button', { name: /^add$/i }).click();
+
+  await page.getByRole('button', { name: new RegExp(playlistName) }).click();
+  await page.getByRole('button', { name: /add song/i }).click();
+
+  const musicSearchInput = page.getByPlaceholder(/search|url/i);
+  await expect(musicSearchInput).toBeVisible({ timeout: 5_000 });
+  await musicSearchInput.fill('new jeans');
   await page.waitForTimeout(1_000);
   const trackAddButtons = page.locator('[data-testid="track-add-button"]');
   await expect(trackAddButtons.nth(2)).toBeVisible({ timeout: 15_000 });
@@ -125,10 +131,10 @@ export async function createPartyroom(
   partyroomName: string,
   introduction = 'e2e-test'
 ) {
-  await page.locator('[data-testid="create-partyroom-button"]').click();
+  await page.getByRole('button', { name: /be a pfplay host/i }).click();
   await page.locator('input[name="name"]').fill(partyroomName);
   await page.locator('textarea[name="introduce"]').fill(introduction);
-  await page.locator('button[type="submit"]').click();
+  await page.getByRole('button', { name: /create party/i }).click();
   await page.waitForURL(/\/parties\/\d+/, { timeout: 20_000 });
 
   return page.url();
@@ -137,20 +143,20 @@ export async function createPartyroom(
 export async function registerAsDj(page: Page, playlistName?: string) {
   await openDjQueueDrawer(page);
 
-  const registerButton = page.locator('[data-testid="register-dj-queue"]');
+  const registerButton = page.getByRole('button', { name: /register.*dj queue|dj 대기 등록/i });
   const closeButton = page.locator(DJING_DIALOG_CLOSE_SELECTOR);
   await expect(registerButton).toBeVisible({ timeout: 10_000 });
   await expect(registerButton).toBeEnabled({ timeout: 10_000 });
   await registerButton.click({ force: true });
 
-  const confirmButton = page.locator('[data-testid="playlist-confirm"]');
+  const confirmButton = page.getByRole('button', { name: /^confirm$/i });
   await expect(confirmButton).toBeVisible({ timeout: 15_000 });
 
-  const playlistItems = page.locator('[data-testid="select-playlist-item"]');
+  const playlistItems = page.locator('[role="button"][data-testid="select-playlist-item"]');
   await expect(playlistItems.first()).toBeVisible({ timeout: 15_000 });
 
   const playlistItem = playlistName
-    ? page.locator(`[data-testid="select-playlist-item"]:has-text("${playlistName}")`)
+    ? page.getByRole('button', { name: new RegExp(playlistName) })
     : playlistItems.first();
   await expect(playlistItem).toBeVisible({ timeout: 15_000 });
   await playlistItem.click({ force: true });
@@ -164,7 +170,9 @@ export async function registerAsDj(page: Page, playlistName?: string) {
 export async function unregisterAsDj(page: Page) {
   await openDjQueueDrawer(page);
 
-  const unregisterButton = page.locator('[data-testid="unregister-dj-queue"]');
+  const unregisterButton = page.getByRole('button', {
+    name: /cancel dj queue registration|dj 대기 등록 취소/i,
+  });
   await expect(page.locator('[data-testid="current-dj-item"]')).toBeVisible({
     timeout: 30_000,
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,14 +42,48 @@ export default defineConfig({
 
   projects: [
     {
-      name: 'auth-setup',
-      testMatch: /auth\.setup\.ts/,
+      name: 'auth-a',
+      testMatch: /auth\/setup\.a\.ts/,
       teardown: undefined,
     },
     {
-      name: 'e2e',
+      name: 'auth-b',
+      testMatch: /auth\/setup\.b\.ts/,
+      teardown: undefined,
+    },
+    {
+      name: 'auth-c',
+      testMatch: /auth\/setup\.c\.ts/,
+      teardown: undefined,
+    },
+    {
+      name: 'auth-d',
+      testMatch: /auth\/setup\.d\.ts/,
+      teardown: undefined,
+    },
+    {
+      name: 'e2e-a',
+      testMatch: /e2e-a\..*\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
-      dependencies: ['auth-setup'],
+      dependencies: ['auth-a'],
+    },
+    {
+      name: 'e2e-b',
+      testMatch: /e2e-b\..*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['auth-b'],
+    },
+    {
+      name: 'e2e-c',
+      testMatch: /e2e-c\..*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['auth-c'],
+    },
+    {
+      name: 'e2e-d',
+      testMatch: /e2e-d\..*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['auth-d'],
     },
   ],
 });

--- a/src/app/parties/(room)/[id]/_panels/chat-tab-panel.component.tsx
+++ b/src/app/parties/(room)/[id]/_panels/chat-tab-panel.component.tsx
@@ -22,19 +22,21 @@ export default function ChatTabPanel({ className }: Props) {
         <Tab
           tabTitle={t.db.title.chat}
           variant='line'
+          dataTestId='partyroomChatPanel-tab'
           PrefixIcon={<PFChatFilled width={20} height={20} />}
         />
         <Tab
           tabTitle={crewsCount.toString()}
           variant='line'
+          dataTestId='partyroomCrewsPanel-tab'
           PrefixIcon={<PFPersonOutline width={20} height={20} />}
         />
       </TabList>
       <TabPanels className='flex-1 flexCol'>
-        <TabPanel tabIndex={0} className='flex-1 flexCol'>
+        <TabPanel tabIndex={0} className='flex-1 flexCol' data-testid='partyroomChatPanel-trigger'>
           <PartyroomChatPanel />
         </TabPanel>
-        <TabPanel tabIndex={1} className='flex-1 flexCol'>
+        <TabPanel tabIndex={1} className='flex-1 flexCol' data-testid='partyroomCrewsPanel-trigger'>
           <PartyroomCrewsPanel />
         </TabPanel>
       </TabPanels>

--- a/src/entities/avatar/ui/avatar.component.tsx
+++ b/src/entities/avatar/ui/avatar.component.tsx
@@ -65,6 +65,11 @@ const Avatar = memo(
         ref={ref}
         aria-label='Avatar View'
         role='presentation'
+        data-testid='avatar-view'
+        data-avatar-body-uri={bodyUri}
+        data-avatar-face-uri={faceUri ?? ''}
+        data-reaction-type={reaction ?? ''}
+        data-motion-type={motionType ?? ''}
         className={cn('relative will-change-transform')}
         style={{
           width: dimensions.width,
@@ -77,6 +82,7 @@ const Avatar = memo(
           <div
             aria-label='Avatar Reaction'
             role='presentation'
+            data-testid='avatar-reaction'
             className='absolute left-1/2 -top-6 transform -translate-x-1/2 -z-1'
           >
             <ReactionLottie reaction={reaction} />

--- a/src/entities/current-partyroom/lib/alerts/use-penalty-alert.hook.tsx
+++ b/src/entities/current-partyroom/lib/alerts/use-penalty-alert.hook.tsx
@@ -53,7 +53,9 @@ function useOpenPenaltyAlertDialog() {
             </Typography>
 
             <Dialog.ButtonGroup>
-              <Dialog.Button onClick={onCancel}>{t.common.btn.confirm}</Dialog.Button>
+              <Dialog.Button data-testid='penalty-alert-confirm-button' onClick={onCancel}>
+                {t.common.btn.confirm}
+              </Dialog.Button>
             </Dialog.ButtonGroup>
           </>
         ),

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -11,10 +11,12 @@ export default class PartyroomClient {
 
   public constructor() {
     this.socketClient = new SocketClient();
+    this.syncE2EDebugState();
   }
 
   public connect() {
     this.socketClient.connect();
+    this.syncE2EDebugState();
   }
 
   public get connected() {
@@ -33,11 +35,13 @@ export default class PartyroomClient {
 
     this.socketClient.subscribe(`/sub/partyrooms/${partyroomId}`, handler);
     this.subscribedRoomId = partyroomId;
+    this.syncE2EDebugState();
   }
 
   public unsubscribeCurrentRoom() {
     this.socketClient.unsubscribe(`/sub/partyrooms/${this.subscribedRoomId}`);
     this.subscribedRoomId = undefined;
+    this.syncE2EDebugState();
   }
 
   public sendChatMessage(message: string) {
@@ -47,5 +51,23 @@ export default class PartyroomClient {
     this.socketClient.send(`/pub/groups/${this.subscribedRoomId}/send`, {
       content: message,
     });
+  }
+
+  private syncE2EDebugState() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    (
+      window as Window & {
+        __PFPLAY_E2E__?: {
+          partyroomConnected: boolean;
+          subscribedRoomId?: number;
+        };
+      }
+    ).__PFPLAY_E2E__ = {
+      partyroomConnected: this.socketClient.connected,
+      subscribedRoomId: this.subscribedRoomId,
+    };
   }
 }

--- a/src/features/edit-profile-avatar/ui/avatar-body-list-item.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-body-list-item.component.tsx
@@ -31,6 +31,7 @@ const AvatarBodyListItem: FC<Props> = ({ meta }) => {
       selected={selectedAvatar.body?.resourceUri === meta.resourceUri}
       locked={locked.is}
       lockedMessage={locked.reason}
+      testId='avatar-body-list-item'
     />
   );
 };

--- a/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-body-list.component.tsx
@@ -6,7 +6,10 @@ const AvatarBodyList = () => {
   const { data: bodies = [] } = useFetchAvatarBodies();
 
   return (
-    <div className='flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max overflow-auto'>
+    <div
+      className='flex-1 grid grid-cols-2 gap-3 laptop:grid-cols-3 desktop:grid-cols-5 grid-rows-max auto-rows-max overflow-auto'
+      data-testid='avatar-body-list'
+    >
       {bodies.map((body) => (
         <AvatarBodyListItem key={body.id} meta={body} />
       ))}

--- a/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
@@ -23,6 +23,7 @@ const AvatarFaceListItem: FC<Props> = ({ meta, hideSelected }) => {
       imageSrc={meta.resourceUri}
       name={meta.name}
       selected={!hideSelected && selectedAvatar.faceUri === meta.resourceUri}
+      testId='avatar-face-list-item'
     />
   );
 };

--- a/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
@@ -34,6 +34,7 @@ const AvatarFaceList = () => {
             'overflow-hidden': !combinable,
           }
         )}
+        data-testid='avatar-face-list'
       >
         {faces.map((face) => (
           <AvatarFaceListItem key={face.resourceUri} meta={face} hideSelected={!combinable} />

--- a/src/features/edit-profile-avatar/ui/avatar-list-item.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-list-item.component.tsx
@@ -10,6 +10,7 @@ interface Props {
   selected: boolean;
   locked?: boolean;
   lockedMessage?: string;
+  testId?: string;
 }
 
 const AvatarListItem = ({
@@ -19,9 +20,16 @@ const AvatarListItem = ({
   selected,
   locked,
   lockedMessage,
+  testId,
 }: Props) => {
   return (
-    <div className='relative w-full max-width-[200px] aspect-square cursor-pointer group'>
+    <div
+      className='relative w-full max-width-[200px] aspect-square cursor-pointer group'
+      data-testid={testId}
+      data-image-src={imageSrc}
+      data-selected={selected ? 'true' : 'false'}
+      data-locked={locked ? 'true' : 'false'}
+    >
       <Image
         role='button'
         tabIndex={0}

--- a/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
+++ b/src/features/edit-profile-avatar/ui/profile-avatar-edit-panel.component.tsx
@@ -23,6 +23,7 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
     <div
       ref={containerRef}
       className='flexRow justify-start max-w-screen-desktop mx-auto gap-5 p-10 px-[60px]'
+      data-testid='avatar-edit-panel'
     >
       <SelectedAvatarStateProvider>
         <div className='flexCol items-start gap-10'>
@@ -32,8 +33,18 @@ export default function ProfileAvatarEditPanel({ titleRender, actions }: Props) 
         <div className='flex-1 h-full flexCol gap-2'>
           <TabGroup className='flex-1 flexCol overflow-hidden'>
             <TabList className='w-full flexRow'>
-              <Tab tabTitle='body' variant='line' className='w-auto' />
-              <Tab tabTitle='face' variant='line' className='w-auto' />
+              <Tab
+                tabTitle='body'
+                variant='line'
+                className='w-auto'
+                dataTestId='avatar-edit-body-tab'
+              />
+              <Tab
+                tabTitle='face'
+                variant='line'
+                className='w-auto'
+                dataTestId='avatar-edit-face-tab'
+              />
               <div className='flex-1 border-b-[1px] border-b-gray-400' />
             </TabList>
             <TabPanels className='flex-1 flexCol pb-2 overflow-hidden'>

--- a/src/features/edit-profile-avatar/ui/selected-avatar.component.tsx
+++ b/src/features/edit-profile-avatar/ui/selected-avatar.component.tsx
@@ -6,7 +6,12 @@ const SelectedAvatar = () => {
   const selectedAvatar = useSelectedAvatarState();
 
   return (
-    <div className='w-[360px] h-full min-h-[500px] flexCol justify-center items-center bg-black select-none'>
+    <div
+      className='w-[360px] h-full min-h-[500px] flexCol justify-center items-center bg-black select-none'
+      data-testid='avatar-edit-selected-preview'
+      data-avatar-body-uri={selectedAvatar.body?.resourceUri ?? ''}
+      data-avatar-face-uri={selectedAvatar.faceUri ?? ''}
+    >
       {selectedAvatar.body && (
         <Avatar
           height={400}

--- a/src/features/edit-profile-bio/ui/v2-view.component.tsx
+++ b/src/features/edit-profile-bio/ui/v2-view.component.tsx
@@ -23,7 +23,11 @@ const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps)
   return (
     <div className='gap-5 flexRow'>
       <div className='flexCol gap-9'>
-        <div className='w-max h-[216px] flexRowCenter bg-[#1D1D1D] pointer-events-none select-none'>
+        <div
+          className='w-max h-[216px] flexRowCenter bg-[#1D1D1D] pointer-events-none select-none'
+          data-testid='my-profile-avatar-preview'
+          data-avatar-body-uri={me.avatarBodyUri ?? ''}
+        >
           {!!me.avatarBodyUri && (
             <Avatar
               height={180}
@@ -39,7 +43,12 @@ const V2ViewMode = ({ onAvatarSettingClick, changeToEditMode }: V2ViewModeProps)
           )}
         </div>
 
-        <Button size='sm' variant='outline' onClick={onAvatarSettingClick}>
+        <Button
+          size='sm'
+          variant='outline'
+          onClick={onAvatarSettingClick}
+          data-testid='my-profile-avatar-settings-button'
+        >
           {t.lobby.title.ava_settings}
         </Button>
       </div>

--- a/src/features/partyroom/impose-penalty/lib/use-impose-penalty.hook.tsx
+++ b/src/features/partyroom/impose-penalty/lib/use-impose-penalty.hook.tsx
@@ -64,6 +64,7 @@ export default function useImposePenalty() {
         return (
           <>
             <Input
+              data-testid='impose-penalty-reason-input'
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               minLength={2}
@@ -71,10 +72,15 @@ export default function useImposePenalty() {
               classNames={{ container: 'mb-9' }}
             />
             <Dialog.ButtonGroup>
-              <Dialog.Button color='secondary' onClick={onClose}>
+              <Dialog.Button
+                data-testid='impose-penalty-cancel-button'
+                color='secondary'
+                onClick={onClose}
+              >
                 {t.common.btn.cancel}
               </Dialog.Button>
               <Dialog.Button
+                data-testid='impose-penalty-confirm-button'
                 loading={isPending}
                 onClick={handleConfirmBtnClick}
                 disabled={disabled}

--- a/src/shared/ui/components/collapse-list/collapse-list.component.tsx
+++ b/src/shared/ui/components/collapse-list/collapse-list.component.tsx
@@ -11,6 +11,7 @@ type CollapseListProps = {
   title: string;
   infoText?: string;
   displaySuffix?: boolean;
+  buttonTestId?: string;
   classNames?: {
     button?: string;
     panel?: string;
@@ -24,6 +25,7 @@ const CollapseList = ({
   variant = 'default',
   children,
   displaySuffix = true,
+  buttonTestId,
   classNames,
 }: PropsWithChildren<CollapseListProps>) => {
   return (
@@ -31,6 +33,7 @@ const CollapseList = ({
       {({ open }) => (
         <>
           <DisclosureButton
+            data-testid={buttonTestId}
             className={cn(
               'w-full flexRow justify-between items-center px-4 py-3 rounded bg-gray-800 text-left text-gray-50 hover:bg-gray-700 ',
               variant === 'default' && 'border-none',

--- a/src/shared/ui/components/dialog/dialog.component.tsx
+++ b/src/shared/ui/components/dialog/dialog.component.tsx
@@ -120,11 +120,11 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
             leaveFrom='opacity-100'
             leaveTo='opacity-0'
           >
-            <div className='fixed inset-0 bg-dim' />
+            <div data-testid='dialog-backdrop' className='fixed inset-0 bg-dim' />
           </Transition.Child>
         )}
 
-        <div className='fixed inset-0 overflow-y-auto'>
+        <div data-testid='dialog-overlay-container' className='fixed inset-0 overflow-y-auto'>
           <div className='flex min-h-full items-center justify-center p-4 text-center'>
             <Transition.Child
               as={Fragment}
@@ -136,6 +136,7 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
               leaveTo='opacity-0 scale-95'
             >
               <HUDialog.Panel
+                data-testid='dialog-panel'
                 className={cn(
                   'pt-[52px] px-[32px] pb-[32px] w-[440px] max-w-full transform rounded-[6px] bg-gray-800 border border-gray-700 transition-all',
                   classNames?.container
@@ -157,6 +158,7 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
                   >
                     {showCloseIcon && (
                       <TextButton
+                        data-testid='dialog-close-button'
                         onClick={handleClose}
                         Icon={<PFClose width={24} height={24} />}
                         className='absolute top-[2.5px] right-0'

--- a/src/shared/ui/components/dialog/use-dialog.hook.tsx
+++ b/src/shared/ui/components/dialog/use-dialog.hook.tsx
@@ -43,7 +43,9 @@ export const useDialog = () => {
               )}
 
               <Dialog.ButtonGroup>
-                <Dialog.Button onClick={onCancel}>{okText}</Dialog.Button>
+                <Dialog.Button data-testid='alert-dialog-confirm-button' onClick={onCancel}>
+                  {okText}
+                </Dialog.Button>
               </Dialog.ButtonGroup>
             </>
           ),
@@ -71,10 +73,19 @@ export const useDialog = () => {
               )}
 
               <Dialog.ButtonGroup>
-                <Dialog.Button color='secondary' onClick={() => onOk(false)}>
+                <Dialog.Button
+                  data-testid='confirm-dialog-cancel-button'
+                  color='secondary'
+                  onClick={() => onOk(false)}
+                >
                   {cancelText}
                 </Dialog.Button>
-                <Dialog.Button onClick={() => onOk(true)}>{okText}</Dialog.Button>
+                <Dialog.Button
+                  data-testid='confirm-dialog-confirm-button'
+                  onClick={() => onOk(true)}
+                >
+                  {okText}
+                </Dialog.Button>
               </Dialog.ButtonGroup>
             </>
           ),
@@ -103,7 +114,9 @@ export const useDialog = () => {
               </Typography>
 
               <Dialog.ButtonGroup>
-                <Dialog.Button onClick={onCancel}>{t.common.btn.confirm}</Dialog.Button>
+                <Dialog.Button data-testid='error-dialog-confirm-button' onClick={onCancel}>
+                  {t.common.btn.confirm}
+                </Dialog.Button>
               </Dialog.ButtonGroup>
             </>
           ),

--- a/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
+++ b/src/shared/ui/components/display-option-menu-on-hover-listener/display-option-menu-on-hover-listener.component.tsx
@@ -11,6 +11,8 @@ interface DisplayOptionMenuOnHoverListenerProps {
   children: ReactElement | ((isHover: boolean) => ReactElement);
   menuPositionClassName?: string;
   menuItemPanelSize?: MenuItemPanelSize;
+  menuButtonTestId?: string;
+  containerTestId?: string;
   disabled?: boolean;
 }
 
@@ -19,6 +21,8 @@ const DisplayOptionMenuOnHoverListener = ({
   children,
   menuPositionClassName,
   menuItemPanelSize = 'md',
+  menuButtonTestId,
+  containerTestId,
   listenerDisabled = false,
   disabled,
 }: DisplayOptionMenuOnHoverListenerProps) => {
@@ -63,6 +67,7 @@ const DisplayOptionMenuOnHoverListener = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onClick={handleClick}
+      data-testid={containerTestId}
       className='relative'
     >
       {typeof children === 'function' ? children(isHover) : children}
@@ -80,6 +85,7 @@ const DisplayOptionMenuOnHoverListener = ({
 
           <IconMenu
             MenuButtonIcon={<PFMoreVert />}
+            menuButtonTestId={menuButtonTestId}
             menuItemConfig={menuConfig}
             onMenuIconClick={handleMenuIconClick}
             onMenuClose={handleMenuClose}

--- a/src/shared/ui/components/icon-menu/icon-menu.component.tsx
+++ b/src/shared/ui/components/icon-menu/icon-menu.component.tsx
@@ -13,6 +13,7 @@ interface IconMenuProps {
   };
   menuContainerClassName?: string;
   MenuButtonIcon: ReactNode;
+  menuButtonTestId?: string;
   onMenuClose?: () => void;
   onMenuIconClick?: () => void;
 }
@@ -21,6 +22,7 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
   (
     {
       MenuButtonIcon,
+      menuButtonTestId,
       menuItemConfig,
       menuContainerClassName,
       onMenuClose,
@@ -39,7 +41,11 @@ const IconMenu = forwardRef<HTMLDivElement, IconMenuProps>(
         <Menu as='section' className={`relative w-fit`}>
           {({ close }) => (
             <>
-              <MenuButton type='icon' onMenuIconClick={onMenuIconClick}>
+              <MenuButton
+                type='icon'
+                onMenuIconClick={onMenuIconClick}
+                data-testid={menuButtonTestId}
+              >
                 {MenuButtonIcon}
               </MenuButton>
               <MenuItemPanel

--- a/src/shared/ui/components/menu/menu-button.component.tsx
+++ b/src/shared/ui/components/menu/menu-button.component.tsx
@@ -6,17 +6,20 @@ import { buttonColorsDict, buttonSizeDict } from '../button';
 interface MenuButtonProps {
   type: 'icon' | 'button';
   onMenuIconClick?: () => void;
+  'data-testid'?: string;
 }
 export const MenuButton = ({
   type = 'icon',
   children,
   onMenuIconClick,
+  'data-testid': dataTestId,
 }: PropsWithChildren<MenuButtonProps>) => {
   return (
     <_MenuButton
       onClick={() => {
         onMenuIconClick?.();
       }}
+      data-testid={dataTestId}
       className={cn(
         'flex h-max items-center justify-center gap-[8px] rounded-[4px]',
         type === 'icon' && 'flex items-center gap-2 text-gray-50 p-1',

--- a/src/shared/ui/components/tab/tab.component.tsx
+++ b/src/shared/ui/components/tab/tab.component.tsx
@@ -8,6 +8,7 @@ interface CommonProps {
   tabTitle: string;
   PrefixIcon?: ReactNode;
   className?: string;
+  dataTestId?: string;
 }
 interface BoxProps {
   variant?: 'box';
@@ -24,6 +25,7 @@ const Tab = (props: TabProps) => {
       <HeadlessUITab as={Fragment}>
         {({ selected }) => (
           <button
+            data-testid={props.dataTestId}
             className={cn(
               getCommentTabStyle(selected),
               props.variant === 'box' && 'py-[13px] px-[47px] bg-black text-gray-50',
@@ -43,6 +45,7 @@ const Tab = (props: TabProps) => {
 
   return (
     <HeadlessUITab
+      data-testid={props.dataTestId}
       className={({ selected }) =>
         cn(
           getCommentTabStyle(selected),

--- a/src/shared/ui/components/user-list-item/user-list-item.component.tsx
+++ b/src/shared/ui/components/user-list-item/user-list-item.component.tsx
@@ -12,6 +12,8 @@ type UserListItemProps = {
   userListItemConfig: UserListItemType;
   menuItemList?: MenuItem[];
   menuItemPanelSize?: MenuItemPanelSize;
+  dataTestId?: string;
+  menuButtonTestId?: string;
   suffix?: {
     type: SuffixType;
     Component: ReactNode;
@@ -23,11 +25,16 @@ const UserListItem = ({
   userListItemConfig,
   menuItemList,
   menuItemPanelSize,
+  dataTestId,
+  menuButtonTestId,
   suffix,
   menuDisabled,
 }: UserListItemProps) => {
   const innerElement = (
-    <div className='relative w-full flexRow justify-between items-center py-2 px-4 rounded-[4px]'>
+    <div
+      className='relative w-full flexRow justify-between items-center py-2 px-4 rounded-[4px]'
+      data-testid={dataTestId}
+    >
       <div className='flexRow justify-center items-center gap-2'>
         <Image
           src={userListItemConfig.avatarIconUri || '/images/ETC/monkey.png'}
@@ -36,7 +43,11 @@ const UserListItem = ({
           height={32}
           className='w-8 h-8 rounded-full'
         />
-        <Typography type='detail1' className='text-white'>
+        <Typography
+          type='detail1'
+          className='text-white'
+          data-testid={dataTestId ? `${dataTestId}-nickname` : undefined}
+        >
           {userListItemConfig.nickname}
         </Typography>
       </div>
@@ -54,6 +65,8 @@ const UserListItem = ({
       menuConfig={menuItemList}
       menuPositionClassName='top-[8px] right-[12px]'
       menuItemPanelSize={menuItemPanelSize}
+      menuButtonTestId={menuButtonTestId}
+      containerTestId={dataTestId ? `${dataTestId}-hover` : undefined}
       disabled={menuDisabled}
     >
       {innerElement}

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -53,6 +53,9 @@ export default function Avatars() {
       {!!dj && (
         <div
           data-testid='partyroom-current-dj'
+          data-crew-id={String(dj.crewId)}
+          data-avatar-body-uri={dj.avatarBodyUri}
+          data-reaction-type={dj.reactionType ?? ''}
           className='relative'
           style={{
             top: '98%',
@@ -82,6 +85,9 @@ export default function Avatars() {
         <div
           key={'partyroom-dj-queue-' + crew.crewId + index}
           className='absolute'
+          data-crew-id={String(crew.crewId)}
+          data-avatar-body-uri={crew.avatarBodyUri}
+          data-reaction-type={crew.reactionType ?? ''}
           style={{
             top: `${position.y}px`,
             left: `${position.x}px`,
@@ -114,6 +120,10 @@ export default function Avatars() {
           <div
             key={'partyroom-crew-' + crew.crewId + index}
             className='absolute'
+            data-testid='partyroom-crew-item'
+            data-crew-id={String(crew.crewId)}
+            data-avatar-body-uri={crew.avatarBodyUri}
+            data-reaction-type={crew.reactionType ?? ''}
             style={{
               top: `${position.y}px`,
               left: `${position.x}px`,

--- a/src/widgets/partyroom-chat-panel/ui/chat-item.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/chat-item.component.tsx
@@ -19,7 +19,11 @@ const ChatItem = forwardRef<HTMLDivElement, ChatItemProps>(({ message }, ref) =>
   const emphasisGradeLabel = myGradeComparator.isHigherThanOrEqualTo(GradeType.MODERATOR);
 
   return (
-    <div ref={ref} className='flex justify-start items-start gap-[13px]'>
+    <div
+      ref={ref}
+      className='flex justify-start items-start gap-[13px]'
+      data-testid='chat-message-item'
+    >
       <div className='flexCol items-center gap-2 px-[5px] pt-[2px]'>
         <div className='relative'>
           <Profile src={crew.avatarIconUri} size={32} />
@@ -41,12 +45,15 @@ const ChatItem = forwardRef<HTMLDivElement, ChatItemProps>(({ message }, ref) =>
       </div>
 
       <div className='flex-1 flexCol items-start gap-1'>
-        <Typography type='detail2'>{crew.nickname}</Typography>
+        <Typography type='detail2' data-testid='chat-message-nickname'>
+          {crew.nickname}
+        </Typography>
 
         <Typography
           type='caption1'
           className='bg-gray-900 p-2 rounded-sm text-white'
           style={{ wordBreak: 'break-word' }}
+          data-testid='chat-message-content'
         >
           {message.message.content}
         </Typography>

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -112,17 +112,22 @@ export default function PartyroomChatPanel() {
                   label: t.common.btn.kick,
                   onClickItem: () => onClickImposePenalty(PenaltyType.ONE_TIME_EXPULSION),
                   visible: _canImposePenalty,
+                  testId: 'chat-message-menu-kick',
                 },
                 {
                   label: t.common.btn.ban,
                   onClickItem: () => onClickImposePenalty(PenaltyType.PERMANENT_EXPULSION),
                   visible: _canImposePenalty,
+                  testId: 'chat-message-menu-ban',
                 },
                 {
                   label: t.common.btn.block,
                   onClickItem: () => blockCrew({ crewId: message.crew.crewId }),
+                  testId: 'chat-message-menu-block',
                 },
               ]}
+              menuButtonTestId='chat-message-menu-button'
+              containerTestId='chat-message-hover-item'
             >
               <ChatItem message={message} ref={isLast ? lastItemRef : undefined} />
             </DisplayOptionMenuOnHoverListener>
@@ -133,6 +138,7 @@ export default function PartyroomChatPanel() {
       <SendChatMessage>
         {({ message, setMessage, send, canSend }) => (
           <Input
+            data-testid='chat-message-input'
             size='lg'
             variant='outlined'
             disabled={banned}
@@ -144,6 +150,7 @@ export default function PartyroomChatPanel() {
             }}
             Suffix={
               <Button
+                data-testid='chat-message-send-button'
                 color='secondary'
                 variant='fill'
                 Icon={<PFSend width={20} height={20} />}

--- a/src/widgets/partyroom-crews-panel/lib/use-get-restirction-panel-list-items.hook.tsx
+++ b/src/widgets/partyroom-crews-panel/lib/use-get-restirction-panel-list-items.hook.tsx
@@ -31,6 +31,7 @@ export default function useGetRestrictionPanelListItems() {
         size='xs'
         color='secondary'
         variant='outline'
+        data-testid='restriction-penalty-lift-button'
         onClick={() => liftPenalty({ partyroomId, penaltyId: penalty.penaltyId })}
       >
         Lift{/* TODO: i18n */}
@@ -41,6 +42,7 @@ export default function useGetRestrictionPanelListItems() {
         size='xs'
         color='secondary'
         variant='outline'
+        data-testid='restriction-block-lift-button'
         onClick={() => unblockCrew({ blockId: blockedCrew.blockId })}
       >
         Lift{/* TODO: i18n */}

--- a/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
+++ b/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
@@ -21,7 +21,12 @@ export default function AllCrewsPanel() {
   return (
     <div className='flex flex-col gap-6'>
       {Object.entries(Crews.categorizeByGradeType(crews)).map(([category, crews]) => (
-        <CollapseList key={'AllCrewsPanel' + category} title={category} displaySuffix={false}>
+        <CollapseList
+          key={'AllCrewsPanel' + category}
+          title={category}
+          displaySuffix={false}
+          buttonTestId={`all-crews-category-${category}`}
+        >
           {crews.map((crew) => {
             const _canImposePenalty = canImposePenalty(crew.gradeType);
             const onClickImposePenalty = (penaltyType: PenaltyType) => {
@@ -72,9 +77,12 @@ export default function AllCrewsPanel() {
                   {
                     label: t.common.btn.block,
                     onClickItem: () => blockCrew({ crewId: crew.crewId }),
+                    testId: 'crew-menu-block',
                   },
                 ]}
                 menuItemPanelSize='sm'
+                dataTestId='crew-list-item'
+                menuButtonTestId='crew-menu-button'
                 suffix={suffix && { type: 'tag', Component: suffix }}
                 menuDisabled={me?.crewId === crew.crewId}
               />

--- a/src/widgets/partyroom-crews-panel/ui/parts/restriction-panel.component.tsx
+++ b/src/widgets/partyroom-crews-panel/ui/parts/restriction-panel.component.tsx
@@ -24,11 +24,13 @@ export default function RestrictionPanel() {
           key={'RestrictionPanel' + category}
           title={RestrictionPanelListItem.getCategoryLabel(category, t)}
           displaySuffix={false}
+          buttonTestId={`restriction-category-${category}`}
         >
           {items.map((item) => (
             <UserListItem
               key={'RestrictionPanel' + category + item.crewId}
               userListItemConfig={item}
+              dataTestId='restriction-list-item'
               suffix={{
                 type: 'button',
                 Component: item.suffix,

--- a/src/widgets/partyroom-crews-panel/ui/partyroom-crews-panel.component.tsx
+++ b/src/widgets/partyroom-crews-panel/ui/partyroom-crews-panel.component.tsx
@@ -18,15 +18,25 @@ export default function PartyroomCrewsPanel() {
             crews.length.toString().padStart(2, '0')
           )}
           variant='text'
+          dataTestId='allCrewsPanel-tab'
           className='w-fit p-0'
         />
-        <Tab tabTitle={t.crews.title.restriction} variant='text' className='w-fit p-0' />
+        <Tab
+          tabTitle={t.crews.title.restriction}
+          variant='text'
+          dataTestId='restrictionPanel-tab'
+          className='w-fit p-0'
+        />
       </TabList>
       <TabPanels className='flex-1 flexCol'>
-        <TabPanel tabIndex={0} className='flex-1 flexCol'>
+        <TabPanel tabIndex={0} className='flex-1 flexCol' data-testid='allCrewsPanel-trigger'>
           <AllCrewsPanel />
         </TabPanel>
-        <TabPanel tabIndex={1} className='flex-1 flexCol overflow-hidden'>
+        <TabPanel
+          tabIndex={1}
+          className='flex-1 flexCol overflow-hidden'
+          data-testid='restrictionPanel-trigger'
+        >
           <RestrictionPanel />
         </TabPanel>
       </TabPanels>

--- a/src/widgets/partyroom-display-board/ui/parts/action-button.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/action-button.component.tsx
@@ -9,6 +9,8 @@ type Props = {
   active: boolean;
   activeColor?: 'red' | 'green' | 'white';
   onClick: () => void;
+  testId?: string;
+  textTestId?: string;
 };
 
 export default function ActionButton({
@@ -18,11 +20,14 @@ export default function ActionButton({
   active,
   activeColor,
   onClick,
+  testId,
+  textTestId,
 }: Props) {
   return (
     <button
       disabled={disabled}
       onClick={onClick}
+      data-testid={testId}
       className={cn(
         'appearance-none w-[48px] h-[44px] flexColCenter text-center gap-[4px] rounded bg-gray-800 text-gray-200',
         {
@@ -41,7 +46,7 @@ export default function ActionButton({
       }}
     >
       {icon}
-      <Typography type='detail1' className='leading-none'>
+      <Typography type='detail1' className='leading-none' data-testid={textTestId}>
         {text}
       </Typography>
     </button>

--- a/src/widgets/partyroom-display-board/ui/parts/action-buttons.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/action-buttons.component.tsx
@@ -33,6 +33,8 @@ export default function ActionButtons() {
       <ActionButton
         icon={<PFThumbUpAlt width={18} height={18} />}
         text={reaction.aggregation.likeCount}
+        testId='playback-like-button'
+        textTestId='playback-like-count'
         disabled={!playbackActivated}
         active={flag.isLiked}
         activeColor='red'
@@ -47,6 +49,8 @@ export default function ActionButtons() {
       <ActionButton
         icon={<PFPlaylistAdd width={18} height={18} />}
         text={reaction.aggregation.grabCount}
+        testId='playback-grab-button'
+        textTestId='playback-grab-count'
         disabled={!playbackActivated || flag.isGrabbed} // NOTE: grab은 끌 수 없음
         active={flag.isGrabbed}
         activeColor='green'
@@ -61,6 +65,8 @@ export default function ActionButtons() {
       <ActionButton
         icon={<PFThumbDownAlt width={18} height={18} />}
         text={reaction.aggregation.dislikeCount}
+        testId='playback-dislike-button'
+        textTestId='playback-dislike-count'
         disabled={!playbackActivated}
         active={flag.isDisliked}
         activeColor='white'

--- a/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
+++ b/src/widgets/partyroom-edit-profile-avatar-dialog/ui/use-open-edit-profile-avatar-dialog.hook.tsx
@@ -25,6 +25,7 @@ export default function useOpenEditProfileAvatarDialog() {
                 color='secondary'
                 onClick={onCancel}
                 className='w-[200px] max-w-full'
+                data-testid='avatar-edit-cancel-button'
               >
                 {t.common.btn.cancel}
               </Button>
@@ -36,6 +37,7 @@ export default function useOpenEditProfileAvatarDialog() {
                     disabled={!canSubmit}
                     loading={loading}
                     className='w-[200px] max-w-full'
+                    data-testid='avatar-edit-save-button'
                   >
                     {t.common.btn.save}
                   </Button>

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -67,7 +67,11 @@ export default function Sidebar({ className, onClickAvatarSetting, extraButtons 
 
   return (
     <aside className={className}>
-      <button onClick={handleClickProfileButton} className='gap-2 cursor-pointer flexColCenter'>
+      <button
+        onClick={handleClickProfileButton}
+        className='gap-2 cursor-pointer flexColCenter'
+        data-testid='sidebar-my-profile-button'
+      >
         <Profile size={48} src={me.avatarIconUri} />
         <Typography type='caption1' className='text-gray-200'>
           {t.common.btn.my_profile}


### PR DESCRIPTION
### Summary

  - Playwright E2E 시나리오에 saction(E2E-C), profile/avatar/reaction/chat(E2E-D) 흐름을 추가했습니다.
  - 기존 A, B를 포함한 전체 시나리오의 selector를 semantic 우선 기준으로 정리하고 helper를 보강해 테스트 안정성을 개선했습니다.
  - E2E README를 최신 구조와 selector 가이드에 맞게 정리했습니다.

### Changes

E2E 시나리오 추가
- `e2e-c.partyroom-moderation.spec.ts` 추가
- 관리자 기준 moderation 흐름을 검증하도록 구성
- block 이후 채팅 필터링 반영
- restriction panel 에서 unblock 처리
- kick 이후 lobby 이동 및 재입장 가능 여부 확인
- ban 이후 lobby 이동 및 재입장 제한 확인

E2E 시나리오 추가
- `e2e-d.profile-avatar-reaction-chat.spec.ts` 추가
- 프로필 아바타 변경 이후 현재 DJ 아바타 반영 여부 검증
- 현재 playback 에 대한 like reaction 반영 검증
- 채팅 송신 이후 메시지 렌더링 검증

E2E helper / selector 정리
- `e2e/helpers/partyroom.helpers.ts` 확장
- 공통 진입/생성/패널 오픈/제재 액션/채팅/아바타 관련 동작을 helper 로 정리
- E2E-C, D에 이어 기존 A, B 시나리오도 selector 기준을 정리
- `getByRole` 등 semantic selector 를 우선 사용하도록 변경
- 반복 리스트, hover 메뉴, attribute 상태 검증처럼 role 기반 선택이 불안정한 구간만 `data-testid` 유지
- 불필요한 `data-testid` 의존을 줄이고 helper 내부 selector 기준을 문서화된 방향에 맞춤

테스트 지원용 UI 조정
- 아바타, 채팅, crew panel, dialog, menu, tab, display board 등 여러 UI 컴포넌트에
  테스트에서 안정적으로 접근 가능한 anchor/test id/attribute 를 최소 범위로 추가
- current DJ 영역에서 avatar body / reaction 상태를 attribute 기반으로 검증할 수 있도록 보강
- moderation / profile avatar 관련 사용자 흐름이 실제 UI 상태 변화와 연결되도록 관련 컴포넌트와 client 동작 정리

문서 / CI 정리
- `e2e/README.md` 업데이트
- 현재 디렉토리 구조, 시나리오 역할, auth/storageState 구조, helper 설계 의도 정리
- selector 우선순위와 `data-testid` 사용 기준 문서화
- preview E2E workflow를 포함한 Vercel 관련 GitHub Actions에서 Vercel CLI 버전을 고정해 latest 설치 이슈 영향을 피하도록 수정

 ### Test

- 로컬 환경에서 신규/기존 E2E 시나리오 회귀 검증 완료
- 관련 테스트 및 기본 동작 확인 완료