### PR TITLE
[High] 게스트 소셜가입 좀비 me + amplitude id 단절 (D/#7+#9 Phase1)

### DIFF
--- a/docs/adr/012-amplitude-user-id-strategy.md
+++ b/docs/adr/012-amplitude-user-id-strategy.md
@@ -1,0 +1,51 @@
+# ADR-012: amplitude user_id 전략 (GUEST→MEMBER 경계 연속성)
+
+- **상태**: 채택 — 단계적 (Phase 1 = B, Phase 2 = E)
+- **일자**: 2026-05-18
+- **관련 이슈**: pfplay-web (analytics identity 단절), pfplay-platform `MemberSignService` (Phase 2)
+- **관련 노트**: `bugs/2026-05-14-amplitude-user-id-discontinuity.md`, `bugs/2026-05-14-guest-social-promotion-skips-profile-setup.md` (같은 `use-social-sign-in-callback.hook` 공유 — Phase 1 번들)
+
+## 맥락
+
+GUEST 단계에서 OAuth 가입을 거치면 백엔드(`MemberSignService.getMemberOrCreateWithStatus`)가 `new UserId()` 로 **새 `user_account.id`(새 TSID)** 를 발급한다. GUEST 의 synthetic email(`guest-{uid}@guest.local`)은 OAuth real email 과 절대 매칭되지 않아 기존 GUEST row 와 link 가 없다.
+
+프론트의 amplitude 식별(`identifyAuthenticatedUser` → `setUserId(newMemberUid)`)은 **alias / merge / property pinning 호출이 전혀 없다**. 결과:
+
+- amplitude 에서 한 사람이 **두 user (GUEST id / MEMBER id)** 로 영구 분리
+- `amplitude.setUserId(Y)` 로 바꿔도 이전 X 에 쌓인 이벤트는 X 에 영구 잔존 (SDK 확정 동작)
+- funnel / retention / DAU·MAU 데이터 무결성 손상
+- 부가: `User Signed Up` / `User Signed In` 이벤트가 `setUserId` 이전에 발사되어 **GUEST id 로 기록** (가입 funnel 단절)
+
+서비스 동작 자체는 정상 — 순수 analytics 데이터 무결성 문제.
+
+## 선택지
+
+| 선택지                                                           | 설명                                                                                                                             | 트레이드오프                                                                                                                         |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **A** amplitude user_id 불변                                     | 가입 시 `setUserId` 미호출. 첫 GUEST uid 를 영구 amplitude user_id 로 사용, user property 만 갱신                                | 연속성 완벽·가장 깨끗. 단 amplitude id namespace ≠ service id → SQL export 매핑 테이블 필요. 로그인된 채 첫 진입 케이스 별도 처리    |
+| **B** user property pinning                                      | `setUserId(newUid)` 경계에서 GUEST id 를 `Identify.setOnce('canonical_user_id', guestId)` 로 GUEST·MEMBER 양쪽 user 에 영구 부착 | 두 user 는 여전히 분리되나 `canonical_user_id` 로 Cohort/SQL join 가능. frontend only·작은 변경. amplitude UI 의 두-user 표시는 잔존 |
+| **C** amplitude merge/alias API                                  | 가입 시점 `amplitude.merge`/`alias` 호출                                                                                         | 브라우저 SDK 가 user-merge 를 완전 지원하지 않음 — **미채택** (검증 부담·불확실)                                                     |
+| **D** 백엔드 user_account 재사용                                 | OAuth 가입 시 GUEST 의 user_account 를 재사용(providerType/email update + GUEST→MEMBER 전이), id 유지                            | IAM 설계 대수술. schema migration + 기존 코드 광범위 영향 — **미채택** (invasive 과대)                                               |
+| **E** 백엔드 `member.previous_guest_user_account_id` FK + B 결합 | 백엔드가 가입 시 직전 GUEST id 를 member row 에 기록, frontend 가 그 값으로 B 수행                                               | 작은 schema migration. canonical link 의 진실원천이 백엔드라 frontend race 에 비의존. 가장 견고한 절충                               |
+
+## 결정
+
+**B → E 단계적 채택.**
+
+- **Phase 1 (B, frontend only, 즉시)**: `identifyAuthenticatedUser` 에서 `setUserId` 직전 현재(GUEST) amplitude user_id 를 캡처하여 GUEST·MEMBER 양쪽에 `setOnce('canonical_user_id', guestId)` pin. 더불어 `User Signed Up/In` 이벤트를 `setUserId` **이후로 재배치**하여 MEMBER user 에 귀속. (#7 zombie-me race 와 같은 `use-social-sign-in-callback.hook` 공유 → 번들 PR)
+- **Phase 2 (E, backend, 추후)**: `MemberSignService` 가 가입 시 직전 GUEST `user_account.id` 를 `member.previous_guest_user_account_id`(NULLABLE) 로 기록. frontend canonical pin 의 진실원천을 백엔드로 승격(frontend race·SDK 타이밍 비의존). `bugs/2026-05-14-admin-guest-union-view.md`(#8) 의 어드민 가입 전후 통합뷰와 cross-link 보너스.
+
+C(브라우저 SDK 미지원 불확실), D(IAM 대수술) 미채택.
+
+### 근거
+
+- B 는 frontend-only·저위험으로 데이터 무결성 출혈을 즉시 멈춘다 (canonical join 즉시 가능).
+- E 는 canonical link 를 백엔드 진실원천으로 옮겨 frontend race·SDK 로드 타이밍에 비의존하게 견고화한다. schema migration 이 작아 D 대비 위험이 낮다.
+- A 는 가장 깨끗하나 amplitude↔service id namespace 분리로 모든 SQL export 에 매핑 비용이 영구 발생 → B/E 의 `canonical_user_id` property join 이 실용적으로 동등하면서 namespace 일관성 유지.
+
+## 결과
+
+- `canonical_user_id` user property 가 GUEST·MEMBER 양쪽 이벤트에 부착 → amplitude Cohort/SQL 에서 한 사람의 가입 전후 행동을 join 가능 (funnel/retention 복원).
+- `User Signed Up/In` 이 MEMBER user 에 귀속 → 가입 funnel 정합.
+- amplitude UI 상 두 user 분리는 잔존(B 의 알려진 한계) — Phase 2(E) 이후에도 분리는 유지되나 백엔드 권위 link 로 분석 신뢰도 상승. UI 단일화가 필요하면 향후 A 재검토.
+- Phase 2 의 `previous_guest_user_account_id` 는 #8 어드민 GUEST 통합뷰의 join key 로도 재사용.

--- a/src/entities/me/api/use-fetch-me.query.test.ts
+++ b/src/entities/me/api/use-fetch-me.query.test.ts
@@ -1,0 +1,58 @@
+import { usersService } from '@/shared/api/http/services';
+import { queryOptions } from './use-fetch-me.query';
+
+vi.mock('@/shared/api/http/services', () => ({
+  usersService: {
+    getMyInfo: vi.fn(),
+    getMyProfileSummary: vi.fn(),
+  },
+}));
+
+const getMyInfo = usersService.getMyInfo as ReturnType<typeof vi.fn>;
+const getMyProfileSummary = usersService.getMyProfileSummary as ReturnType<typeof vi.fn>;
+
+function runQueryFn() {
+  // queryFn 은 인자 없이 호출 가능하도록 정의됨.
+  return (queryOptions.queryFn as () => Promise<unknown>)();
+}
+
+describe('useFetchMe queryFn — spread merge trap 영구 차단 (옵션 5a, #7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('getMyInfo / getMyProfileSummary 를 동시 발사한다 (순차 await 아님)', async () => {
+    let resolveInfo!: (v: unknown) => void;
+    getMyInfo.mockReturnValue(
+      new Promise((res) => {
+        resolveInfo = res;
+      })
+    );
+    getMyProfileSummary.mockResolvedValue({ nickname: 'n' });
+
+    const promise = runQueryFn();
+    // Promise.all 이면 info 가 아직 pending 이라도 summary 가 이미 호출됨.
+    // 순차 await 였다면 info resolve 전까지 summary 미호출.
+    await Promise.resolve();
+    expect(getMyInfo).toHaveBeenCalledTimes(1);
+    expect(getMyProfileSummary).toHaveBeenCalledTimes(1);
+
+    resolveInfo({ authorityTier: 'FM' });
+    await promise;
+  });
+
+  test('두 응답을 spread merge 하여 반환한다', async () => {
+    getMyInfo.mockResolvedValue({ uid: 'u1', authorityTier: 'FM', profileUpdated: false });
+    getMyProfileSummary.mockResolvedValue({ nickname: '새유저', avatarBodyUri: 'b' });
+
+    const result = (await runQueryFn()) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      uid: 'u1',
+      authorityTier: 'FM',
+      profileUpdated: false,
+      nickname: '새유저',
+      avatarBodyUri: 'b',
+    });
+  });
+});

