### PR TITLE
[Obs] Phase A5 — 클라이언트 관측 이벤트 스키마 + 호출지 (EVENT_RECEIVED_FOREIGN #3 신호)

### DIFF
--- a/src/entities/partyroom-client/lib/handle-subscription-event.test.ts
+++ b/src/entities/partyroom-client/lib/handle-subscription-event.test.ts
@@ -61,6 +61,19 @@ vi.mock('./subscription-callbacks/use-dj-queue-changed-callback.hook', () => ({
   default: vi.fn(),
 }));
 
+const obs = vi.hoisted(() => ({
+  currentPartyroomId: undefined as number | undefined,
+  recordClientEvent: vi.fn(),
+}));
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useCurrentPartyroom: { getState: () => ({ id: obs.currentPartyroomId }) },
+  }),
+}));
+vi.mock('@/shared/lib/observability/client-events', () => ({
+  recordClientEvent: obs.recordClientEvent,
+}));
+
 import { renderHook } from '@testing-library/react';
 import { PartyroomEventType } from '@/shared/api/websocket/types/partyroom';
 import { warnLog } from '@/shared/lib/functions/log/logger';
@@ -172,6 +185,7 @@ function setupCallbacks() {
 describe('useHandleSubscriptionEvent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    obs.currentPartyroomId = undefined;
   });
 
   test('유효한 JSON + 알려진 eventType → 해당 콜백이 호출된다', () => {
@@ -221,6 +235,60 @@ describe('useHandleSubscriptionEvent', () => {
     for (const cb of callbacks.values()) {
       expect(cb).not.toHaveBeenCalled();
     }
+  });
+
+  describe('client observability (EVENT_RECEIVED / EVENT_RECEIVED_FOREIGN)', () => {
+    const baseEvent = {
+      eventType: PartyroomEventType.CHAT_MESSAGE_SENT,
+      partyroomId: 42,
+      id: 'msg-uuid-1',
+    };
+
+    test('현재 룸과 동일 partyroomId → EVENT_RECEIVED', () => {
+      setupCallbacks();
+      obs.currentPartyroomId = 42;
+      const { result } = renderHook(() => useHandleSubscriptionEvent());
+
+      result.current(createMessage(JSON.stringify(baseEvent)));
+
+      expect(obs.recordClientEvent).toHaveBeenCalledWith({
+        type: 'EVENT_RECEIVED',
+        eventType: PartyroomEventType.CHAT_MESSAGE_SENT,
+        partyroomId: 42,
+        messageId: 'msg-uuid-1',
+      });
+    });
+
+    test('현재 룸과 다른 partyroomId → EVENT_RECEIVED_FOREIGN (#3 신호)', () => {
+      setupCallbacks();
+      obs.currentPartyroomId = 7;
+      const { result } = renderHook(() => useHandleSubscriptionEvent());
+
+      result.current(createMessage(JSON.stringify(baseEvent)));
+
+      expect(obs.recordClientEvent).toHaveBeenCalledWith({
+        type: 'EVENT_RECEIVED_FOREIGN',
+        eventType: PartyroomEventType.CHAT_MESSAGE_SENT,
+        receivedPartyroomId: 42,
+        currentPartyroomId: 7,
+        messageId: 'msg-uuid-1',
+      });
+    });
+
+    test('현재 룸 미설정(undefined) → FOREIGN 미발사, EVENT_RECEIVED 로 폴백', () => {
+      setupCallbacks();
+      obs.currentPartyroomId = undefined;
+      const { result } = renderHook(() => useHandleSubscriptionEvent());
+
+      result.current(createMessage(JSON.stringify(baseEvent)));
+
+      expect(obs.recordClientEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'EVENT_RECEIVED' })
+      );
+      expect(obs.recordClientEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'EVENT_RECEIVED_FOREIGN' })
+      );
+    });
   });
 
   describe.each(CALLBACK_MAP.map(({ eventType, label }) => ({ eventType, label })))(

--- a/src/entities/partyroom-client/lib/handle-subscription-event.ts
+++ b/src/entities/partyroom-client/lib/handle-subscription-event.ts
@@ -2,6 +2,8 @@ import { IMessage } from '@stomp/stompjs';
 import { PartyroomEventType, PartyroomSubEvent } from '@/shared/api/websocket/types/partyroom';
 import { specificLog, warnLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
+import { recordClientEvent } from '@/shared/lib/observability/client-events';
+import { useStores } from '@/shared/lib/store/stores.context';
 import useChatCallback from './subscription-callbacks/use-chat-callback.hook';
 import useCrewEnteredCallback from './subscription-callbacks/use-crew-entered-callback.hook';
 import useCrewExitedCallback from './subscription-callbacks/use-crew-exited-callback.hook';
@@ -21,6 +23,7 @@ const warnLogger = logger(warnLog);
 const infoLogger = logger(specificLog);
 
 export default function useHandleSubscriptionEvent() {
+  const { useCurrentPartyroom } = useStores();
   const partyroomCloseCallback = usePartyroomCloseCallback();
   const playbackDeactivatedCallback = usePlaybackDeactivatedCallback();
   const crewEnteredCallback = useCrewEnteredCallback();
@@ -49,6 +52,25 @@ export default function useHandleSubscriptionEvent() {
     }
 
     infoLogger('Received event:', event);
+
+    const currentPartyroomId = useCurrentPartyroom.getState().id;
+    if (currentPartyroomId != null && event.partyroomId !== currentPartyroomId) {
+      // #3 결정적 신호 — 화면 partyroom 과 다른 룸 이벤트 수신 (cross-room hijack).
+      recordClientEvent({
+        type: 'EVENT_RECEIVED_FOREIGN',
+        eventType: String(event.eventType),
+        receivedPartyroomId: event.partyroomId,
+        currentPartyroomId,
+        messageId: event.id,
+      });
+    } else {
+      recordClientEvent({
+        type: 'EVENT_RECEIVED',
+        eventType: String(event.eventType),
+        partyroomId: event.partyroomId,
+        messageId: event.id,
+      });
+    }
 
     switch (event.eventType) {
       case PartyroomEventType.PARTYROOM_CLOSED:

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -1,5 +1,6 @@
 import { IMessage } from '@stomp/stompjs';
 import SocketClient, { OnConnectOptions } from '@/shared/api/websocket/client';
+import { recordClientEvent } from '@/shared/lib/observability/client-events';
 
 /**
  * Socket Client를 캡슐화하여 최소한의 인터페이스만을 노출하며,
@@ -46,17 +47,27 @@ export default class PartyroomClient {
     }
 
     if (this.subscribedRoomId != null) {
+      recordClientEvent({
+        type: 'PARTYROOM_SUBSCRIBE_REPLACED',
+        fromPartyroomId: this.subscribedRoomId,
+        toPartyroomId: partyroomId,
+      });
       this.unsubscribeCurrentRoom();
     }
 
     this.socketClient.subscribe(`/sub/partyrooms/${partyroomId}`, handler);
     this.subscribedRoomId = partyroomId;
+    recordClientEvent({ type: 'PARTYROOM_SUBSCRIBE', partyroomId });
     this.syncE2EDebugState();
   }
 
   public unsubscribeCurrentRoom() {
-    this.socketClient.unsubscribe(`/sub/partyrooms/${this.subscribedRoomId}`);
+    const roomId = this.subscribedRoomId;
+    this.socketClient.unsubscribe(`/sub/partyrooms/${roomId}`);
     this.subscribedRoomId = undefined;
+    if (roomId != null) {
+      recordClientEvent({ type: 'PARTYROOM_UNSUBSCRIBE', partyroomId: roomId });
+    }
     this.syncE2EDebugState();
   }
 

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -1,8 +1,9 @@
-import { Client } from '@stomp/stompjs';
+import { Client, IFrame } from '@stomp/stompjs';
 import { StompSubscription } from '@stomp/stompjs/src/stomp-subscription';
 import { messageCallbackType } from '@stomp/stompjs/src/types';
 import { specificLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
+import { recordClientEvent } from '@/shared/lib/observability/client-events';
 
 const logger = withDebugger(0);
 const log = logger<string>((msg) => {
@@ -47,6 +48,7 @@ export default class SocketClient {
 
   public constructor() {
     const handleConnect = () => {
+      recordClientEvent({ type: 'WS_CONNECT', brokerURL: this.client.brokerURL ?? '' });
       this.startHeartbeat();
 
       // subscriptions[] (원하는 구독 집합) 기준으로 reconcile.
@@ -64,8 +66,21 @@ export default class SocketClient {
     };
 
     const handleDisconnect = () => {
+      recordClientEvent({
+        type: 'WS_DISCONNECT',
+        reason: 'transport-closed',
+        subscriptionCount: this.subscriptions.length,
+      });
       this.stopHeartbeat();
       this.teardownLiveSubscriptions();
+    };
+
+    const handleStompError = (frame: IFrame) => {
+      recordClientEvent({
+        type: 'WS_STOMP_ERROR',
+        message: frame.headers?.['message'] ?? frame.body ?? 'unknown',
+      });
+      handleDisconnect();
     };
 
     this.client = new Client({
@@ -79,7 +94,7 @@ export default class SocketClient {
       debug: log,
       onConnect: handleConnect,
       onWebSocketClose: handleDisconnect,
-      onStompError: handleDisconnect,
+      onStompError: handleStompError,
     });
   }
 

--- a/src/shared/lib/observability/client-events.ts
+++ b/src/shared/lib/observability/client-events.ts
@@ -1,0 +1,35 @@
+/**
+ * 클라이언트 측 관측 이벤트 스키마 (Observability Phase A5).
+ *
+ * Phase A 에선 `console.info`/`console.error` 로만 emit 된다 (OSS only 정책 —
+ * 사용자 콘솔 dump 를 받아야 우리에게 도달). Phase B 에서 backend forward
+ * endpoint 가 도입되면 {@link recordClientEvent} 구현부만 교체하면 되고,
+ * 호출 지점은 변경 zero 다 (스키마를 미리 고정하는 것이 이 파일의 목적).
+ */
+export type ClientObservabilityEvent =
+  | { type: 'WS_CONNECT'; brokerURL: string }
+  | { type: 'WS_DISCONNECT'; reason: string; subscriptionCount: number }
+  | { type: 'WS_STOMP_ERROR'; message: string }
+  | { type: 'PARTYROOM_SUBSCRIBE'; partyroomId: number }
+  | { type: 'PARTYROOM_UNSUBSCRIBE'; partyroomId: number }
+  | { type: 'PARTYROOM_SUBSCRIBE_REPLACED'; fromPartyroomId: number; toPartyroomId: number }
+  | { type: 'EVENT_RECEIVED'; eventType: string; partyroomId: number; messageId: string }
+  | {
+      // #3 (subscription resurrection / cross-room hijack) 의 결정적 신호 —
+      // 화면의 현재 partyroom 과 다른 partyroom 이벤트를 받았다는 직접 증거.
+      type: 'EVENT_RECEIVED_FOREIGN';
+      eventType: string;
+      receivedPartyroomId: number;
+      currentPartyroomId: number;
+      messageId: string;
+    };
+
+/**
+ * 관측 이벤트를 기록한다. Phase A: 콘솔 emit only.
+ * 오류/불변식 위반 신호(STOMP 에러, foreign 이벤트)는 `console.error` 로,
+ * 그 외는 `console.info` 로 — ADR-009(error-monitoring) 의 severity 정책.
+ */
+export function recordClientEvent(event: ClientObservabilityEvent): void {
+  const isError = event.type === 'WS_STOMP_ERROR' || event.type === 'EVENT_RECEIVED_FOREIGN';
+  (isError ? console.error : console.info)('[client-obs]', event);
+}


### PR DESCRIPTION
## 요약

Observability Phase A frontend 분(A5). backend A1~A4 는 pfplay-platform(#210 머지 / #235·PR #236). 로드맵 C/T2-4. Closes #307 (prod ship 시 close 컨벤션 — development 단계선 OPEN 유지).

Phase A frontend 의 ROI 한계 인정(OSS only — 사용자 콘솔 dump 의존). **핵심 = 스키마 사전 고정**: Phase B backend forward endpoint 도입 시 `recordClientEvent` 구현부만 교체, 호출지 50+ 변경 zero.

## 변경

- **`src/shared/lib/observability/client-events.ts` 신설** — `ClientObservabilityEvent` discriminated union + `recordClientEvent`. 오류/불변식 위반(WS_STOMP_ERROR, EVENT_RECEIVED_FOREIGN)은 `console.error`, 그 외 `console.info` (ADR-009 severity 정책 — 별도 console.error 산재 대신 단일 emitter 로 우아하게 통합).
- **`client.ts`** — WS_CONNECT / WS_DISCONNECT(reason+subscriptionCount) / WS_STOMP_ERROR. `onStompError` 를 전용 핸들러로 분리(기존엔 handleDisconnect 로 합쳐져 에러 신호 손실).
- **`partyroom-client.ts`** — PARTYROOM_SUBSCRIBE / UNSUBSCRIBE / SUBSCRIBE_REPLACED. 계획 초안의 `PARTYROOM_SUBSCRIBE_BLOCKED(duplicate)` 는 #30 fix 로 throw→**replace** 정책이 됐으므로 실제 동작에 맞춰 `SUBSCRIBE_REPLACED(from→to)` 로 모델. 행위 보존(roomId 캡처 후 emit).
- **`handle-subscription-event.ts`** — `EVENT_RECEIVED_FOREIGN`: 화면 partyroom(`useCurrentPartyroom.getState().id`) ≠ 수신 `partyroomId` = **#3 cross-room hijack 의 결정적 production 신호**. 일치 시 `EVENT_RECEIVED`. (계획의 `useCurrentPartyroom.getState()` 를 context-provided zustand store 의 `.getState()` 로 적용.)
- 회귀 단위테스트 3종(동일룸→RECEIVED / 다른룸→FOREIGN / 미설정→폴백) + 기존 테스트에 `useStores`/`recordClientEvent` 모킹 보강(내 hook 변경으로 provider 의존 생겨 기존 20테스트 보호).

## 비범위(Phase B deferred)
- clock-skew/`estimatedServerTs` 분석 layer 보강(계획 §보강, 선택)
- backend forward / Cloud Run sink(Phase C)

## 검증
- 영향 테스트 **54 GREEN** (handle-subscription-event 20 / partyroom-client 9 / client 25)
- `tsc --noEmit` 통과, eslint 0 error (잔여 warning 은 기존 @ts-expect-error, `yarn lint --quiet` 대상)

## 머지 후 모니터링
pfplay-web `development` 머지 = stg 배포 → post-merge E2E 모니터링 필요. 실패 시 #303 만성 cold-start flake 시그니처 교차확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)