### PR TITLE
[High] 일시 401 bounded retry — cold-start 홈 추방 방지 (B, #312)

### DIFF
--- a/src/app/_providers/react-query.provider.tsx
+++ b/src/app/_providers/react-query.provider.tsx
@@ -5,11 +5,11 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental';
 import { getErrorMessage } from '@/shared/api/http/error/get-error-message';
 import isAuthError from '@/shared/api/http/error/is-auth-error';
-import isForbiddenError from '@/shared/api/http/error/is-forbidden-error';
 import { FIVE_MINUTES } from '@/shared/config/time';
 import { shouldSkipGlobalErrorHandling } from '@/shared/lib/decorators/skip-global-error-handling';
 import { Dialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
+import { shouldRetryQuery } from './should-retry-query';
 
 /**
  * @see https://github.com/TanStack/query/issues/6116#issuecomment-1904051005
@@ -40,12 +40,7 @@ function makeQueryClient() {
          */
         staleTime: FIVE_MINUTES,
         refetchOnWindowFocus: false,
-        retry: (failureCount, error) => {
-          if (process.env.NODE_ENV === 'development') return false;
-          if (isAuthError(error)) return false;
-          if (isForbiddenError(error)) return false;
-          return failureCount <= 3;
-        },
+        retry: shouldRetryQuery,
       },
     },
     queryCache: new QueryCache({

--- a/src/app/_providers/should-retry-query.test.ts
+++ b/src/app/_providers/should-retry-query.test.ts
@@ -1,0 +1,50 @@
+import { shouldRetryQuery } from './should-retry-query';
+
+const authError = { isAxiosError: true, response: { status: 401 } };
+const forbiddenError = { isAxiosError: true, response: { status: 403 } };
+const serverError = { isAxiosError: true, response: { status: 500 } };
+const networkError = { isAxiosError: true, message: 'Network Error' };
+
+describe('shouldRetryQuery (web#303 / #312 — 일시 401 bounded retry)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('development 환경이면 무조건 false (어떤 에러든)', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    expect(shouldRetryQuery(1, authError)).toBe(false);
+    expect(shouldRetryQuery(1, serverError)).toBe(false);
+  });
+
+  test('403(forbidden)은 즉시 중단 — 재시도 무의미', () => {
+    expect(shouldRetryQuery(1, forbiddenError)).toBe(false);
+    expect(shouldRetryQuery(3, forbiddenError)).toBe(false);
+  });
+
+  describe('401(auth) — 일시 401 자가회복용 bounded 재시도', () => {
+    test('failureCount 1·2 는 재시도(true)', () => {
+      expect(shouldRetryQuery(1, authError)).toBe(true);
+      expect(shouldRetryQuery(2, authError)).toBe(true);
+    });
+
+    test('failureCount 3 부터는 확정(false) → 그때 리다이렉트', () => {
+      expect(shouldRetryQuery(3, authError)).toBe(false);
+      expect(shouldRetryQuery(4, authError)).toBe(false);
+    });
+
+    test('error.status(직접)로도 401 인식', () => {
+      expect(shouldRetryQuery(1, { isAxiosError: true, status: 401 })).toBe(true);
+    });
+  });
+
+  describe('기타 에러(5xx/네트워크) — 기존 정책 보존', () => {
+    test('failureCount <= 3 재시도', () => {
+      expect(shouldRetryQuery(1, serverError)).toBe(true);
+      expect(shouldRetryQuery(3, networkError)).toBe(true);
+    });
+
+    test('failureCount 4 부터 중단', () => {
+      expect(shouldRetryQuery(4, serverError)).toBe(false);
+    });
+  });
+});

--- a/src/app/_providers/should-retry-query.ts
+++ b/src/app/_providers/should-retry-query.ts
@@ -1,0 +1,24 @@
+import isAuthError from '@/shared/api/http/error/is-auth-error';
+import isForbiddenError from '@/shared/api/http/error/is-forbidden-error';
+
+/**
+ * 전역 쿼리 retry 정책 (web#303 / #312).
+ *
+ * 401(`isAuthError`)을 즉시 no-retry 로 확정하면, cold-start·세션 워밍·레이스
+ * 로 인한 **일시 401** 도 곧장 에러 확정 → `handleBubbledError` 및
+ * `ProtectedLayout` 의 `location.href='/'` 가 발화해 사용자를 홈으로 추방한다
+ * (#303 의 `navigated to "/"`). 일시 401 과 확정 미인증 401 은 응답만으로
+ * 구분 불가하므로, **bounded 재시도**로 일시 401 을 자가회복시키고 — 재시도
+ * 후에도 401 이면 그때 확정시켜 정상적으로 리다이렉트한다.
+ *
+ * - 403(`isForbiddenError`)은 권한 문제로 재시도 무의미 → 즉시 중단(기존 동작).
+ * - mutation 에는 적용되지 않음(queries 기본 옵션).
+ *
+ * 순수 함수로 분리(provider 의 React/next 의존과 디커플) — 단위 테스트 용이.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  if (process.env.NODE_ENV === 'development') return false;
+  if (isForbiddenError(error)) return false;
+  if (isAuthError(error)) return failureCount <= 2; // 최대 2회 재시도 후 확정
+  return failureCount <= 3;
+}


### PR DESCRIPTION
## 요약

web#303 의 **제품측 근본 수정**(B). warm-up+테스트 하드닝(PR #311)은 확률만 낮출 뿐 미해결임이 실측됨(#303: warm 재시도 2회 모두 9/2, `navigated to "/"` 지속). Closes #312. Refs #303.

## Root cause

`react-query.provider.tsx` 전역 쿼리 retry 가 `isAuthError`(401)를 **즉시 no-retry** 로 확정 → cold-start·세션 워밍·레이스로 인한 **일시 401** 도 곧장 에러 확정 → 두 곳(`handleBubbledError` 전역 / `ProtectedLayout`)의 `location.href='/'` 발화 → `navigated to "/"`. 일시 401 과 확정 미인증 401 을 응답만으로 구분하지 않음.

## 변경

- **`should-retry-query.ts` 신설**: retry 정책을 순수 함수 `shouldRetryQuery` 로 분리(provider 의 React/next 의존과 디커플 → 단위 테스트 용이). 401 은 `failureCount <= 2` **bounded retry**:
  - 진짜 미인증 → 재시도 후에도 401 → 확정 → 정상 리다이렉트(동작 보존)
  - 일시 cold 401 → 재시도로 자가회복 → 에러 미확정 → 리다이렉트 없음
  - 두 리다이렉트 사이트는 *확정 후* 발화 → retry 한 곳 수정으로 **양쪽 동시 근본 해결**
- 403(`isForbiddenError`)·5xx/네트워크·dev·mutation 동작 **불변**.
- `react-query.provider.tsx` 는 분리된 함수 import (행위 동일, 인라인 제거).
- 회귀 단위테스트 7.

## 검증
- 단위테스트 7 GREEN, `tsc --noEmit` 통과, eslint 0 error(잔여 warning 은 기존 Dialog literal, `--quiet` 대상).
- 효과는 prod ship 시 #303 와 함께 측정(close 컨벤션). #311(부분완화)과 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)