### PR TITLE
fix(e2e): e2e dev 로그인 인증 세션 저장 플로우 안정화

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [development]
+    branches: [fix-ci-stg-auth-setup-flake]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [fix-ci-stg-auth-setup-flake]
+    branches: [development]
   workflow_dispatch:
 
 jobs:

--- a/e2e/auth/shared.ts
+++ b/e2e/auth/shared.ts
@@ -1,25 +1,8 @@
 import path from 'path';
-import { Browser, Locator, Page, expect } from '@playwright/test';
+import { Browser, Page, expect } from '@playwright/test';
 import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 
 export const AUTH_DIR = path.join(__dirname, '../.auth');
-
-async function waitForDialogToSettle(dialog: Locator) {
-  await expect(dialog).toBeVisible({ timeout: 10_000 });
-  await expect
-    .poll(
-      async () =>
-        dialog.evaluate((element) =>
-          element
-            .getAnimations({ subtree: true })
-            .every(
-              (animation) => animation.playState === 'finished' || animation.playState === 'idle'
-            )
-        ),
-      { timeout: 5_000 }
-    )
-    .toBe(true);
-}
 
 async function clickDevFullCrewSignIn(page: Page) {
   const devBtn = page.locator('[data-testid="dev-sign-in-button"]');
@@ -31,22 +14,13 @@ async function clickDevFullCrewSignIn(page: Page) {
     .locator('[data-testid="dialog-panel"]')
     .filter({ has: page.locator('[data-testid="dev-sign-in-full"]') })
     .first();
-  await waitForDialogToSettle(dialog);
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
 
   const fullCrewButton = dialog.locator('[data-testid="dev-sign-in-full"]');
   await expect(fullCrewButton).toBeVisible({ timeout: 10_000 });
   await expect(fullCrewButton).toBeEnabled({ timeout: 10_000 });
-  await Promise.all([
-    page.waitForResponse(
-      (response) =>
-        response.request().method() === 'POST' &&
-        response.url().includes('/v1/users/members/sign/temporary/full-member') &&
-        response.ok(),
-      { timeout: 10_000 }
-    ),
-    fullCrewButton.click({ force: true }),
-  ]);
-  await expect(dialog).toBeHidden({ timeout: 10_000 });
+  await fullCrewButton.click();
+  await expect(dialog).toBeHidden({ timeout: 15_000 });
 }
 
 export async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
@@ -86,7 +60,7 @@ export async function authenticateUser(browser: Browser, outputPath: string, bas
   log('clicking full crew sign-in');
   await clickDevFullCrewSignIn(page);
 
-  log('goto /parties explicitly after sign-in response');
+  log('goto /parties explicitly after dialog closed');
   await page.goto(`${baseURL}/parties`);
   await page.waitForURL(/\/parties(?:$|\/)/, { timeout: 10_000 });
   log(`arrived at /parties, current URL: ${page.url()}`);

--- a/e2e/auth/shared.ts
+++ b/e2e/auth/shared.ts
@@ -8,7 +8,7 @@ async function clickDevFullCrewSignIn(page: Page) {
   const devBtn = page.locator('[data-testid="dev-sign-in-button"]');
   await expect(devBtn).toBeVisible({ timeout: 10_000 });
   await expect(devBtn).toBeEnabled({ timeout: 10_000 });
-  await devBtn.click();
+  await devBtn.click({ force: true });
 
   const dialog = page
     .locator('[data-testid="dialog-panel"]')
@@ -19,7 +19,7 @@ async function clickDevFullCrewSignIn(page: Page) {
   const fullCrewButton = dialog.locator('[data-testid="dev-sign-in-full"]');
   await expect(fullCrewButton).toBeVisible({ timeout: 10_000 });
   await expect(fullCrewButton).toBeEnabled({ timeout: 10_000 });
-  await fullCrewButton.click();
+  await fullCrewButton.click({ force: true });
   await expect(dialog).toBeHidden({ timeout: 15_000 });
 }
 

--- a/e2e/auth/shared.ts
+++ b/e2e/auth/shared.ts
@@ -36,7 +36,17 @@ async function clickDevFullCrewSignIn(page: Page) {
   const fullCrewButton = dialog.locator('[data-testid="dev-sign-in-full"]');
   await expect(fullCrewButton).toBeVisible({ timeout: 10_000 });
   await expect(fullCrewButton).toBeEnabled({ timeout: 10_000 });
-  await fullCrewButton.click({ force: true });
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/v1/users/members/sign/temporary/full-member') &&
+        response.ok(),
+      { timeout: 10_000 }
+    ),
+    fullCrewButton.click({ force: true }),
+  ]);
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
 }
 
 export async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
