### PR TITLE
fix(e2e): CI cold-start flake 안정화 — beforeAll 보강 + workers 1 직렬화

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [fix/e2e-b-cold-start-flake]
+    branches: [development]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -2,7 +2,7 @@ name: preview deploy and e2e
 
 on:
   push:
-    branches: [development]
+    branches: [fix/e2e-b-cold-start-flake]
   workflow_dispatch:
 
 jobs:

--- a/e2e/e2e-b.dj-state-machine.spec.ts
+++ b/e2e/e2e-b.dj-state-machine.spec.ts
@@ -82,6 +82,11 @@ test.describe('E2E-B: DJ 상태 머신 + 다중 클라이언트 동기화', () =
   };
 
   test.beforeAll(async ({ browser }) => {
+    // CI cold-start 시 me fetch + sidebar mount 가 지연되어 60s 내 setup 이 끝나지
+    // 못해 timeout 이 발생했다. 두 사용자의 playlist 생성 + partyroom 생성을 모두
+    // 포함하므로 기본 60s 보다 넉넉하게 잡는다.
+    test.setTimeout(90_000);
+
     const timestamp = Date.now().toString(36);
     user1PlaylistName = `E2EB-U1-${timestamp}`;
     user2PlaylistName = `E2EB-U2-${timestamp}`;

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -125,7 +125,12 @@ async function pickShortTrackIndices(
 }
 
 export async function createPlaylistWithTracks(page: Page, playlistName: string) {
-  await page.getByRole('button', { name: /^playlist$/i }).click();
+  // Sidebar 의 Playlist 버튼은 ProtectedLayout 이 me 쿼리 로드 완료 후에만 그려진다.
+  // CI cold-start 시 me fetch 가 길어져 sidebar 가 늦게 mount 되므로 명시적 wait 으로
+  // 실패 메시지를 명확히 하고, 기본 expect 타임아웃(15s)보다 넉넉하게 둔다.
+  const playlistButton = page.getByRole('button', { name: /^playlist$/i });
+  await expect(playlistButton).toBeVisible({ timeout: 30_000 });
+  await playlistButton.click();
   await expect(page.getByRole('button', { name: /add list/i })).toBeVisible({ timeout: 5_000 });
   await page.getByRole('button', { name: /add list/i }).click();
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
 
   // 테스트 작업 나눠서 돌릴 워커 수
-  workers: process.env.CI ? 2 : 1,
+  // CI 의 cross-region + cold-start 환경에서 2 workers 가 동일 백엔드/Vercel 을
+  // 동시 hit 하면 워밍 안 된 상태에서 상호 간섭으로 flake 가 발생한다. 총 소요
+  // 시간이 늘더라도 안정성 우선으로 CI 도 1 worker 로 직렬화.
+  workers: 1,
 
   // 테스트 결과 출력할 형식
   reporter: process.env.CI ? 'github' : 'list',


### PR DESCRIPTION
  ## Summary
  - e2e-b `beforeAll` 60s → 90s, Playlist 버튼 명시적 wait 추가 — cold-start 시 sidebar mount
  지연으로 click 이 무한 대기하던 케이스 해소
  - CI workers 2 → 1 — cross-region + cold backend 를 두 워커가 동시 hit 하며 e2e-a/b/c, auth
  까지 연쇄 timeout 나던 간섭 제거

  ## Test plan
  - [x] CI preview e2e (fix branch trigger) 통과
  - [ ] 머지 후 development push 재확인