### PR TITLE
fix(playlist): 게스트 로비 /v1/playlists 5회 헛호출 차단 (D#10, #305)

### DIFF
--- a/src/app/_providers/react-query.provider.tsx
+++ b/src/app/_providers/react-query.provider.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental';
 import { getErrorMessage } from '@/shared/api/http/error/get-error-message';
 import isAuthError from '@/shared/api/http/error/is-auth-error';
+import isForbiddenError from '@/shared/api/http/error/is-forbidden-error';
 import { FIVE_MINUTES } from '@/shared/config/time';
 import { shouldSkipGlobalErrorHandling } from '@/shared/lib/decorators/skip-global-error-handling';
 import { Dialog } from '@/shared/ui/components/dialog';
@@ -42,6 +43,7 @@ function makeQueryClient() {
         retry: (failureCount, error) => {
           if (process.env.NODE_ENV === 'development') return false;
           if (isAuthError(error)) return false;
+          if (isForbiddenError(error)) return false;
           return failureCount <= 3;
         },
       },

--- a/src/app/parties/playlist-action.provider.test.tsx
+++ b/src/app/parties/playlist-action.provider.test.tsx
@@ -1,0 +1,88 @@
+vi.mock('@/entities/me', () => ({
+  useFetchMe: vi.fn(),
+}));
+vi.mock('@/features/playlist/list', () => ({
+  useFetchPlaylists: vi.fn(),
+}));
+vi.mock('@/features/playlist/add', () => ({
+  useAddPlaylistDialog: vi.fn(),
+}));
+vi.mock('@/features/playlist/add-tracks', () => ({
+  useAddPlaylistTrack: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('@/features/playlist/edit', () => ({
+  useEditPlaylistDialog: vi.fn(),
+}));
+vi.mock('@/features/playlist/move-track-to-playlist', () => ({
+  useMoveTrackToPlaylistDialog: vi.fn(),
+}));
+vi.mock('@/features/playlist/move-track-to-the-other-playlist', () => ({
+  useChangeTrackOrder: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/features/playlist/remove', () => ({
+  useRemovePlaylist: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('@/features/playlist/remove-track', () => ({
+  useRemovePlaylistTrack: () => ({ mutate: vi.fn() }),
+}));
+
+import { render } from '@testing-library/react';
+import { useFetchMe } from '@/entities/me';
+import { useFetchPlaylists } from '@/features/playlist/list';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import PlaylistActionProvider from './playlist-action.provider';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useFetchPlaylists as Mock).mockReturnValue({ data: [] });
+});
+
+describe('PlaylistActionProvider 게스트 게이팅', () => {
+  test('게스트(GT)면 useFetchPlaylists를 enabled: false로 호출한다', () => {
+    (useFetchMe as Mock).mockReturnValue({ data: { authorityTier: AuthorityTier.GT } });
+
+    render(
+      <PlaylistActionProvider>
+        <div>child</div>
+      </PlaylistActionProvider>
+    );
+
+    expect(useFetchPlaylists).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  test('정회원(FM)이면 useFetchPlaylists를 enabled: true로 호출한다', () => {
+    (useFetchMe as Mock).mockReturnValue({ data: { authorityTier: AuthorityTier.FM } });
+
+    render(
+      <PlaylistActionProvider>
+        <div>child</div>
+      </PlaylistActionProvider>
+    );
+
+    expect(useFetchPlaylists).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  test('준회원(AM)이면 useFetchPlaylists를 enabled: true로 호출한다', () => {
+    (useFetchMe as Mock).mockReturnValue({ data: { authorityTier: AuthorityTier.AM } });
+
+    render(
+      <PlaylistActionProvider>
+        <div>child</div>
+      </PlaylistActionProvider>
+    );
+
+    expect(useFetchPlaylists).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  test('me 데이터가 아직 없으면 enabled: false (게스트 안전 기본값)', () => {
+    (useFetchMe as Mock).mockReturnValue({ data: undefined });
+
+    render(
+      <PlaylistActionProvider>
+        <div>child</div>
+      </PlaylistActionProvider>
+    );
+
+    expect(useFetchPlaylists).toHaveBeenCalledWith({ enabled: false });
+  });
+});

--- a/src/app/parties/playlist-action.provider.tsx
+++ b/src/app/parties/playlist-action.provider.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useCallback } from 'react';
+import { useFetchMe } from '@/entities/me';
 import { PlaylistActionContext } from '@/entities/playlist';
 import { PlaylistActionOptions } from '@/entities/playlist/lib/playlist-action.context';
 import { useAddPlaylistDialog } from '@/features/playlist/add';
@@ -9,6 +10,7 @@ import { useMoveTrackToPlaylistDialog } from '@/features/playlist/move-track-to-
 import { useChangeTrackOrder } from '@/features/playlist/move-track-to-the-other-playlist';
 import { useRemovePlaylist } from '@/features/playlist/remove';
 import { useRemovePlaylistTrack } from '@/features/playlist/remove-track';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import {
   AddTrackToPlaylistRequestBody,
   ChangeTrackOrderRequest,
@@ -16,7 +18,11 @@ import {
 } from '@/shared/api/http/types/playlists';
 
 export default function PlaylistActionProvider({ children }: { children: ReactNode }) {
-  const { data: list = [] } = useFetchPlaylists();
+  const { data: me } = useFetchMe();
+  // 게스트(GT)는 플레이리스트 보유 자격이 없어 prefetch 가 무의미하다.
+  // me 가 아직 없으면 게스트 안전 기본값(미발사)으로 둔다.
+  const isMember = !!me && me.authorityTier !== AuthorityTier.GT;
+  const { data: list = [] } = useFetchPlaylists({ enabled: isMember });
   const add = useAddPlaylistDialog();
   const edit = useEditPlaylistDialog(list);
   const moveTrack = useMoveTrackToPlaylistDialog(list);

--- a/src/features/playlist/list/api/use-fetch-playlists.integration.test.ts
+++ b/src/features/playlist/list/api/use-fetch-playlists.integration.test.ts
@@ -36,4 +36,32 @@ describe('useFetchPlaylists 통합', () => {
       expect(grablist.name).toBe('Grabbed Songs');
     }
   });
+
+  test('enabled: false 이면 쿼리를 발사하지 않는다', async () => {
+    const { result } = renderWithClient(() => useFetchPlaylists({ enabled: false }));
+
+    // 비활성 쿼리는 fetch 자체가 일어나지 않고 idle/pending 상태로 유지된다
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  test('enabled: true 이면 쿼리를 발사한다', async () => {
+    const { result } = renderWithClient(() => useFetchPlaylists({ enabled: true }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(Number), name: expect.any(String) }),
+      ])
+    );
+  });
+
+  test('options 미지정 시 기존처럼 쿼리를 발사한다 (default-true 하위호환)', async () => {
+    const { result } = renderWithClient(() => useFetchPlaylists());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeDefined();
+  });
 });

--- a/src/features/playlist/list/api/use-fetch-playlists.query.ts
+++ b/src/features/playlist/list/api/use-fetch-playlists.query.ts
@@ -10,7 +10,7 @@ import { GetPlaylistsResponse, Playlist } from '@/shared/api/http/types/playlist
 import { FIVE_MINUTES, ONE_MINUTE } from '@/shared/config/time';
 import { Dictionary, useI18n } from '@/shared/lib/localization/i18n.context';
 
-export default function useFetchPlaylists() {
+export default function useFetchPlaylists(options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
   const t = useI18n();
 
@@ -31,6 +31,7 @@ export default function useFetchPlaylists() {
     select: ({ playlists }) => overwriteGrabPlaylistName(playlists, t),
     staleTime: ONE_MINUTE,
     gcTime: FIVE_MINUTES,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/src/shared/api/http/error/is-forbidden-error.test.ts
+++ b/src/shared/api/http/error/is-forbidden-error.test.ts
@@ -1,0 +1,61 @@
+vi.mock('axios', () => ({
+  isAxiosError: vi.fn(),
+}));
+
+import { isAxiosError } from 'axios';
+import isForbiddenError from './is-forbidden-error';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createAxiosError(overrides: { status?: number; responseStatus?: number }) {
+  return {
+    status: overrides.status,
+    response: overrides.responseStatus != null ? { status: overrides.responseStatus } : undefined,
+    isAxiosError: true,
+  };
+}
+
+describe('isForbiddenError', () => {
+  test('AxiosError + status 403 → true', () => {
+    const error = createAxiosError({ status: 403 });
+    (isAxiosError as Mock).mockReturnValue(true);
+
+    expect(isForbiddenError(error)).toBe(true);
+  });
+
+  test('AxiosError + response.status 403 → true', () => {
+    const error = createAxiosError({ responseStatus: 403 });
+    (isAxiosError as Mock).mockReturnValue(true);
+
+    expect(isForbiddenError(error)).toBe(true);
+  });
+
+  test('AxiosError + status 401 → false', () => {
+    const error = createAxiosError({ status: 401, responseStatus: 401 });
+    (isAxiosError as Mock).mockReturnValue(true);
+
+    expect(isForbiddenError(error)).toBe(false);
+  });
+
+  test('AxiosError + status 500 → false', () => {
+    const error = createAxiosError({ status: 500, responseStatus: 500 });
+    (isAxiosError as Mock).mockReturnValue(true);
+
+    expect(isForbiddenError(error)).toBe(false);
+  });
+
+  test('일반 Error → false', () => {
+    (isAxiosError as Mock).mockReturnValue(false);
+
+    const error = new Error('일반 에러');
+    expect(isForbiddenError(error)).toBe(false);
+  });
+
+  test('undefined → false', () => {
+    (isAxiosError as Mock).mockReturnValue(false);
+
+    expect(isForbiddenError(undefined)).toBe(false);
+  });
+});

--- a/src/shared/api/http/error/is-forbidden-error.ts
+++ b/src/shared/api/http/error/is-forbidden-error.ts
@@ -1,0 +1,5 @@
+import { isAxiosError } from 'axios';
+
+export default function isForbiddenError(error: unknown) {
+  return isAxiosError(error) && (error.status === 403 || error.response?.status === 403);
+}


### PR DESCRIPTION
## 배경 (#305, D/#10)

게스트로 로비(`/parties`) 진입 시 `GET /api/v1/playlists` 가 **5회**(첫 호출+4 재시도) 발사된다. 응답 status **403**(2026-05-14 검증), dev 모드는 retry 비활성이라 prod 한정. UX 차단성은 없으나 backend 부담 + Cloud Logging noise + console.error 5회.

근본 원인은 frontend: `PlaylistActionProvider`(모든 `/parties/*` 공통 부모)가 진입자 종류와 무관하게 `useFetchPlaylists()` 무조건 발사. 게스트(`authorityTier === 'GT'`)는 playlist 자격 없음. react-query retry 가 `isAuthError`(401만) 통과 못한 403 에 `failureCount<=3` → 5회. (backend 403·401-only 가드는 정상 design.)

## 변경 (로드맵 결정 조합 — 옵션1 + 옵션4)

1. **옵션1 (root cause)** — `useFetchPlaylists` 에 optional `{ enabled?: boolean }` 추가(`enabled: options?.enabled ?? true`, 기존 호출지 default-true 보존). `PlaylistActionProvider` 에서 **non-suspense** `useFetchMe` + `!!me && authorityTier !== GT` → `{ enabled: isMember }`. Context·children·`list=[]` default 무변경.
   - bug-doc 스케치의 `useSuspenseFetchMe` 대신 non-suspense `useFetchMe` 사용 — provider 트리에 suspense 경계가 없어 suspense 훅 도입 시 렌더 의미 변경(회귀) 위험. `header.component.tsx:54` 의 기존 canonical 컨벤션과 동일. `me` 는 ProtectedLayout 이 로드 보장 + 동일 `[QueryKeys.Me]` 캐시 공유(추가 네트워크 0), `!!me &&` 는 me-부재 시 게스트-안전(미발사) fail-safe.
2. **옵션4 (defensive)** — 신규 `is-forbidden-error.ts`(`is-auth-error.ts` 정확 미러, 403). `react-query.provider` retry 콜백에 `isAuthError` 직후 `if (isForbiddenError(error)) return false;` 한 줄. 403=권한부족=재시도 무의미, 같은 패턴 미래 발현 일괄 차단(401 대칭). 그 외 retry 로직 무변경.

범위 밖(이슈 명시): 옵션2(조건부 Provider wrap) / 옵션3(backend 200+[]) / 다른 호출지 동작 변경.

## 호출지 backward-compat

`useFetchPlaylists` 호출지 3곳: provider(변경) / `register-button.component.tsx`·`music-search.component.tsx`(no-arg → `undefined ?? true` = 기존 동작 동일, byte-unchanged).

## 테스트

- 신규 `is-forbidden-error.test.ts`: 403(status·response.status)→true / 401·500·non-axios·undefined→false
- 신규 `playlist-action.provider.test.tsx`: GT→`{enabled:false}` / FM·AM→`{enabled:true}` / me-undefined→`{enabled:false}`
- 확장 `use-fetch-playlists.integration.test.ts`: `{enabled:false}`→쿼리 idle 미발사(v5 `fetchStatus==='idle'`+`isPending`) / `{enabled:true}`·no-arg→발사. 기존 2 케이스 무변경
- 전 스위트 **1210/1210**, `tsc --noEmit` clean, eslint 0 error(신규 warning 0; 기존 무관 warning 2건은 본 diff 라인 밖)

스펙·코드품질 2단 서브에이전트 리뷰 통과(예측 리스크 — provider me-cache flip-flop / "미발사" 단언 견고성 — 모두 정밀 검토 후 sound 판정).

## 운영 메모

- pfplay-web 2-tier: development = stg. 머지 = stg 배포 + post-merge `vercel-preview-e2e.yml`(E2E). E2E 만성 flake = #303(본 PR 무관, 별건). PR-레벨 체크 green 확인 후 머지, post-merge development E2E 는 #303 대비 교차검증.
- prod(main) 미반영 — development(stg) 머지. **#305 는 prod ship 시 close 예정(prod-close 컨벤션, development 머지로는 OPEN 유지).**