### PR TITLE
fix(e2e): preview e2e flake 안정화 — DJ queue drawer + auth cold-start

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [fix/e2e-b-dj-queue-drawer-flake]
+    branches: [development]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [development]
+    branches: [fix/e2e-b-dj-queue-drawer-flake]
   workflow_dispatch:
 
 jobs:

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -38,33 +38,36 @@ export async function enterPartyroomAndWaitUntilReady(page: Page, partyroomUrl: 
 }
 
 export async function openDjQueueDrawer(page: Page) {
+  const drawerCloseButton = page
+    .locator(DJING_DIALOG_CLOSE_SELECTOR)
+    .or(page.locator(DJING_DIALOG_CLOSE_SELECTOR_EMPTY))
+    .first();
+  const isDrawerOpen = () => drawerCloseButton.isVisible().catch(() => false);
+
+  if (await isDrawerOpen()) {
+    return;
+  }
+
+  if (await page.locator('[data-testid="dialog-panel"]:visible').count()) {
+    await closeVisibleDialogOverlays(page);
+  }
+
   const djQueueButton = page.getByRole('button', { name: /^dj queue$/i });
   await expect(djQueueButton).toBeVisible({ timeout: 30_000 });
   await expect(djQueueButton).toBeEnabled({ timeout: 40_000 });
 
-  await djQueueButton.click({ force: true }); // 알 수 없는 이유로 실패함
-  await page.evaluate(() => {
-    const buttons = Array.from(document.querySelectorAll('button'));
-    const button = buttons.find((candidate) =>
-      /dj queue/i.test(candidate.textContent?.trim() ?? '')
-    ) as HTMLButtonElement | undefined;
-    button?.click();
-  });
+  await djQueueButton.click({ force: true });
+  if (!(await isDrawerOpen())) {
+    await page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll('button'));
+      const button = buttons.find((candidate) =>
+        /dj queue/i.test(candidate.textContent?.trim() ?? '')
+      ) as HTMLButtonElement | undefined;
+      button?.click();
+    });
+  }
 
-  await expect
-    .poll(
-      async () =>
-        (await page
-          .locator(DJING_DIALOG_CLOSE_SELECTOR)
-          .isVisible()
-          .catch(() => false)) ||
-        (await page
-          .locator(DJING_DIALOG_CLOSE_SELECTOR_EMPTY)
-          .isVisible()
-          .catch(() => false)),
-      { timeout: 10_000 }
-    )
-    .toBe(true);
+  await expect.poll(isDrawerOpen, { timeout: 10_000 }).toBe(true);
 }
 
 function parseDurationToMinutes(text: string): number {

--- a/src/shared/api/http/client/client.ts
+++ b/src/shared/api/http/client/client.ts
@@ -10,9 +10,13 @@ import {
   unwrapResponse,
 } from './interceptors/response';
 
+// Preview/CI 콜드 스타트(러너→Vercel→백엔드 cross-region) 대응을 위해 환경변수로 override 가능.
+// 미설정 시 production 디폴트 4s 유지.
+const HTTP_TIMEOUT_MS = Number(process.env.NEXT_PUBLIC_HTTP_TIMEOUT_MS) || 4000;
+
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_HOST_NAME,
-  timeout: 4000,
+  timeout: HTTP_TIMEOUT_MS,
   validateStatus: (status) => status >= 200 && status < 400,
   withCredentials: true,
 });


### PR DESCRIPTION
  ## Summary

  preview e2e에서 산발적으로 떨어지던 두 가지 flake를 잡습니다.

  ### Changes
1) DJ queue drawer toggle race (`e2e/helpers/partyroom.helpers.ts`)
  - 기존: drawer가 이미 열려 있어도 `Dj queue` 버튼을 다시 클릭 → 토글로 닫혀 폴링 타임아웃.
  - 수정: 클릭 전 drawer 상태(`isDrawerOpen`)를 먼저 확인해 idempotent하게 동작.
  - 추가: 다른 dialog가 시야를 가로채는 케이스 대비 → `dialog-panel:visible` 검출 시
  `closeVisibleDialogOverlays`로 정리 후 클릭.
  - 단순화: drawer가 이미 열려 있으면 DOM-evaluate fallback 클릭은 스킵.

  ### 2) Auth setup cold-start timeout (`src/shared/api/http/client/client.ts`)
  GitHub Actions runner → Vercel edge → 백엔드의 cross-region cold-start가 axios 기본 timeout 4s를 초과하면서
  `temporary_SignInFullCrew` POST가 reject되고, dialog가 열린 채로 `/sign-in`에 멈춰 auth setup 전체가 무너지는
  패턴이 재현됨.

  ```ts
  const HTTP_TIMEOUT_MS = Number(process.env.NEXT_PUBLIC_HTTP_TIMEOUT_MS) || 4000;
  ```
빌드 시 NEXT_PUBLIC_HTTP_TIMEOUT_MS를 읽어 override 가능하게 변경. 미설정 시 production 디폴트 4s 그대로 유지
  — production은 영향 없음, Preview에만 여유를 줌.
  
  Required ops change (merge 전)

  - Vercel Project → Settings → Environment Variables → Preview 에 NEXT_PUBLIC_HTTP_TIMEOUT_MS=15000 등록
  - 미등록 시 이 PR의 timeout fix가 빌드에 인라인되지 않아 무효.

 ####  Test plan

  - preview e2e on fix branch — 11/11 통과 확인
  - merge 직전 .github/workflows/vercel-preview-e2e.yml 의 branches: 를 [development]로 환원
  - 머지 후 development push로 preview e2e 정상 통과 확인