### PR TITLE
fix(websocket): PR-3 클라 구독 단일진실원천 + PartyroomClient replace (#5 #30 web#298)

### DIFF
--- a/src/entities/partyroom-client/lib/partyroom-client.test.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.test.ts
@@ -13,6 +13,18 @@ describe('PartyroomClient', () => {
     vi.clearAllMocks();
     client = new PartyroomClient();
     mockSocketInstance = MockSocketClient.mock.instances[0] as Mocked<SocketClient>;
+
+    // SoT(subscriptions[]) 를 실제 client.ts 의미대로 동작시켜
+    // "단일 destination" 불변식을 진짜로 검증할 수 있게 한다.
+    mockSocketInstance.subscriptions = [];
+    mockSocketInstance.subscribe.mockImplementation((destination: any, callback: any) => {
+      mockSocketInstance.subscriptions.push({ destination, callback } as any);
+    });
+    mockSocketInstance.unsubscribe.mockImplementation((destination: any) => {
+      mockSocketInstance.subscriptions = mockSocketInstance.subscriptions.filter(
+        (s) => s.destination !== destination
+      );
+    });
   });
 
   test('connect() → socketClient.connect()를 위임한다', () => {
@@ -33,21 +45,52 @@ describe('PartyroomClient', () => {
   });
 
   describe('subscribe', () => {
-    test('이미 구독이 있으면 Error를 throw한다', () => {
-      mockSocketInstance.subscriptions = [{ destination: '/sub/partyrooms/1' } as any];
-
-      expect(() => client.subscribe(2, vi.fn())).toThrow(
-        'Cannot connect to multiple partyrooms at the same time.'
-      );
-    });
-
     test('구독이 없으면 올바른 경로로 subscribe를 호출한다', () => {
-      mockSocketInstance.subscriptions = [];
       const handler = vi.fn();
 
       client.subscribe(42, handler);
 
       expect(mockSocketInstance.subscribe).toHaveBeenCalledWith('/sub/partyrooms/42', handler);
+    });
+
+    test('이미 다른 방을 구독 중이면 throw하지 않고 기존 방을 해지한 뒤 새 방을 구독한다 (#30 throw 발원 제거 + 단일 destination)', () => {
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+
+      client.subscribe(1, handlerA);
+
+      expect(() => client.subscribe(2, handlerB)).not.toThrow();
+
+      // 기존 방 해지가 새 방 구독보다 먼저 일어나야 한다 (unsubscribe-then-subscribe 순서).
+      const unsubscribeOrder = mockSocketInstance.unsubscribe.mock.invocationCallOrder[0];
+      const subscribeBOrder = mockSocketInstance.subscribe.mock.calls.findIndex(
+        ([dest]) => dest === '/sub/partyrooms/2'
+      );
+      expect(mockSocketInstance.unsubscribe).toHaveBeenCalledWith('/sub/partyrooms/1');
+      expect(mockSocketInstance.subscribe).toHaveBeenLastCalledWith('/sub/partyrooms/2', handlerB);
+      expect(unsubscribeOrder).toBeLessThan(
+        mockSocketInstance.subscribe.mock.invocationCallOrder[subscribeBOrder]
+      );
+
+      // SoT(subscriptions[]) 에는 새 방(2)만 단 1개 남아야 한다.
+      expect(mockSocketInstance.subscriptions).toHaveLength(1);
+      expect(mockSocketInstance.subscriptions[0].destination).toBe('/sub/partyrooms/2');
+    });
+
+    test('같은 방을 다시 subscribe하면 중복 SoT 엔트리를 만들지 않는다 (idempotent)', () => {
+      const handler = vi.fn();
+
+      client.subscribe(7, handler);
+      client.subscribe(7, handler);
+
+      // 동일 destination 으로 두 번째 socketClient.subscribe 가 호출되면
+      // T3.1 의 단일 destination 전제(중복 SoT 엔트리)를 위반한다 — 막아야 한다.
+      const subscribeCallsForSeven = mockSocketInstance.subscribe.mock.calls.filter(
+        ([dest]) => dest === '/sub/partyrooms/7'
+      );
+      expect(subscribeCallsForSeven).toHaveLength(1);
+      expect(mockSocketInstance.subscriptions).toHaveLength(1);
+      expect(mockSocketInstance.subscriptions[0].destination).toBe('/sub/partyrooms/7');
     });
   });
 

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -36,6 +36,8 @@ export default class PartyroomClient {
    * - 동시에 이는 SocketClient.subscriptions[] (T3.1 단일 진실원천)의
    *   "destination 당 활성 구독 1개" 전제를 소비자 계층에서 강제합니다.
    * - 동일 방으로의 재구독은 idempotent — 중복 SoT 엔트리를 만들지 않기 위해 no-op 합니다.
+   *   이때 새로 전달된 handler 는 의도적으로 무시됩니다 (이미 구독 중인 방에 대해 다른 handler 로
+   *   재구독해도 교체되지 않는 no-op 이므로, 향후 두 번째 호출자는 이 점에 유의해야 합니다).
    */
   public subscribe(partyroomId: number, handler: (message: IMessage) => void) {
     if (this.subscribedRoomId === partyroomId) {

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -27,10 +27,24 @@ export default class PartyroomClient {
     this.socketClient.onConnect(callback, options);
   }
 
+  /**
+   * partyroom 을 구독합니다. **replace 정책**:
+   * 이미 다른 방을 구독 중이면 기존 방을 먼저 해지한 뒤 새 방을 구독합니다 (throw 없음).
+   *
+   * - 과거의 "다중 구독 시 throw" 가드는 #30 (throw → silent → router.push → unmount → 강제 퇴장)
+   *   증폭의 발원지였으므로 제거되었습니다. 동기적 unsubscribe-then-subscribe 로 대체합니다.
+   * - 동시에 이는 SocketClient.subscriptions[] (T3.1 단일 진실원천)의
+   *   "destination 당 활성 구독 1개" 전제를 소비자 계층에서 강제합니다.
+   * - 동일 방으로의 재구독은 idempotent — 중복 SoT 엔트리를 만들지 않기 위해 no-op 합니다.
+   */
   public subscribe(partyroomId: number, handler: (message: IMessage) => void) {
-    if (this.socketClient.subscriptions.length) {
-      // TODO: 다른 방 연결 끊고 이 방에 연결할래? 라는 문구 출력하도록 작업
-      throw new Error('Cannot connect to multiple partyrooms at the same time.');
+    if (this.subscribedRoomId === partyroomId) {
+      // 동일 destination 재구독은 T3.1 단일 destination 전제를 위반(중복 SoT 엔트리)하므로 no-op.
+      return;
+    }
+
+    if (this.subscribedRoomId != null) {
+      this.unsubscribeCurrentRoom();
     }
 
     this.socketClient.subscribe(`/sub/partyrooms/${partyroomId}`, handler);

--- a/src/shared/api/websocket/client.test.ts
+++ b/src/shared/api/websocket/client.test.ts
@@ -147,10 +147,83 @@ describe('SocketClient', () => {
       expect(sc.subscriptions).toHaveLength(1);
       expect(sc.subscriptions[0].destination).toBe('/sub/test');
     });
+
+    test('미연결 상태에서도 subscriptions에 destination+callback을 동기적으로 기록한다', () => {
+      const sc = new SocketClient();
+      const handler = vi.fn();
+
+      sc.subscribe('/sub/test' as any, handler);
+
+      // connect 전인데도 동기적으로 등록되어 있어야 한다 (단일 진실원천)
+      expect(sc.subscriptions).toHaveLength(1);
+      expect(sc.subscriptions[0].destination).toBe('/sub/test');
+      expect(sc.subscriptions[0].callback).toBe(handler);
+      // 아직 연결 전이므로 실제 STOMP subscribe 는 호출되지 않는다
+      expect(getStompClient(sc).subscribe).not.toHaveBeenCalled();
+    });
+
+    test('이미 연결된 상태 → 동기적으로 client.subscribe 를 즉시 호출하고 기록한다', () => {
+      const sc = new SocketClient();
+      getStompClient(sc).connected = true;
+      const handler = vi.fn();
+
+      sc.subscribe('/sub/now' as any, handler);
+
+      expect(getStompClient(sc).subscribe).toHaveBeenCalledWith('/sub/now', handler);
+      expect(sc.subscriptions).toHaveLength(1);
+      expect(sc.subscriptions[0].destination).toBe('/sub/now');
+      expect(sc.subscriptions[0].callback).toBe(handler);
+    });
+
+    test('onConnectQueue 에 subscribe 콜백을 더 이상 보관하지 않는다', () => {
+      const sc = new SocketClient();
+      const handler = vi.fn();
+
+      sc.subscribe('/sub/test' as any, handler);
+
+      const queue = (sc as any).onConnectQueue;
+      expect(queue).toHaveLength(0);
+    });
+
+    test('(재)연결 시 connect 핸들러가 subscriptions 의 모든 항목을 구독한다', () => {
+      const sc = new SocketClient();
+      const a = vi.fn();
+      const b = vi.fn();
+
+      sc.subscribe('/sub/a' as any, a);
+      sc.subscribe('/sub/b' as any, b);
+
+      triggerConnect(sc);
+
+      const subscribe = getStompClient(sc).subscribe;
+      expect(subscribe).toHaveBeenCalledWith('/sub/a', a);
+      expect(subscribe).toHaveBeenCalledWith('/sub/b', b);
+      expect(sc.subscriptions).toHaveLength(2);
+    });
+
+    test('reconnect 시 STOMP 핸들을 갱신하며 중복 구독하지 않는다', () => {
+      const sc = new SocketClient();
+      const a = vi.fn();
+      sc.subscribe('/sub/a' as any, a);
+
+      triggerConnect(sc);
+      expect(sc.subscriptions).toHaveLength(1);
+
+      // disconnect → 재연결
+      const stomp = getStompClient(sc);
+      stomp.__config.onWebSocketClose();
+      stomp.subscribe.mockClear();
+      triggerConnect(sc);
+
+      // /sub/a 가 정확히 한 번만 재구독되어야 한다 (heartbeat sub 제외)
+      const subscribeCallsForA = stomp.subscribe.mock.calls.filter((c: any[]) => c[0] === '/sub/a');
+      expect(subscribeCallsForA).toHaveLength(1);
+      expect(sc.subscriptions).toHaveLength(1);
+    });
   });
 
   describe('unsubscribe', () => {
-    test('연결 안 됨 → 아무 동작도 하지 않는다', () => {
+    test('연결 안 됨 → 에러 없이 통과한다', () => {
       const sc = new SocketClient();
       sc.unsubscribe('/sub/test' as any);
       // 에러 없이 통과
@@ -163,18 +236,71 @@ describe('SocketClient', () => {
       // 에러 없이 통과
     });
 
-    test('해당 destination이 있으면 해제하고 배열에서 제거한다', () => {
+    test('연결됨 + destination 존재 → STOMP 해제하고 subscriptions 에서 제거한다', () => {
       const sc = new SocketClient();
       sc.subscribe('/sub/room' as any, vi.fn());
       triggerConnect(sc);
 
       expect(sc.subscriptions).toHaveLength(1);
-      const unsubFn = sc.subscriptions[0].unsubscribe;
+      const stomp = getStompClient(sc);
+      const stompSub = stomp.subscribe.mock.results.find(
+        (r: any) => r.value.destination === '/sub/room'
+      )?.value;
 
       sc.unsubscribe('/sub/room' as any);
 
-      expect(unsubFn).toHaveBeenCalled();
+      expect(stompSub.unsubscribe).toHaveBeenCalled();
       expect(sc.subscriptions).toHaveLength(0);
+    });
+
+    test('미연결 상태에서도 subscriptions 에서 무조건 제거한다 (#5/#30 누수 해소)', () => {
+      const sc = new SocketClient();
+      sc.subscribe('/sub/room' as any, vi.fn());
+
+      expect(sc.subscriptions).toHaveLength(1);
+
+      // 아직 연결 전 — 그래도 제거되어야 한다
+      sc.unsubscribe('/sub/room' as any);
+
+      expect(sc.subscriptions).toHaveLength(0);
+    });
+
+    test('미연결 시 unsubscribe 한 destination 은 이후 connect 에서 재구독되지 않는다', () => {
+      const sc = new SocketClient();
+      sc.subscribe('/sub/room' as any, vi.fn());
+      sc.unsubscribe('/sub/room' as any);
+
+      triggerConnect(sc);
+
+      const stomp = getStompClient(sc);
+      const roomCalls = stomp.subscribe.mock.calls.filter((c: any[]) => c[0] === '/sub/room');
+      expect(roomCalls).toHaveLength(0);
+      expect(sc.subscriptions).toHaveLength(0);
+    });
+
+    test('#5 회귀잠금: subscribe A → unsubscribe A → subscribe B → disconnect → connect ⇒ B 만 구독, A 부활 없음', () => {
+      const sc = new SocketClient();
+      const aCb = vi.fn();
+      const bCb = vi.fn();
+
+      sc.subscribe('/sub/roomA' as any, aCb);
+      sc.unsubscribe('/sub/roomA' as any);
+      sc.subscribe('/sub/roomB' as any, bCb);
+
+      const stomp = getStompClient(sc);
+
+      // disconnect
+      stomp.__config.onWebSocketClose();
+      // reconnect
+      stomp.subscribe.mockClear();
+      triggerConnect(sc);
+
+      const aCalls = stomp.subscribe.mock.calls.filter((c: any[]) => c[0] === '/sub/roomA');
+      const bCalls = stomp.subscribe.mock.calls.filter((c: any[]) => c[0] === '/sub/roomB');
+
+      expect(aCalls).toHaveLength(0); // A 는 부활하면 안 된다
+      expect(bCalls).toHaveLength(1); // B 만 재구독
+      expect(sc.subscriptions.map((s) => s.destination)).toEqual(['/sub/roomB']);
     });
   });
 
@@ -186,8 +312,8 @@ describe('SocketClient', () => {
       triggerConnect(sc);
 
       expect(sc.subscriptions).toHaveLength(2);
-      const unsub0 = sc.subscriptions[0].unsubscribe;
-      const unsub1 = sc.subscriptions[1].unsubscribe;
+      const unsub0 = sc.subscriptions[0].stompSubscription?.unsubscribe;
+      const unsub1 = sc.subscriptions[1].stompSubscription?.unsubscribe;
 
       sc.unsubscribeAll();
 

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -128,6 +128,11 @@ export default class SocketClient {
    * 이미 connect 상태라면 즉시 실제 STOMP 구독을 수행하고,
    * 아니라면 connect 시 connect 핸들러가 `subscriptions[]` 기준으로 (재)구독합니다.
    * reconnect 시에도 `subscriptions[]` 만으로 reconcile 됩니다.
+   *
+   * @precondition 호출자는 destination 의 유일성을 보장해야 합니다 (destination 당 활성 구독 1개).
+   *   intervening `unsubscribe` 없이 동일 destination 으로 재호출하면 `subscriptions[]` 에
+   *   중복 항목이 쌓여 reconnect reconcile 시 중복 live 핸들이 생성되므로 미지원입니다.
+   *   단일 destination / replace 강제는 소비자 책임입니다 (PartyroomClient single-room guard / replace 정책).
    */
   public subscribe(destination: Destination, callback: messageCallbackType) {
     const subscription: Subscription = { destination, callback };

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -14,8 +14,16 @@ const log = logger<string>((msg) => {
 });
 
 export type Destination = `/${string}`;
-export interface Subscription extends StompSubscription {
+/**
+ * 구독의 단일 진실원천(SoT) 엔트리.
+ * `destination` + `callback` 은 "원하는 구독 집합"을 표현하며,
+ * `stompSubscription` 은 현재 살아있는 STOMP 핸들(연결 시에만 존재)이다.
+ * reconnect 는 오직 이 배열을 기준으로 reconcile 한다.
+ */
+export interface Subscription {
   destination: Destination;
+  callback: messageCallbackType;
+  stompSubscription?: StompSubscription;
 }
 
 export type OnConnectOptions = {
@@ -41,13 +49,23 @@ export default class SocketClient {
     const handleConnect = () => {
       this.startHeartbeat();
 
+      // subscriptions[] (원하는 구독 집합) 기준으로 reconcile.
+      // 살아있는 STOMP 핸들이 있으면 깔끔히 버리고 다시 구독 → 중복 구독 방지.
+      this.subscriptions.forEach((subscription) => {
+        subscription.stompSubscription?.unsubscribe();
+        subscription.stompSubscription = this.client.subscribe(
+          subscription.destination,
+          subscription.callback
+        );
+      });
+
       this.onConnectQueue.forEach(({ callback }) => callback());
       this.onConnectQueue = this.onConnectQueue.filter(({ options }) => !options?.once);
     };
 
     const handleDisconnect = () => {
       this.stopHeartbeat();
-      this.unsubscribeAll();
+      this.teardownLiveSubscriptions();
     };
 
     this.client = new Client({
@@ -106,43 +124,56 @@ export default class SocketClient {
 
   /**
    * 구독을 시작합니다.
-   * connect 상태가 아니라면, connect 되길 기다린 후 구독됩니다.
-   * reconnect 시 자동으로 재구독됩니다.
+   * `subscriptions[]` (원하는 구독 집합)에 동기적으로 기록합니다 — 단일 진실원천.
+   * 이미 connect 상태라면 즉시 실제 STOMP 구독을 수행하고,
+   * 아니라면 connect 시 connect 핸들러가 `subscriptions[]` 기준으로 (재)구독합니다.
+   * reconnect 시에도 `subscriptions[]` 만으로 reconcile 됩니다.
    */
   public subscribe(destination: Destination, callback: messageCallbackType) {
-    this.onConnect(() => {
-      const subscription = this.client.subscribe(destination, callback);
+    const subscription: Subscription = { destination, callback };
 
-      this.subscriptions.push({
-        ...subscription,
-        destination,
-      });
-    });
+    if (this.connected) {
+      subscription.stompSubscription = this.client.subscribe(destination, callback);
+    }
+
+    this.subscriptions.push(subscription);
   }
 
   /**
    * 구독을 해지합니다.
+   * `connected` 여부와 무관하게 `subscriptions[]` (원하는 구독 집합)에서 무조건 제거합니다.
+   * 살아있는 STOMP 핸들이 있으면 실제 해지도 수행합니다.
+   * 제거 후에는 이후 reconnect 가 이 destination 을 재구독하지 않습니다 (#5 부활 차단).
    */
   public unsubscribe(destination: Destination) {
-    if (!this.connected) return;
-
     const subscription = this.subscriptions.find(
       (subscription) => subscription.destination === destination
     );
     if (!subscription) return;
 
-    subscription.unsubscribe();
+    subscription.stompSubscription?.unsubscribe();
     this.subscriptions = this.subscriptions.filter(
       (subscription) => subscription.destination !== destination
     );
   }
 
   /**
-   * 모든 구독을 해지합니다.
+   * 모든 구독을 해지합니다 (원하는 구독 집합까지 비웁니다).
    */
   public unsubscribeAll() {
-    this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+    this.subscriptions.forEach((subscription) => subscription.stompSubscription?.unsubscribe());
     this.subscriptions = [];
+  }
+
+  /**
+   * 살아있는 STOMP 핸들만 정리합니다.
+   * `subscriptions[]` (원하는 구독 집합)은 보존하여 reconnect 시 reconcile 가능하게 합니다.
+   */
+  private teardownLiveSubscriptions() {
+    this.subscriptions.forEach((subscription) => {
+      subscription.stompSubscription?.unsubscribe();
+      subscription.stompSubscription = undefined;
+    });
   }
 
   /*


### PR DESCRIPTION
## 목적

클라이언트 구독 관리 결함 두 건을 동시에 닫는다.

- **#5**: reconnect 시 stale 구독이 부활하여 크로스룸 메시지 하이재킹이 발생. SocketClient 가 `onConnectQueue` 에 subscribe 콜백을 적재하던 구조가 원인.
- **#30**: `PartyroomClient.subscribe` 의 다중 구독 throw → silent catch → `router.push` → unmount → 강제 퇴장 증폭. throw 가드 자체가 발원지.

두 건 모두 **클라 구독 관리 결함**이라는 같은 뿌리.

## 변경 요약

### T3.1 — SocketClient `subscriptions[]` 단일 진실원천 (`src/shared/api/websocket/client.ts`)
- `onConnectQueue` 에 subscribe 콜백을 적재하던 경로 제거 (reconnect stale 부활 차단).
- `unsubscribe` 의 연결상태 의존(`!connected` 누수) 제거 — 연결 상태와 무관하게 `subscriptions[]` 에서 제거.
- reconnect 는 `onConnectQueue` 재실행이 아니라 현재 `subscriptions[]` 를 reconcile 하여 복원.

### T3.2 — PartyroomClient replace 정책 (`src/entities/partyroom-client/lib/partyroom-client.ts`)
- `subscribe` 의 throw 가드 제거 → **replace 정책**: 기존 방 구독 중이면 먼저 unsubscribe 후 새 방 subscribe.
- 동일 방 재구독은 idempotent **no-op** (중복 SoT 엔트리 방지). → 소비자 계층에서 destination 당 활성 구독 1개를 강제.

## 회귀 잠금

- **#5 lock**: `A → unsub A → B → disconnect → connect ⇒ B 만 복원` (stale A 부활 없음).
- replace ordering 검증 (unsub-then-sub 순서).
- `client.test.ts` **25/25 green**, `partyroom-client` 스위트 **66/66 green**.

## 트레이드오프 / 주의

- 동일 방 재구독 시 새로 전달된 handler 는 의도적으로 **무시**되는 no-op (polish 커밋에서 JSDoc 명시).
- 단일 destination 불변식은 `PartyroomClient` consumer 가 강제. `client.ts` SoT 는 해당 precondition 을 문서화만 함 — belt & suspenders 구조.

## 검증 결과

| 스위트 | 결과 |
| --- | --- |
| `src/shared/api/websocket/client.test.ts` | 25/25 PASS |
| `src/entities/partyroom-client` | 66/66 PASS (14 files) |
| `src/features/partyroom` (sanity, #30 caller 영역) | 105/105 PASS (34 files) |
| `tsc --noEmit` | clean |

## 후속

- PR-4: web L2 exit 분리 · unload backend-exit 제거.
- 서버측 단일룸 SUBSCRIBE 가드는 PR-2 에서 pfplay-platform develop 에 머지됨 → **클라 + 서버 양쪽 방어 완성**.

NOTE: PR-1 · PR-2(platform)는 pfplay-platform develop 에 머지됨. 이 PR 은 **pfplay-web development** 대상 (develop/main 아님).

Reference #5 #30 web#298