### PR TITLE
[E2E] cold-start flake 완화 — preview warm-up + auth/helper 하드닝 (#303)

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -57,6 +57,29 @@ jobs:
           key: playwright-${{ hashFiles('**/yarn.lock') }}
 
       - run: npx playwright install --with-deps chromium
+
+      # web#303: 매 run 새로 배포되는 Vercel preview 프론트는 구조상 cold —
+      # serverless/SSR 함수의 첫 히트가 느려 me-fetch-게이트 ProtectedLayout
+      # 사이드바(Playlist 버튼)가 30s 안에 안 그려져 E2E 가 만성 flake.
+      # yarn install/playwright install 동안 함수가 다시 식으므로, 테스트 직전
+      # 에 핵심 경로를 다회 선접속해 함수 인스턴스를 데운다(best-effort, 실패해도
+      # 테스트 진행). Vercel 배포 보호 우회 헤더 필수 — 없으면 보호 월만 데움.
+      - name: Warm up preview (mitigate cold-start flake — web#303)
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set +e
+          routes="/ /sign-in /parties"
+          for pass in 1 2 3; do
+            for r in $routes; do
+              out=$(curl -s -o /dev/null -w "%{http_code} %{time_total}s" \
+                -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+                --max-time 60 "$E2E_BASE_URL$r")
+              echo "warm pass$pass $r -> $out"
+            done
+          done
+          exit 0
+
       - run: yarn test:e2e
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/e2e/auth/shared.ts
+++ b/e2e/auth/shared.ts
@@ -4,23 +4,27 @@ import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 
 export const AUTH_DIR = path.join(__dirname, '../.auth');
 
+// web#303: cold-start(Vercel preview 함수 cold) 시 첫 히트가 느려 기존 10s
+// 대기로는 한 번의 느린 응답에도 깨졌다. 30s 로 상향해 cold 첫 히트를 흡수.
+const STEP_TIMEOUT = 30_000;
+
 async function clickDevFullCrewSignIn(page: Page) {
   const devBtn = page.locator('[data-testid="dev-sign-in-button"]');
-  await expect(devBtn).toBeVisible({ timeout: 10_000 });
-  await expect(devBtn).toBeEnabled({ timeout: 10_000 });
+  await expect(devBtn).toBeVisible({ timeout: STEP_TIMEOUT });
+  await expect(devBtn).toBeEnabled({ timeout: STEP_TIMEOUT });
   await devBtn.click({ force: true });
 
   const dialog = page
     .locator('[data-testid="dialog-panel"]')
     .filter({ has: page.locator('[data-testid="dev-sign-in-full"]') })
     .first();
-  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await expect(dialog).toBeVisible({ timeout: STEP_TIMEOUT });
 
   const fullCrewButton = dialog.locator('[data-testid="dev-sign-in-full"]');
-  await expect(fullCrewButton).toBeVisible({ timeout: 10_000 });
-  await expect(fullCrewButton).toBeEnabled({ timeout: 10_000 });
+  await expect(fullCrewButton).toBeVisible({ timeout: STEP_TIMEOUT });
+  await expect(fullCrewButton).toBeEnabled({ timeout: STEP_TIMEOUT });
   await fullCrewButton.click({ force: true });
-  await expect(dialog).toBeHidden({ timeout: 15_000 });
+  await expect(dialog).toBeHidden({ timeout: STEP_TIMEOUT });
 }
 
 export async function authenticateUser(browser: Browser, outputPath: string, baseURL: string) {
@@ -52,6 +56,17 @@ export async function authenticateUser(browser: Browser, outputPath: string, bas
   page.on('crash', () => {
     log('page crashed');
   });
+  // web#303 D: console.error 의 `Failed to load resource: 401 ()` 는 URL 이
+  // 빠져 어느 요청인지 단정 불가했다. 네트워크 레벨(method+URL)로 직접 로깅해
+  // 향후 실패를 결정적으로 진단 (status>=400 만 — 노이즈 억제).
+  page.on('response', (res) => {
+    if (res.status() >= 400) {
+      log(`HTTP ${res.status()} ${res.request().method()} ${res.url()}`);
+    }
+  });
+  page.on('requestfailed', (req) => {
+    log(`REQ_FAILED ${req.method()} ${req.url()} :: ${req.failure()?.errorText ?? 'unknown'}`);
+  });
   await page.addInitScript(ETHEREUM_MOCK_SCRIPT);
   log(`goto ${baseURL}/sign-in`);
   await page.goto(`${baseURL}/sign-in`);
@@ -61,8 +76,26 @@ export async function authenticateUser(browser: Browser, outputPath: string, bas
   await clickDevFullCrewSignIn(page);
 
   log('goto /parties explicitly after dialog closed');
-  await page.goto(`${baseURL}/parties`);
-  await page.waitForURL(/\/parties(?:$|\/)/, { timeout: 10_000 });
+  // web#303: dev-crew 로그인 직후 me-fetch 가 아직 pending 이면 ProtectedLayout
+  // 가드가 미인증으로 오판해 `/` 로 바운스한다(= createPlaylistWithTracks 의
+  // "navigated to /" 와 동일 메커니즘). 제품측 근본 해결(ProtectedLayout 이
+  // me-pending 중 하드리다이렉트 안 하기)은 **B 로 후속 분리**. 여기선
+  // 테스트 레벨 방어: storageState 쿠키 인증은 유효하므로 `/` 로 바운스되면
+  // me 안정 후 재진입하면 /parties 가 유지된다. 최대 3회 재시도.
+  const partiesUrl = /\/parties(?:$|[/?#])/;
+  let onParties = false;
+  for (let attempt = 0; attempt < 3 && !onParties; attempt++) {
+    if (!partiesUrl.test(page.url())) {
+      await page.goto(`${baseURL}/parties`);
+    }
+    try {
+      await page.waitForURL(partiesUrl, { timeout: STEP_TIMEOUT });
+      onParties = true;
+    } catch {
+      log(`/parties bounced to ${page.url()} (attempt ${attempt + 1}) — retrying`);
+      await page.goto(`${baseURL}/parties`);
+    }
+  }
   log(`arrived at /parties, current URL: ${page.url()}`);
   log(`writing storageState to ${outputPath}`);
   await context.storageState({ path: outputPath });

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -126,8 +126,25 @@ async function pickShortTrackIndices(
 
 export async function createPlaylistWithTracks(page: Page, playlistName: string) {
   // Sidebar 의 Playlist 버튼은 ProtectedLayout 이 me 쿼리 로드 완료 후에만 그려진다.
-  // CI cold-start 시 me fetch 가 길어져 sidebar 가 늦게 mount 되므로 명시적 wait 으로
-  // 실패 메시지를 명확히 하고, 기본 expect 타임아웃(15s)보다 넉넉하게 둔다.
+  // cold-start 시 me-fetch 가 늦으면 (1) sidebar 가 늦게 mount 되거나, (2) 가드가
+  // me-pending 을 미인증으로 오판해 `/` 로 바운스한다(web#303). (2) 의 제품측
+  // 근본 해결(ProtectedLayout 이 me-pending 중 `/` 로 하드리다이렉트 안 하기)은
+  // **B 로 후속 분리** — 본 변경은 테스트 레벨 방어다: storageState 는 유효
+  // 인증이므로 `/` 로 바운스됐으면 me 안정 후 /parties 1회 재진입으로 복구.
+  const partiesUrl = /\/parties(?:$|[/?#])/;
+  let onParties = false;
+  for (let attempt = 0; attempt < 2 && !onParties; attempt++) {
+    if (!partiesUrl.test(page.url())) {
+      await page.goto('/parties');
+    }
+    try {
+      await page.waitForURL(partiesUrl, { timeout: 30_000 });
+      onParties = true;
+    } catch {
+      await page.goto('/parties'); // me-pending 가드 바운스 의심 — 재진입
+    }
+  }
+
   const playlistButton = page.getByRole('button', { name: /^playlist$/i });
   await expect(playlistButton).toBeVisible({ timeout: 30_000 });
   await playlistButton.click();


### PR DESCRIPTION
## 요약

web#303 만성 cold-start E2E flake 완화. **테스트 인프라 한정, 제품 코드 변경 0.** Refs #303 (close 아님 — 효과 측정·잔여 B 후속).

## 변경 (4)

- **warm-up** `vercel-preview-e2e.yml`: `e2e` job 의 `yarn test:e2e` 직전, 새로 배포된 Vercel preview 의 핵심 경로(`/`, `/sign-in`, `/parties`)를 Vercel 우회헤더로 3-pass 선접속해 serverless/SSR 함수를 데움. `set +e`/`exit 0` best-effort — 실패해도 테스트 진행, **악화 불가**. yarn/playwright install 동안 식는 함수를 테스트 직전에 재가열.
- **A** `e2e/auth/shared.ts`: dev-sign-in 단계 타임아웃 10/15s → `STEP_TIMEOUT=30s` (cold 첫 히트 흡수).
- **C** `partyroom.helpers.ts` + `shared.ts`: `createPlaylistWithTracks` 와 auth-setup `/parties` 단계에 `/parties` URL 보장 + `/` 바운스 시 재진입(최대 1~3회, storageState 인증 유효 전제).
- **D** `shared.ts`: `page.on('response')`(status≥400 method+URL) + `requestfailed` 네트워크 로깅 — 기존 console-only 로깅이 401 의 URL 을 빼 진단 불가했던 문제 해소. **이번 RCA 가 D 로 401 원인을 규명함**(가치 실증).

## RCA 요약 (로컬 조사)

로컬 E2E 실패는 **환경 전용 3원인**으로 규명, 전부 본 변경/제품 코드와 무관:
1. `.env.local` 의 `NEXT_PUBLIC_WAGMI_PROJECT_ID` 에 `// 주석` 혼입 → WalletConnect 크래시 (로컬 설정, 사용자 수정).
2. **HTTPS dev(`localhost:3000`) ↔ HTTP 백엔드(`localhost:8080`) schemeful-cross-site → `SameSite=Lax` 쿠키 미전송 → `/me` 401** (HTTP 동일 scheme 으로 전환 시 auth 정상 통과 확인).
3. `next dev --turbo` cold 청크/RSC 레이스(최초 hit; warm 시 자가해소; **CI 는 prebuilt 라 무관**).

→ CI(prebuilt + 동일 scheme HTTPS)엔 1·2·3 없음. 거기서 실재하는 #303 = **Vercel preview 함수 cold-start** → warm-up + A/C/D 가 그걸 정조준. 충실한 검증 = CI post-merge E2E run (#303 에 효과 추적).

## 후속 (별도, #303 에 기록)

**B**: `ProtectedLayout`(`src/app/parties/layout.tsx`)이 `error && isAuthError(error)` 첫 발생에 `location.href='/'` 하드 리다이렉트 — 일시/cold me-fetch 401 을 확정 미인증으로 오판해 사용자/E2E 를 홈으로 추방(= "navigated to /" 의 제품측 뿌리). blast radius(모든 보호 라우트 인증) 커 별도 설계·PR. 상세: #303 코멘트.

## 검증
- tsc/eslint/YAML green. 테스트 전용(제품 0)·warm-up best-effort = 회귀 불가.
- 로컬: 1·2 해소 후 auth 정상 통과(HTTP 동일 scheme), 잔여 3 은 로컬 dev 전용.
- 머지 후 development post-merge E2E run 들로 #303 완화 효과 측정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)