### PR TITLE
fix(ssr): with-debugger 무가드 window 가드 — 서버측 공유 axios 크래시 (#314, #303 아님)

### DIFF
--- a/src/shared/lib/functions/log/with-debugger.node.test.ts
+++ b/src/shared/lib/functions/log/with-debugger.node.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+// L1 (#314/#303): 서버측(SSR/RSC, window 부재)에서 withDebugger 가 무가드
+// `window.debugLevel` 접근으로 ReferenceError 즉사 → 공유 axios 전 요청이
+// 서버측에서 죽는 근본. 서버 컨텍스트에선 throw 없이 fallback 이어야 한다.
+import withDebugger from './with-debugger';
+
+describe('withDebugger (server / no window)', () => {
+  const prev = process.env.NODE_ENV;
+  beforeAll(() => {
+    process.env.NODE_ENV = 'production';
+  });
+  afterAll(() => {
+    process.env.NODE_ENV = prev;
+  });
+
+  test('window 부재 + production 이면 throw 없이 fallback 반환, fn 미호출', () => {
+    expect(typeof window).toBe('undefined');
+
+    const fn = vi.fn();
+
+    expect(() => withDebugger(0)(fn, 'fallback')('a')).not.toThrow();
+    expect(withDebugger(0)(fn, 'fallback')('a')).toBe('fallback');
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('window 부재 + development 이면 기존대로 fn 호출(거동 보존)', () => {
+    process.env.NODE_ENV = 'development';
+    const fn = vi.fn().mockReturnValue('r');
+
+    expect(withDebugger(0)(fn)('a')).toBe('r');
+    expect(fn).toHaveBeenCalledWith('a');
+
+    process.env.NODE_ENV = 'production';
+  });
+});

--- a/src/shared/lib/functions/log/with-debugger.ts
+++ b/src/shared/lib/functions/log/with-debugger.ts
@@ -4,7 +4,10 @@
 export default function withDebugger(debugLevel: number) {
   return <T, P = void>(fn: (...args: T[]) => P, fallback?: P) =>
     (...args: T[]) => {
-      if (process.env.NODE_ENV === 'development' || window.debugLevel > debugLevel) {
+      if (
+        process.env.NODE_ENV === 'development' ||
+        (typeof window !== 'undefined' && window.debugLevel > debugLevel)
+      ) {
         return fn(...args);
       }
       return fallback;


### PR DESCRIPTION
## 스코프 (중요)

**이 PR 은 #303(E2E cold flake) fix 가 아니다.** 서버측 계측 프로브(#314)가 부수적으로 드러낸 **독립 잠복 SSR-safety 버그 1건(L1)** 만 수정한다.

## L1 — `with-debugger.ts` 무가드 `window`

`with-debugger.ts` 의 `window.debugLevel` 무가드 참조 → **prod 빌드** SSR/RSC 에서 `ReferenceError: window is not defined`. `logRequest`/`logResponse`/`logError` 가 전부 `withDebugger` 로 감싸여 있어, 공유 axios 클라이언트의 **모든 서버측 요청이 백엔드 도달 전 즉사**. dev 는 `process.env.NODE_ENV==='development'` 의 `||` short-circuit 으로 `window` 미평가 → 그간 미발견.

서버측 계측 프로브 3/3 결과(임시, 폐기됨):
```
getMyInfo:           ReferenceError "window is not defined"
getMyProfileSummary: ReferenceError "window is not defined"
withForwardedCookie: HTTP 401   (인터셉터 우회 raw axios = 네트워크 정상)
```

수정: `typeof window` 가드. 서버=fallback(로그 skip), **클라/dev 거동 불변**.

## 검증

- node-env 회귀 테스트 추가, 전 단위 테스트 GREEN, `tsc`·eslint clean.
- 변경은 server-only(`typeof window` 가드) → 클라이언트 경로 provably 불변.

## #303 와의 관계 (정정)

#303 의 기존 framing("서버 401 스트리밍→redirect")과 그에 따른 server-side 수정 가설은 **로그 증거로 폐기**. preview E2E 로그상 #303 작동 원인 = **클라이언트측 cold Vercel preview RSC payload fetch abort(`net::ERR_ABORTED` on `_rsc=`) + 첫 클라 401**(server-side 아님). 본 L1 은 진짜 잠복버그지만 #303 작동 원인이 아니며, 머지해도 #303 E2E flake 는 그대로(실측: 3F/1flaky/7P = development baseline flake band 내, 시그니처 동일).

- **L2**(서버측 쿠키 전달) / **L3**(decorator `location` 가드 + predicate-throw 방어): #314 follow-up 으로 보류.
- **#303**: 클라이언트측 cold-RSC/401 가설로 재조사(별 트랙, 계측 우선).

Refs #314, #303