@@ -76,32 +86,10 @@ export async function authenticateUser(browser: Browser, outputPath: string, bas
   log('clicking full crew sign-in');
   await clickDevFullCrewSignIn(page);
 
-  const pfpPlayButton = page.locator('[data-testid="home-pfp-play-button"]');
-  log('waiting until page is effectively ready for /parties');
-  await expect
-    .poll(
-      async () => {
-        if (/\/parties(?:$|\/)/.test(page.url())) {
-          return 'ready';
-        }
-
-        if (await pfpPlayButton.isVisible().catch(() => false)) {
-          return (await pfpPlayButton.getAttribute('href')) === '/parties' ? 'ready' : 'waiting';
-        }
-
-        return 'waiting';
-      },
-      { timeout: 30_000 }
-    )
-    .toBe('ready');
-  log(`page became ready, current URL: ${page.url()}`);
-
-  if (!/\/parties(?:$|\/)/.test(page.url())) {
-    log('goto /parties explicitly');
-    await page.goto(`${baseURL}/parties`);
-    await page.waitForURL(/\/parties/, { timeout: 10_000 });
-    log(`arrived at /parties, current URL: ${page.url()}`);
-  }
+  log('goto /parties explicitly after sign-in response');
+  await page.goto(`${baseURL}/parties`);
+  await page.waitForURL(/\/parties(?:$|\/)/, { timeout: 10_000 });
+  log(`arrived at /parties, current URL: ${page.url()}`);
   log(`writing storageState to ${outputPath}`);
   await context.storageState({ path: outputPath });
   log('storageState written');

--- a/e2e/e2e-a.partyroom-join-sync.spec.ts
+++ b/e2e/e2e-a.partyroom-join-sync.spec.ts
@@ -76,24 +76,9 @@ test('User2(late join)는 User1이 재생 중인 곡과 동일한 곡을 player�
   let partyroomUrl: string | undefined;
 
   try {
-    log('user1 goto /');
-    await page1.goto('/');
-
-    const pfpPlayButton = page1.locator('[data-testid="home-pfp-play-button"]');
-    if (await pfpPlayButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      // useFetchMe 완료 전에는 href가 /sign-in일 수 있으므로 실제 목적지가 바뀔 때까지 대기
-      log('home pfp play button visible, waiting for href=/parties');
-      await expect(pfpPlayButton).toHaveAttribute('href', '/parties', { timeout: 15_000 });
-      log(`href became /parties, current URL: ${page1.url()}`);
-      await pfpPlayButton.click();
-      log('clicked home pfp play button, waiting for /parties');
-      await page1.waitForURL(/\/parties$/, { timeout: 10_000 });
-      log(`arrived at /parties from home, current URL: ${page1.url()}`);
-    } else {
-      log('home pfp play button not visible, goto /parties directly');
-      await page1.goto('/parties');
-      log(`arrived at /parties directly, current URL: ${page1.url()}`);
-    }
+    log('user1 goto /parties');
+    await page1.goto('/parties');
+    log(`arrived at /parties, current URL: ${page1.url()}`);
 
     // ─── User1: 플레이리스트 생성 + 트랙 추가 ───────────────────────────
     const uniquePlaylistName = `E2EA${Date.now().toString(36)}`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
 
   // 테스트 작업 나눠서 돌릴 워커 수
-  workers: 1,
+  workers: process.env.CI ? 2 : 1,
 
   // 테스트 결과 출력할 형식
   reporter: process.env.CI ? 'github' : 'list',


### PR DESCRIPTION
### Summary
  E2E dev 로그인 후 인증 세션 저장 플로우를 단순화하고, /parties 진입 기준으로 인증 완료를 판별하도록 정리해 CI
  플래키니스를 줄였습니다. 함께 STG 인증 세션 생성, E2E 진입 경로, Playwright 워커 수, GitHub Actions 타깃 브랜
  치 설정도 안정화했습니다.

  ### Changes

  - e2e/auth/shared.ts
      - dev 로그인 버튼과 full crew 선택 버튼 클릭 흐름을 단순화
      - 다이얼로그 애니메이션 종료를 복잡하게 폴링하던 로직 제거
      - 로그인 후 홈 상태를 간접 판별하지 않고, 다이얼로그가 닫힌 뒤 /parties로 명시적으로 이동해 인증 세션 저장
      - STG 인증 세션 생성 과정에서도 동일한 안정화 방향 반영
  - e2e/e2e-a.partyroom-join-sync.spec.ts
      - 홈에서 버튼 href 변경을 기다리며 진입하던 로직 제거
      - 테스트 시작 시 바로 /parties로 진입하도록 변경
  - playwright.config.ts
      - CI 환경 워커 수를 1 -> 2로 조정해 실행 효율 개선
  - .github/workflows/vercel-preview-e2e.yml
      - preview E2E 대상 브랜치 설정 복구
      - CI에서 안정화된 E2E 플로우를 기준으로 실행되도록 정리

  ### Test

  - STG 환경
      - 인증 세션 생성 후 /parties 기준으로 로그인 완료가 안정적으로 판별되는지 확인
      - VERCEL_AUTOMATION_BYPASS_SECRET 적용 상태에서 CI와 동일한 흐름으로 통과하는지 확인
  - CI
      - GitHub Actions preview E2E가 올바른 브랜치를 대상으로 실행되는지 확인
      - Playwright workers=2 설정에서 세션 충돌이나 초기 진입 플래키니스 없이 통과하는지 확인