### PR TITLE
fix(grade-label): HOST 라벨 'Admin' → 'Host'

### DIFF
--- a/src/entities/current-partyroom/config/grade-type-label.ts
+++ b/src/entities/current-partyroom/config/grade-type-label.ts
@@ -1,7 +1,7 @@
 import { GradeType } from '@/shared/api/http/types/@enums';
 
 export const GRADE_TYPE_LABEL: Record<GradeType, string> = {
-  [GradeType.HOST]: 'Admin',
+  [GradeType.HOST]: 'Host',
   [GradeType.COMMUNITY_MANAGER]: 'Community Manager',
   [GradeType.MODERATOR]: 'Moderator',
   [GradeType.CLUBBER]: 'Clubber',

--- a/src/entities/partyroom-client/config/grade-type-label.ts
+++ b/src/entities/partyroom-client/config/grade-type-label.ts
@@ -1,7 +1,7 @@
 import { GradeType } from '@/shared/api/http/types/@enums';
 
 export const GRADE_TYPE_LABEL: Record<GradeType, string> = {
-  [GradeType.HOST]: 'Admin',
+  [GradeType.HOST]: 'Host',
   [GradeType.COMMUNITY_MANAGER]: 'CM',
   [GradeType.MODERATOR]: 'Mod',
   [GradeType.CLUBBER]: 'Clubber',

--- a/src/features/partyroom/create/ui/form.component.tsx
+++ b/src/features/partyroom/create/ui/form.component.tsx
@@ -50,7 +50,7 @@ export default function PartyroomCreateForm({ onSuccess }: Props) {
         <FormItem
           label={
             <Typography as='span' type='body2'>
-              Admin
+              Host
             </Typography>
           }
           classNames={{ label: 'text-gray-200' }}


### PR DESCRIPTION
## Summary
HOST grade 라벨을 "Admin" → "Host"로 변경. 호스트는 시스템 관리자가 아니라 파티룸 owner이므로 "Admin"은 오해 소지가 있었음.

## Files
- `src/entities/partyroom-client/config/grade-type-label.ts` — 채팅 아이콘 밑 grade 라벨 (`chat-item.component.tsx`에서 사용)
- `src/entities/current-partyroom/config/grade-type-label.ts` — grade 변경 alert / dropdown options (현재 HOST가 노출되는 코드 경로는 없으나 일관성을 위해 함께)
- `src/features/partyroom/create/ui/form.component.tsx` — 파티룸 생성 폼에서 본인(생성자=호스트) 옆 라벨

## 화면 영향 범위
- ✓ **채팅 아이콘 밑 라벨** "Admin" → "Host" (일반 파티룸 호스트, Main Stage의 super admin 모두 해당)
- ✓ **파티룸 생성 폼**의 본인 옆 라벨
- ✗ grade adjust dropdown / 변경 alert / system msg — `Permission.adjustableGrades = lowerGrades`라 HOST는 옵션·prev·next 어디에도 등장하지 않으므로 시각 변화 없음

## Side-effect 점검
- Unit/E2E test에서 라벨 문자열 직접 assert하는 곳 없음
- Snapshot test 없음
- Analytics tracker는 라벨 문자열 사용 안 함
- 새 i18n 키 추가가 아니므로 xlsx drift 무관
- 백엔드 API 무관

## Test plan
- [x] Vitest: `partyroom-chat-panel`, `partyroom-client`, `current-partyroom`, `partyroom/create`, `partyroom/adjust-grade` 패키지 — 27 files / 198 tests pass, 회귀 0건
- [ ] stg 배포 후 채팅창 + 파티룸 생성 폼에서 "Host" 라벨 확인

## Context
직전 작업 [pfplay-platform PR #208](https://github.com/pfplay/pfplay-platform/pull/208)에서 super admin이 Main Stage host로 자가치유되는 fix가 prod 진입했고, 그 시점에 채팅 라벨 "Admin"이 사용자분 눈에 띄었음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)