--- a/src/entities/me/api/use-fetch-me.query.ts
+++ b/src/entities/me/api/use-fetch-me.query.ts
@@ -24,8 +24,14 @@ export function useSuspenseFetchMe(): UseSuspenseQueryResult<Me.Model, AxiosErro
 export const queryOptions: UseQueryOptions<Me.Model, AxiosError<APIError>> = {
   queryKey: [QueryKeys.Me],
   queryFn: async () => {
-    const meInfo = await usersService.getMyInfo();
-    const meProfileSummary = await usersService.getMyProfileSummary();
+    // 동시 발사 — 두 endpoint 가 항상 같은 cookie/session 으로 호출됨을 보장.
+    // 순차 await 면 token 변경 시점(login/logout/promote)에 info=GUEST cookie,
+    // summary=새 cookie 로 갈려 spread merge 가 하이브리드 좀비 me 를 만든다.
+    // Promise.all 이 그 race window 자체를 영구히 닫는다 (옵션 5a, #7).
+    const [meInfo, meProfileSummary] = await Promise.all([
+      usersService.getMyInfo(),
+      usersService.getMyProfileSummary(),
+    ]);
 
     return {
       ...meInfo,

--- a/src/entities/me/model/me.model.test.ts
+++ b/src/entities/me/model/me.model.test.ts
@@ -33,6 +33,20 @@ describe('me model', () => {
       const model = createModel({ profileUpdated: true });
       expect(serviceEntry(model)).toBe('/parties');
     });
+
+    test('isNewUser=true 면 profileUpdated=true 여도 설정 페이지 강제 (좀비 me 안전망)', () => {
+      const model = createModel({ profileUpdated: true });
+      expect(serviceEntry(model, true)).toBe('/settings/profile');
+    });
+
+    test('isNewUser=false 면 profileUpdated 기준 동작 (기존 회귀)', () => {
+      const model = createModel({ profileUpdated: true });
+      expect(serviceEntry(model, false)).toBe('/parties');
+    });
+
+    test('isNewUser=true 라도 model null 이면 루트 (가드 우선순위)', () => {
+      expect(serviceEntry(null, true)).toBe('/');
+    });
   });
 
   describe('score', () => {

--- a/src/entities/me/model/me.model.ts
+++ b/src/entities/me/model/me.model.ts
@@ -3,10 +3,13 @@ import { GetMyInfoResponse, GetMyProfileSummaryResponse } from '@/shared/api/htt
 
 export type Model = GetMyInfoResponse & GetMyProfileSummaryResponse;
 
-export const serviceEntry = (model: Model | null): string => {
+export const serviceEntry = (model: Model | null, isNewUser?: boolean): string => {
   if (!model) return '/';
 
-  if (!model.profileUpdated) {
+  // 신규 가입자는 me 데이터와 무관하게 프로필 설정 강제 (defense-in-depth).
+  // zombie me(좀비: auth=GUEST + profile=신규) 의 profileUpdated=true 가
+  // 가드를 통과시키는 race 를 isNewUser 안전망으로 차단한다.
+  if (isNewUser || !model.profileUpdated) {
     return '/settings/profile';
   }
 

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
@@ -1,0 +1,120 @@
+import { renderWithClient } from '@/shared/api/__test__/test-utils';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import useOAuth2Callback from './use-social-sign-in-callback.hook';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+const callbackLogin = vi.fn();
+vi.mock('../api/use-callback-login', () => ({
+  __esModule: true,
+  default: () => ({ mutateAsync: callbackLogin }),
+}));
+
+const fetchMeAsync = vi.fn();
+vi.mock('@/entities/me', () => ({
+  useFetchMeAsync: () => fetchMeAsync,
+}));
+
+const identifyAuthenticatedUser = vi.fn();
+const trackSignedUp = vi.fn();
+const trackSignedIn = vi.fn();
+vi.mock('@/shared/lib/analytics/auth-tracking', () => ({
+  identifyAuthenticatedUser: (...a: unknown[]) => identifyAuthenticatedUser(...a),
+  trackSignedUp: (...a: unknown[]) => trackSignedUp(...a),
+  trackSignedIn: (...a: unknown[]) => trackSignedIn(...a),
+}));
+
+function meModel(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: 'member-uid',
+    authorityTier: AuthorityTier.FM,
+    profileUpdated: true,
+    nickname: 'n',
+    ...overrides,
+  } as never;
+}
+
+describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('옵션2: isNewUser=true 면 profileUpdated=true(좀비 me) 여도 /settings/profile 강제', async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: true });
+    fetchMeAsync.mockResolvedValue(meModel({ profileUpdated: true }));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(push).toHaveBeenCalledWith('/settings/profile');
+  });
+
+  test('isNewUser=false + profileUpdated=true → /parties (기존 회귀)', async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: false });
+    fetchMeAsync.mockResolvedValue(meModel({ profileUpdated: true }));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(push).toHaveBeenCalledWith('/parties');
+  });
+
+  test('옵션1: callback 후 [Me] 캐시 cancel+remove 를 fetchMeAsync 이전에 수행', async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: false });
+    fetchMeAsync.mockResolvedValue(meModel());
+
+    const { result, queryClient } = renderWithClient(() => useOAuth2Callback());
+    const cancelSpy = vi.spyOn(queryClient, 'cancelQueries');
+    const removeSpy = vi.spyOn(queryClient, 'removeQueries');
+
+    await result.current('google');
+
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: [QueryKeys.Me] });
+    expect(removeSpy).toHaveBeenCalledWith({ queryKey: [QueryKeys.Me] });
+    expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMeAsync.mock.invocationCallOrder[0]
+    );
+  });
+
+  test('#9: identify(setUserId+canonical) 가 trackSignedUp/In 보다 먼저 발사', async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: true });
+    fetchMeAsync.mockResolvedValue(meModel({ authorityTier: AuthorityTier.FM }));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
+    expect(trackSignedUp).toHaveBeenCalledWith('google');
+    expect(trackSignedIn).toHaveBeenCalledTimes(1);
+    expect(identifyAuthenticatedUser.mock.invocationCallOrder[0]).toBeLessThan(
+      trackSignedUp.mock.invocationCallOrder[0]
+    );
+    expect(identifyAuthenticatedUser.mock.invocationCallOrder[0]).toBeLessThan(
+      trackSignedIn.mock.invocationCallOrder[0]
+    );
+  });
+
+  test('isNewUser=false 면 trackSignedUp 미발사, trackSignedIn 은 발사', async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: false });
+    fetchMeAsync.mockResolvedValue(meModel());
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(trackSignedUp).not.toHaveBeenCalled();
+    expect(trackSignedIn).toHaveBeenCalledTimes(1);
+  });
+
+  test('callbackLogin 실패 시 /sign-in 으로', async () => {
+    callbackLogin.mockRejectedValue(new Error('exchange failed'));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(push).toHaveBeenCalledWith('/sign-in');
+  });
+});

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
@@ -2,8 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useFetchMeAsync } from '@/entities/me';
 import * as Me from '@/entities/me/model/me.model';
