### PR TITLE
fix: 파티룸 목록 카드 배경과 아바타 클러스터 위치 안정화

### DIFF
--- a/src/features/partyroom/list/ui/main-partyroom-card.component.tsx
+++ b/src/features/partyroom/list/ui/main-partyroom-card.component.tsx
@@ -22,11 +22,14 @@ export default function MainPartyroomCard({ onClose }: MainPartyroomCardProps) {
     return null; // 메인 파티룸은 항상 존재한다고 가정하지만, 최소한의 안전장치.
   }
   return (
-    <BackdropBlurContainer>
+    <BackdropBlurContainer
+      src={partyroom.playback?.thumbnailImage}
+      alt={partyroom.playback?.name || t.lobby.para.pfplay_main_stage}
+    >
       <Link
         href={`/parties/${partyroom.partyroomId}?source=list`}
         onClick={onClose}
-        className='flexCol tablet:flexRow items-start tablet:items-end gap-[20px] tablet:gap-[50px] desktop:gap-[169px] px-7 py-10 backdrop-blur-xl bg-backdrop-black/80'
+        className='flexCol tablet:flexRow items-start tablet:items-end gap-[20px] tablet:gap-[50px] desktop:gap-[169px] px-7 py-10 backdrop-blur-sm bg-backdrop-black/80'
       >
         <div className='flexCol gap-6 tablet:gap-12 pb-[21px]'>
           <div className='gap-3 flexCol'>

--- a/src/features/partyroom/list/ui/main-partyroom-card.component.tsx
+++ b/src/features/partyroom/list/ui/main-partyroom-card.component.tsx
@@ -7,6 +7,7 @@ import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { BackdropBlurContainer } from '@/shared/ui/components/backdrop-blur-container';
 import { Typography } from '@/shared/ui/components/typography';
 import Crews from './crews.component';
+import { getPartyroomCardBackdropProps } from './partyroom-card-backdrop';
 import { useSuspenseFetchMainPartyroom } from '../api/use-fetch-main-partyroom.query';
 
 interface MainPartyroomCardProps {
@@ -24,7 +25,7 @@ export default function MainPartyroomCard({ onClose }: MainPartyroomCardProps) {
   return (
     <BackdropBlurContainer
       src={partyroom.playback?.thumbnailImage}
-      alt={partyroom.playback?.name || t.lobby.para.pfplay_main_stage}
+      {...getPartyroomCardBackdropProps(partyroom.playback?.thumbnailImage)}
     >
       <Link
         href={`/parties/${partyroom.partyroomId}?source=list`}

--- a/src/features/partyroom/list/ui/partyroom-card-backdrop.ts
+++ b/src/features/partyroom/list/ui/partyroom-card-backdrop.ts
@@ -1,0 +1,9 @@
+const PARTYROOM_CARD_FALLBACK_SRC = '/images/Background/Partyroom.png';
+const PARTYROOM_CARD_FALLBACK_IMAGE_CLASS_NAME = 'object-[24%_60%] scale-110';
+
+export function getPartyroomCardBackdropProps(thumbnailImage?: string) {
+  return {
+    fallbackSrc: PARTYROOM_CARD_FALLBACK_SRC,
+    imageClassName: thumbnailImage ? undefined : PARTYROOM_CARD_FALLBACK_IMAGE_CLASS_NAME,
+  };
+}

--- a/src/features/partyroom/list/ui/partyroom-card.component.tsx
+++ b/src/features/partyroom/list/ui/partyroom-card.component.tsx
@@ -26,11 +26,14 @@ const PartyroomCard = ({ roomId, summary, onClose }: PartyroomCardProps) => {
   };
 
   return (
-    <BackdropBlurContainer>
+    <BackdropBlurContainer
+      src={summary.playback?.thumbnailImage}
+      alt={summary.playback?.name || summary.title}
+    >
       <Link
         href={`/parties/${roomId}?source=list`}
         onClick={handleClick}
-        className='h-full flexCol justify-between gap-[61px] py-6 px-7 backdrop-blur-xl bg-backdrop-black/80'
+        className='h-full flexCol justify-between gap-[61px] py-6 px-7 backdrop-blur-sm bg-backdrop-black/80'
       >
         <Typography type='title2' className='text-gray-50'>
           {summary.title}

--- a/src/features/partyroom/list/ui/partyroom-card.component.tsx
+++ b/src/features/partyroom/list/ui/partyroom-card.component.tsx
@@ -9,6 +9,7 @@ import { BackdropBlurContainer } from '@/shared/ui/components/backdrop-blur-cont
 import { Typography } from '@/shared/ui/components/typography';
 import { PFInfoOutline } from '@/shared/ui/icons';
 import Crews from './crews.component';
+import { getPartyroomCardBackdropProps } from './partyroom-card-backdrop';
 
 interface PartyroomCardProps {
   roomId: number;
@@ -28,7 +29,7 @@ const PartyroomCard = ({ roomId, summary, onClose }: PartyroomCardProps) => {
   return (
     <BackdropBlurContainer
       src={summary.playback?.thumbnailImage}
-      alt={summary.playback?.name || summary.title}
+      {...getPartyroomCardBackdropProps(summary.playback?.thumbnailImage)}
     >
       <Link
         href={`/parties/${roomId}?source=list`}

--- a/src/shared/ui/components/backdrop-blur-container/backdrop-blur-container.component.tsx
+++ b/src/shared/ui/components/backdrop-blur-container/backdrop-blur-container.component.tsx
@@ -16,16 +16,19 @@ const BackdropBlurContainer = ({
   children,
 }: PropsWithChildren<BackdropBlurContainerProps>) => {
   return (
-    <div className={cn('relative border border-gray-800 rounded cursor-pointer', className)}>
+    <div
+      className={cn(
+        'relative overflow-hidden border border-gray-800 rounded cursor-pointer',
+        className
+      )}
+    >
       <div className='absolute inset-1'>
-        {/* FIXME: replace the image according to api spec */}
         <Image
           priority
           src={src || '/images/ETC/PlaylistThumbnail.png'}
           alt={alt || 'backdrop image'}
-          width={80}
-          height={40}
-          className='object-fill w-full h-full p-2 select-none'
+          fill
+          className='object-cover select-none scale-105'
         />
       </div>
       {children}

--- a/src/shared/ui/components/backdrop-blur-container/backdrop-blur-container.component.tsx
+++ b/src/shared/ui/components/backdrop-blur-container/backdrop-blur-container.component.tsx
@@ -5,14 +5,16 @@ import { cn } from '@/shared/lib/functions/cn';
 
 interface BackdropBlurContainerProps {
   src?: string;
-  alt?: string;
   className?: string;
+  fallbackSrc?: string;
+  imageClassName?: string;
 }
 
 const BackdropBlurContainer = ({
   src,
-  alt,
   className,
+  fallbackSrc,
+  imageClassName,
   children,
 }: PropsWithChildren<BackdropBlurContainerProps>) => {
   return (
@@ -25,10 +27,10 @@ const BackdropBlurContainer = ({
       <div className='absolute inset-1'>
         <Image
           priority
-          src={src || '/images/ETC/PlaylistThumbnail.png'}
-          alt={alt || 'backdrop image'}
+          src={src || fallbackSrc || '/images/ETC/PlaylistThumbnail.png'}
+          alt={'backdrop image'}
           fill
-          className='object-cover select-none scale-105'
+          className={cn('object-cover select-none scale-105', imageClassName)}
         />
       </div>
       {children}

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
@@ -24,7 +24,13 @@ beforeEach(() => {
 
 describe('useAvatarCluster', () => {
   test('빈 크루 리스트에서 빈 결과를 반환한다', () => {
-    const { result } = renderHook(() => useAvatarCluster({ crews: [], djQueueCrewIds: [] }));
+    const { result } = renderHook(() =>
+      useAvatarCluster({
+        crews: [],
+        djQueueCrewIds: [],
+        stageBounds: { width: 1920, height: 1080 },
+      })
+    );
 
     expect(result.current.courtPositions).toEqual([]);
     expect(result.current.queuePositions).toEqual([]);
@@ -33,7 +39,9 @@ describe('useAvatarCluster', () => {
   test('크루에 position을 할당한다', () => {
     const crews = [makeCrew(1), makeCrew(2), makeCrew(3)];
 
-    const { result } = renderHook(() => useAvatarCluster({ crews, djQueueCrewIds: [] }));
+    const { result } = renderHook(() =>
+      useAvatarCluster({ crews, djQueueCrewIds: [], stageBounds: { width: 1920, height: 1080 } })
+    );
 
     expect(result.current.courtPositions).toHaveLength(3);
     result.current.courtPositions.forEach((c) => {
@@ -46,7 +54,13 @@ describe('useAvatarCluster', () => {
   test('DJ 대기열 크루를 분리한다', () => {
     const crews = [makeCrew(1), makeCrew(2), makeCrew(3)];
 
-    const { result } = renderHook(() => useAvatarCluster({ crews, djQueueCrewIds: [2] }));
+    const { result } = renderHook(() =>
+      useAvatarCluster({
+        crews,
+        djQueueCrewIds: [2],
+        stageBounds: { width: 1920, height: 1080 },
+      })
+    );
 
     expect(result.current.courtPositions).toHaveLength(2);
     expect(result.current.queuePositions).toHaveLength(1);
@@ -56,11 +70,42 @@ describe('useAvatarCluster', () => {
   test('모든 position이 유한한 숫자이다', () => {
     const crews = Array.from({ length: 10 }, (_, i) => makeCrew(i + 1));
 
-    const { result } = renderHook(() => useAvatarCluster({ crews, djQueueCrewIds: [3, 7] }));
+    const { result } = renderHook(() =>
+      useAvatarCluster({
+        crews,
+        djQueueCrewIds: [3, 7],
+        stageBounds: { width: 1920, height: 1080 },
+      })
+    );
 
     [...result.current.courtPositions, ...result.current.queuePositions].forEach((c) => {
       expect(Number.isFinite(c.position.x)).toBe(true);
       expect(Number.isFinite(c.position.y)).toBe(true);
+    });
+  });
+
+  test('stage bounds가 바뀌면 기존 위치를 새 스테이지 비율에 맞춰 재계산한다', () => {
+    const crews = [makeCrew(1), makeCrew(2), makeCrew(3)];
+
+    const { result, rerender } = renderHook(
+      ({ stageBounds }) => useAvatarCluster({ crews, djQueueCrewIds: [], stageBounds }),
+      {
+        initialProps: { stageBounds: { width: 1920, height: 1080 } },
+      }
+    );
+
+    const initialPositions = result.current.courtPositions;
+
+    rerender({ stageBounds: { width: 960, height: 540 } });
+
+    const resizedPositions = result.current.courtPositions;
+
+    expect(resizedPositions).toHaveLength(initialPositions.length);
+    resizedPositions.forEach((position, index) => {
+      expect(position.position.x).not.toBe(initialPositions[index].position.x);
+      expect(position.position.y).not.toBe(initialPositions[index].position.y);
+      expect(position.position.x).toBeGreaterThanOrEqual(0);
+      expect(position.position.y).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.ts
@@ -20,6 +20,7 @@ import {
 type D3Node = SimulationNodeDatum & Crew.Model & { fx?: number; fy?: number };
 type PositionedCrew = Crew.Model & { position: Point };
 export type CrewPosition = { crewId: number; position: Point };
+export type StageBounds = { width: number; height: number };
 
 export type OvalBounds = {
   centerX: number;
@@ -90,17 +91,20 @@ function runClusterSimulation({
   crews,
   existingNodes,
   ovalConfig,
+  stageBounds,
+  prevStageBounds,
 }: {
   crews: Crew.Model[];
   existingNodes: D3Node[];
   ovalConfig: OvalConfig;
+  stageBounds: StageBounds;
+  prevStageBounds?: StageBounds;
 }): { positionedCrews: PositionedCrew[]; updatedNodes: D3Node[] } {
   if (crews.length === 0) {
     return { positionedCrews: [], updatedNodes: [] };
   }
 
-  const width = window.innerWidth;
-  const height = window.innerHeight;
+  const { width, height } = stageBounds;
   const centerX = width * ovalConfig.CENTER_X_RATIO;
   const centerY = height * ovalConfig.CENTER_Y_RATIO;
 
@@ -201,6 +205,32 @@ function runClusterSimulation({
     return bestPosition;
   };
 
+  const normalizeNodeToStage = (node: D3Node): D3Node => {
+    if (!prevStageBounds) {
+      return node;
+    }
+
+    const prevCenterX = prevStageBounds.width * ovalConfig.CENTER_X_RATIO;
+    const prevCenterY = prevStageBounds.height * ovalConfig.CENTER_Y_RATIO;
+    const prevRadiusX = prevStageBounds.width * ovalConfig.RADIUS_X_RATIO;
+    const prevRadiusY = prevStageBounds.height * ovalConfig.RADIUS_Y_RATIO;
+    const x = node.x ?? prevCenterX;
+    const y = node.y ?? prevCenterY;
+
+    const normalizedX = prevRadiusX === 0 ? 0 : (x - prevCenterX) / prevRadiusX;
+    const normalizedY = prevRadiusY === 0 ? 0 : (y - prevCenterY) / prevRadiusY;
+    const nextX = centerX + normalizedX * ovalRadiusX;
+    const nextY = centerY + normalizedY * ovalRadiusY;
+
+    return {
+      ...node,
+      x: nextX,
+      y: nextY,
+      fx: nextX,
+      fy: nextY,
+    };
+  };
+
   // 기존 노드 위치 고정
   const keptNodes = existingNodes.map((n) => {
     if (!incomingIds.has(n.crewId)) return n;
@@ -208,13 +238,13 @@ function runClusterSimulation({
     const updatedCrew = crews.find((c) => c.crewId === n.crewId);
     if (!updatedCrew) return n;
 
-    return {
+    return normalizeNodeToStage({
       ...updatedCrew,
       x: n.x,
       y: n.y,
       fx: n.x,
       fy: n.y,
-    };
+    });
   });
 
   // 기존 노드들의 위치 정보
@@ -291,9 +321,11 @@ function runClusterSimulation({
 export function useAvatarCluster({
   crews,
   djQueueCrewIds,
+  stageBounds,
 }: {
   crews: Crew.Model[];
   djQueueCrewIds: number[];
+  stageBounds: StageBounds;
 }): {
   courtPositions: CrewPosition[];
   queuePositions: CrewPosition[];
@@ -305,14 +337,24 @@ export function useAvatarCluster({
   const queueNodesRef = useRef<D3Node[]>([]);
   const prevCrewIdsRef = useRef<string>('');
   const prevQueueIdsRef = useRef<string>('');
+  const prevCourtStageBoundsRef = useRef<StageBounds>();
+  const prevQueueStageBoundsRef = useRef<StageBounds>();
 
   useEffect(() => {
+    if (stageBounds.width <= 0 || stageBounds.height <= 0) {
+      return;
+    }
+
     const currentCrewIdsKey = JSON.stringify(crews.map((c) => c.crewId).sort());
     const currentQueueIdsKey = JSON.stringify([...djQueueCrewIds].sort());
+    const stageBoundsChanged =
+      prevCourtStageBoundsRef.current?.width !== stageBounds.width ||
+      prevCourtStageBoundsRef.current?.height !== stageBounds.height;
 
     if (
       prevCrewIdsRef.current === currentCrewIdsKey &&
-      prevQueueIdsRef.current === currentQueueIdsKey
+      prevQueueIdsRef.current === currentQueueIdsKey &&
+      !stageBoundsChanged
     ) {
       return; // 미변경 시 early return
     }
@@ -329,19 +371,25 @@ export function useAvatarCluster({
       crews: courtCrews,
       existingNodes: courtNodesRef.current,
       ovalConfig: OVAL_CONFIG_COURT,
+      stageBounds,
+      prevStageBounds: prevCourtStageBoundsRef.current,
     });
     courtNodesRef.current = courtResult.updatedNodes;
     setCourtClustered(courtResult.positionedCrews);
+    prevCourtStageBoundsRef.current = stageBounds;
 
     const queueResult = runClusterSimulation({
       crews: queueCrews,
       existingNodes: queueNodesRef.current,
       ovalConfig: OVAL_CONFIG_QUEUE,
+      stageBounds,
+      prevStageBounds: prevQueueStageBoundsRef.current,
     });
 
     queueNodesRef.current = queueResult.updatedNodes;
     setQueueClustered(queueResult.positionedCrews);
-  }, [crews, djQueueCrewIds]);
+    prevQueueStageBoundsRef.current = stageBounds;
+  }, [crews, djQueueCrewIds, stageBounds]);
 
   return {
     courtPositions: courtClustered.map(({ crewId, position }) => ({ crewId, position })),

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 import { Avatar } from '@/entities/avatar';
 import { BASE_SCALE, BASE_X, BASE_Y } from '@/entities/avatar/config/base-size';
 import { useAvatarDance } from '@/entities/avatar/ui/useAvatarDance.hook';
@@ -30,10 +31,41 @@ export default function Avatars() {
     : [];
 
   const { registerAvatar } = useAvatarDance();
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const [stageBounds, setStageBounds] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const element = stageRef.current;
+    if (!element) {
+      return;
+    }
+
+    const updateStageBounds = () => {
+      setStageBounds({
+        width: element.clientWidth,
+        height: element.clientHeight,
+      });
+    };
+
+    updateStageBounds();
+
+    const observer = new ResizeObserver(() => {
+      updateStageBounds();
+    });
+
+    observer.observe(element);
+    window.addEventListener('resize', updateStageBounds);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateStageBounds);
+    };
+  }, []);
 
   const { courtPositions, queuePositions } = useAvatarCluster({
     crews: crews,
     djQueueCrewIds: djQueueCrewIds,
+    stageBounds,
   });
 
   const crewMap = new Map(crews.map((c) => [c.crewId, c]));
@@ -49,7 +81,10 @@ export default function Avatars() {
      * 파티룸 배경과 같은 aspect ratio, bg-cover, bg-left-bottom, overflow-hidden 를 적용하여,
      * 화면 신축에 상관 없이 배경 이미지 상 항상 같은 위치에 아바타가 위치하도록 함
      */
-    <div className='h-screen aspect-partyroom-bg absolute inset-0 z-0 bg-cover bg-left-bottom overflow-hidden'>
+    <div
+      ref={stageRef}
+      className='h-screen aspect-partyroom-bg absolute inset-0 z-0 bg-cover bg-left-bottom overflow-hidden'
+    >
       {!!dj && (
         <div
           data-testid='partyroom-current-dj'


### PR DESCRIPTION
## Summary

  파티룸 목록 화면의 시각적 완성도와 아바타 배치 안정성을 개선했습니다.
  - 파티룸 목록 카드와 메인 파티룸 카드에 현재 재생 중인 썸네일을 배경으로 적용했습니
  다.
  - 썸네일이 없는 경우에는 무대 배경 이미지를 fallback으로 사용하도록 처리했습니다.
  - 파티룸 리사이즈, DJ 변경, DJ 대기열 변경 시 아바타 클러스터 위치가 흔들리거나 비정
  상적으로 재배치되던 문제를 수정했습니다.
  - 스테이지 실제 크기를 기준으로 아바타 위치를 계산하도록 변경하고, 리사이즈 시 기존
  위치를 비율에 맞게 재정규화하도록 보완했습니다.

  ## 테스트

  - `use-avatar-cluster` 리사이즈 대응 테스트 추가
  - 파티룸 목록/메인 카드 배경 썸네일 및 fallback UI 확인