+import { QueryKeys } from '@/shared/api/http/query-keys';
 import { OAuth2Provider } from '@/shared/api/http/types/users';
 import {
   identifyAuthenticatedUser,
@@ -14,6 +16,7 @@ import useCallbackLogin from '../api/use-callback-login';
 
 export default function useOAuth2Callback() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { mutateAsync: callbackLogin } = useCallbackLogin();
   const fetchMeAsync = useFetchMeAsync();
 
@@ -21,6 +24,13 @@ export default function useOAuth2Callback() {
     async (oauth2Provider: OAuth2Provider) => {
       try {
         const tokenResponse = await callbackLogin(oauth2Provider);
+
+        // 옵션1(#7): root layout 의 <SystemAnnouncementSubscriber/> 가 callback
+        // 보다 먼저 발사한 GUEST-cookie in-flight me query 를 abort + stale 제거.
+        // cancelQueries 가 필수 — removeQueries 만으로는 in-flight 가 살아남아
+        // 좀비 me 가 캐시에 다시 박힌다. 그 후 fetchMeAsync 는 새 cookie 로 재호출.
+        await queryClient.cancelQueries({ queryKey: [QueryKeys.Me] });
+        queryClient.removeQueries({ queryKey: [QueryKeys.Me] });
 
         let me: Me.Model | null = null;
         try {
@@ -30,22 +40,25 @@ export default function useOAuth2Callback() {
         }
 
         if (me) {
-          if (tokenResponse.isNewUser) {
-            trackSignedUp(oauth2Provider);
-          }
-          trackSignedIn(me.authorityTier);
+          // #9 (ADR-012 B): identify(→setUserId + canonical pin) 를 먼저 수행한
+          // 뒤 track 발사 — 이전엔 track 이 setUserId 전이라 GUEST id 로 귀속됐다.
           identifyAuthenticatedUser({
             uid: me.uid,
             authorityTier: me.authorityTier,
             oauthProvider: oauth2Provider,
           });
+          if (tokenResponse.isNewUser) {
+            trackSignedUp(oauth2Provider);
+          }
+          trackSignedIn(me.authorityTier);
         }
 
-        router.push(Me.serviceEntry(me));
+        // 옵션2(#7): 신규 가입자는 좀비 me 와 무관하게 프로필 설정 강제.
+        router.push(Me.serviceEntry(me, tokenResponse.isNewUser));
       } catch {
         router.push('/sign-in');
       }
     },
-    [callbackLogin, fetchMeAsync, router]
+    [callbackLogin, fetchMeAsync, queryClient, router]
   );
 }

--- a/src/shared/lib/analytics/auth-tracking.test.ts
+++ b/src/shared/lib/analytics/auth-tracking.test.ts
@@ -21,6 +21,7 @@ vi.mock('@amplitude/analytics-browser', () => {
     init: vi.fn(),
     track: vi.fn(),
     setUserId: vi.fn(),
+    getUserId: vi.fn(),
     identify: vi.fn(),
     reset: vi.fn(),
     Identify,
@@ -101,6 +102,46 @@ describe('auth-tracking', () => {
       identifyAuthenticatedUser({ uid: 'uid-1', authorityTier: AuthorityTier.GT });
       const setCalls = identifyProto.set.mock.calls.map((call) => call[0]);
       expect(setCalls).not.toContain('oauth_provider');
+    });
+  });
+
+  describe('canonical_user_id pinning (ADR-012 Phase 1 = B)', () => {
+    test('GUEST id 존재 & uid 와 다르면 GUEST·MEMBER 양쪽에 canonical pin + 순서(GUEST identify → setUserId → MEMBER identify)', () => {
+      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('guest-account-id');
+
+      identifyAuthenticatedUser({ uid: 'member-uid-1', authorityTier: AuthorityTier.FM });
+
+      expect(amplitude.setUserId).toHaveBeenCalledWith('member-uid-1');
+      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'guest-account-id');
+      // GUEST 측 + MEMBER 측 = identify 2회 호출, setUserId 가 그 사이.
+      expect(amplitude.identify).toHaveBeenCalledTimes(2);
+      const firstIdentifyOrder = (amplitude.identify as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0];
+      const setUserIdOrder = (amplitude.setUserId as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0];
+      const secondIdentifyOrder = (amplitude.identify as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[1];
+      expect(firstIdentifyOrder).toBeLessThan(setUserIdOrder);
+      expect(setUserIdOrder).toBeLessThan(secondIdentifyOrder);
+    });
+
+    test('GUEST id 미상(SDK 미로드) 면 canonical=uid, GUEST 측 pre-pin 생략', () => {
+      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+
+      identifyAuthenticatedUser({ uid: 'member-uid-2', authorityTier: AuthorityTier.FM });
+
+      expect(amplitude.setUserId).toHaveBeenCalledWith('member-uid-2');
+      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'member-uid-2');
+      expect(amplitude.identify).toHaveBeenCalledTimes(1); // MEMBER 측 1회만
+    });
+
+    test('현재 id 가 이미 uid (재로그인) 면 GUEST 측 pre-pin 생략, canonical=uid', () => {
+      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('member-uid-3');
+
+      identifyAuthenticatedUser({ uid: 'member-uid-3', authorityTier: AuthorityTier.AM });
+
+      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'member-uid-3');
+      expect(amplitude.identify).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/shared/lib/analytics/auth-tracking.ts
+++ b/src/shared/lib/analytics/auth-tracking.ts
@@ -2,7 +2,7 @@ import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import type { OAuth2Provider } from '@/shared/api/http/types/users';
 
 import type { AuthType } from './events';
-import { identify, setUserId, track } from './index';
+import { getCurrentUserId, identify, setUserId, track } from './index';
 
 export function authTypeOf(authorityTier: AuthorityTier): AuthType {
   return authorityTier === AuthorityTier.GT ? 'guest' : 'member';
@@ -19,6 +19,19 @@ export function identifyAuthenticatedUser({
   authorityTier,
   oauthProvider,
 }: IdentifyAuthArgs): void {
+  // ADR-012 (Phase 1 = B): setUserId 직전 현재(GUEST) amplitude id 를 캡처.
+  // canonical_user_id 는 한 사람의 최초 id — GUEST·MEMBER 양쪽 user 에 동일 값을
+  // setOnce pin 하여 가입 전후 행동을 Cohort/SQL join 으로 잇는다.
+  const previousUserId = getCurrentUserId();
+  const canonicalUserId = previousUserId ?? uid;
+
+  // GUEST user 측에도 같은 anchor 를 박는다 (setUserId 로 전환되기 전이라
+  // 이 identify 는 GUEST id 에 귀속). previousUserId 가 이미 uid 면(재로그인 등)
+  // setUserId 후 한 번만 박아도 충분하므로 생략.
+  if (previousUserId && previousUserId !== uid) {
+    identify({ setOnce: { canonical_user_id: canonicalUserId } });
+  }
+
   setUserId(uid);
   identify({
     set: {
@@ -26,6 +39,7 @@ export function identifyAuthenticatedUser({
       authority_tier: authorityTier,
       ...(oauthProvider ? { oauth_provider: oauthProvider } : {}),
     },
+    setOnce: { canonical_user_id: canonicalUserId },
   });
 }
 

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -96,6 +96,12 @@ export type UserPropertySetOnce = {
   has_created_partyroom?: boolean;
   /** ISO 8601 timestamp recorded the first time the user enters any partyroom. */
   first_partyroom_entered_at?: string;
+  /**
+   * GUEST→MEMBER 가입 경계에서 한 사람의 amplitude identity 를 잇는 anchor.
+   * GUEST·MEMBER 양쪽 user 에 동일한 (최초 GUEST) id 를 setOnce 로 pin 하여
+   * Cohort/SQL join 으로 가입 전후 행동을 연결한다. ADR-012 (Phase 1 = B).
+   */
+  canonical_user_id?: string;
 };
 
 export type UserPropertyAdd = {

--- a/src/shared/lib/analytics/index.test.ts
+++ b/src/shared/lib/analytics/index.test.ts
@@ -3,6 +3,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 import {
   __preloadSdkForTests,
   __resetForTests,
+  getCurrentUserId,
   identify,
   initAnalytics,
   resetAnalyticsUser,
@@ -26,6 +27,7 @@ vi.mock('@amplitude/analytics-browser', () => {
     init: vi.fn(),
     track: vi.fn(),
     setUserId: vi.fn(),
+    getUserId: vi.fn(),
     identify: vi.fn(),
     reset: vi.fn(),
     Identify,
@@ -179,6 +181,18 @@ describe('analytics module', () => {
     test('calls amplitude.reset', () => {
       resetAnalyticsUser();
       expect(amplitude.reset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCurrentUserId', () => {
+    test('SDK 로드 상태면 amplitude.getUserId 결과 반환', () => {
+      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('current-id');
+      expect(getCurrentUserId()).toBe('current-id');
+    });
+
+    test('SDK 미로드면 undefined (GUEST id 미상 — caller fallback)', () => {
+      __resetForTests(); // sdk = null
+      expect(getCurrentUserId()).toBeUndefined();
     });
   });
 });

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -131,6 +131,16 @@ export function resetAnalyticsUser(): void {
   });
 }
 
+/**
+ * 현재 amplitude user_id (SDK 미로드 시 undefined).
+ * GUEST→MEMBER 경계에서 setUserId 직전 GUEST id 를 캡처하는 데 쓴다 (ADR-012).
+ * SDK 가 아직 로드 전이면 GUEST id 미상이라 undefined — caller 가 fallback 처리.
+ */
+export function getCurrentUserId(): string | undefined {
+  if (!isEnabled() || !sdk) return undefined;
+  return sdk.getUserId();
+}
+
 export function __resetForTests(): void {
   initialized = false;
   sdk = null;


### PR DESCRIPTION
## 요약

같은 `use-social-sign-in-callback.hook` 을 공유하는 #7·#9 를 **ADR-012(amplitude user_id 전략, B→E 단계적 채택) Phase 1** 로 번들 처리. Closes #309 (prod ship 시 close 컨벤션 — development 단계선 OPEN 유지). ADR 신설: `docs/adr/012-amplitude-user-id-strategy.md`.

## #7 — 게스트 소셜가입 직후 프로필 설정 스킵 (zombie me)

root cause(prod 검증 확정): root layout `<SystemAnnouncementSubscriber/>` 가 callback 보다 먼저 `useFetchMe` 발사 → 첫 endpoint(`/me/info`)가 게스트 cookie 응답 → queryFn `{...meInfo, ...meProfileSummary}` spread 가 게스트 auth + 신규 profile 의 **하이브리드 좀비 me** 생성.

- **옵션 5a (영구 fix)** `use-fetch-me.query.ts`: `Promise.all([getMyInfo, getMyProfileSummary])` — 두 endpoint 동일 cookie 보장, token 변경 시점 spread-merge race window 자체 폐쇄
- **옵션 1** callback hook: `cancelQueries`+`removeQueries([Me])` 후 `fetchMeAsync` — in-flight GUEST-cookie 질의 abort (cancel 필수: remove 만으론 in-flight 가 좀비 재기입)
- **옵션 2** `Me.serviceEntry(model, isNewUser?)`: 신규가입은 좀비 me 무관 `/settings/profile` 강제 (defense-in-depth)

## #9 (ADR-012 옵션 B) — amplitude GUEST→MEMBER id 단절

- `analytics/index.ts` `getCurrentUserId()` 추가
- `identifyAuthenticatedUser`: `setUserId` 직전 GUEST amplitude id 캡처 → GUEST·MEMBER 양쪽 `setOnce('canonical_user_id', guestId)` pin (events.ts `UserPropertySetOnce` 타입 추가). Cohort/SQL join 으로 가입 전후 연결
- callback hook: `trackSignedUp/In` 을 `identifyAuthenticatedUser`(setUserId) **이후로 재배치** — 이전엔 setUserId 전이라 `User Signed Up/In` 이 GUEST id 로 귀속되던 가입 funnel 단절 해소

Phase 2(E, backend `member.previous_guest_user_account_id` FK)는 별건 추후.

## 검증
- 회귀 **55 tests GREEN** (me.model 12 / auth-tracking 11 / analytics index 21 / use-fetch-me.query 2 / callback hook 6 / use-fetch-me integration 3). serviceEntry isNewUser·Promise.all 동시발사·canonical GUEST/MEMBER 양쪽·identify→track 순서·cancel/remove before fetch 모두 잠금
- `tsc --noEmit` 통과, eslint 0 problem

## 머지 후 모니터링
`development` 머지 = stg 배포 → post-merge E2E 모니터링. 실패 시 #303 만성 cold-start flake 시그니처 교차확인 + warm rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)