### PR TITLE
feat(E/#3) PR-3: changeType별 self-removed 알림 (web UX)

### DIFF
--- a/docs/superpowers/plans/2026-05-19-e3-pr3-changetype-modal.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr3-changetype-modal.md
@@ -1,0 +1,185 @@
+# E/#3 PR-3 — web changeType별 self-removed 알림 (pfplay-web) 구현 계획
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development. Checkbox(`- [ ]`) steps.
+
+**Goal:** PR-2(platform #240, merged)로 dj-queue-changed 메시지에 실린 `changeType`(+DEACTIVATE `playbackTimeLimitMinutes`)를 소비해, self 가 큐에서 빠질 때 changeType별로 사용자에게 안내(canonical `alert.notify`): DEACTIVATE="재생 시간 제한(N분) 초과로 중단", DEQUEUE_ADMIN="관리자에 의해 대기열에서 제외", DEQUEUE_EXIT=silent. analytics `reason` 하드코딩('admin') 제거→실제 changeType 반영.
+
+**Architecture:** canonical `useCurrentPartyroom().alert.notify(AlertMessage.Model)` 확장 — `AlertMessage.Model` union 에 DJ-removal variant 추가(penalty/grade 와 동일 UX·additive), 렌더 consumer(`useAlert` 콜백)에 분기 추가. 미지 changeType/필드부재 = 기존 동작 보존(backward-compat). `use-playback-deactivated-callback` **무변경**(state-reset 유지; 모달 단일출처=DjQueueChanged DEACTIVATE).
+
+**Tech Stack:** Next.js, TS, zustand store(`useCurrentPartyroom`), react-query, vitest. i18n = `useI18n()` 타입 dict(`dictionaries/{ko,en}.json`, Dictionary=typeof en.json) + `processI18nString(t.x.y,{var})`. ⚠ ko/en json **직접 편집**(`yarn i18n` 무지성 금지 — xlsx↔json drift, memory feedback_pfplay_web_i18n_drift). pfplay-web 2-tier `development`=stg.
+
+**Spec:** `pfplay-platform/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md` §3-3 + limit-only 개정. **Scope:** PR-3=web UX only. 배지=PR-4. PR-1/2 동작 무변경.
+
+---
+
+## File Structure
+
+- `src/shared/api/websocket/types/partyroom.ts` — `DjChangeType` 문자열 union 신설; `DjQueueChangedEvent` 에 optional `changeType?`, `playbackTimeLimitMinutes?: number | null`.
+- `src/entities/current-partyroom/model/alert-message.model.ts` — `DjRemovedAlertMessage` variant(들) + `Model` union + type guard.
+- `src/shared/lib/analytics/room-tracking.ts` — `trackDjAdminDeregisterDetected` 가 changeType 기반 reason 도출.
+- `src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts` — self-removed 분기 changeType별 `alert.notify`/track.
+- 알림 렌더 consumer(penalty/grade 를 처리하는 `useAlert(cb)` 콜백 — 구현자가 위치 식별: `git grep -ln "useAlert(" src` → penalty/grade switch 가진 곳, 예상 `widgets/partyroom-chat-panel/...` 또는 전용 alert 핸들러) — DJ variant 렌더 분기.
+- `src/shared/lib/localization/dictionaries/{ko,en}.json` — 신규 키(en 먼저=Dictionary 타입 갱신, ko 미러).
+- 테스트: `use-dj-queue-changed-callback.hook.test.ts`(확장), `alert-message.model` guard, `room-tracking` reason, 렌더 consumer 테스트(있으면 확장).
+
+---
+
+## Chunk 1: changeType별 self-removed 알림
+
+### Task 1: TS 타입 — DjChangeType + 이벤트/알림 모델 (additive)
+
+**Files:** Modify `src/shared/api/websocket/types/partyroom.ts`, `src/entities/current-partyroom/model/alert-message.model.ts`; Test `alert-message.model.test.ts`(없으면 신설, 동 디렉터리 테스트 컨벤션).
+
+- [ ] **Step 1: 실패 테스트** (alert-message.model guard) — 신규 variant guard:
+
+```ts
+import * as AlertMessage from './alert-message.model';
+test('dj-deactivated guard', () => {
+  const m: AlertMessage.Model = { type: 'dj-deactivated', playbackTimeLimitMinutes: 5 };
+  expect(AlertMessage.isDjRemovedAlertMessage(m)).toBe(true);
+  expect(AlertMessage.isPenaltyAlertMessage(m)).toBe(false);
+});
+test('dj-admin-removed guard', () => {
+  const m: AlertMessage.Model = { type: 'dj-admin-removed' };
+  expect(AlertMessage.isDjRemovedAlertMessage(m)).toBe(true);
+});
+test('기존 grade/penalty guard 회귀', () => {
+  expect(
+    AlertMessage.isDjRemovedAlertMessage({ type: 'grade-adjusted', prev: 0 as any, next: 0 as any })
+  ).toBe(false);
+});
+```
+
+(GradeType import 등은 기존 model 테스트/파일 방식 따름.)
+
+- [ ] **Step 2: 실패 확인** — `yarn vitest run src/entities/current-partyroom/model/alert-message.model.test.ts` → FAIL(guard/variant 부재).
+
+- [ ] **Step 3: 구현**
+      `partyroom.ts`: add
+
+  ```ts
+  export type DjChangeType =
+    | 'ENQUEUE'
+    | 'DEQUEUE'
+    | 'DEQUEUE_ADMIN'
+    | 'DEQUEUE_EXIT'
+    | 'ROTATE'
+    | 'DEACTIVATE';
+  ```
+
+  `DjQueueChangedEvent` 에 optional 필드 추가(기존 djs 등 유지):
+
+  ```ts
+  export type DjQueueChangedEvent = WebSocketEventBase & {
+    eventType: PartyroomEventType.DJ_QUEUE_CHANGED;
+    djs: Array<{ crewId: number; orderNumber: number; nickname: string; avatarIconUri: string }>;
+    changeType?: DjChangeType; // PR-2 additive; 구 메시지엔 없음
+    playbackTimeLimitMinutes?: number | null; // DEACTIVATE 한정(limit-only), 그 외 null/없음
+  };
+  ```
+
+  `alert-message.model.ts`: union 확장 + guard:
+
+  ```ts
+  export type Model = PenaltyAlertMessage | GradeAdjustedAlertMessage | DjRemovedAlertMessage;
+
+  type DjRemovedAlertMessage =
+    | { type: 'dj-deactivated'; playbackTimeLimitMinutes: number | null }
+    | { type: 'dj-admin-removed' };
+
+  export const isDjRemovedAlertMessage = (m: Model): m is DjRemovedAlertMessage =>
+    m.type === 'dj-deactivated' || m.type === 'dj-admin-removed';
+  ```
+
+  (기존 isPenaltyAlertMessage/isGradeAdjustedAlertMessage 무변경 — 새 type 들은 PenaltyType 값이 아니므로 자동 배제됨; 확인.)
+
+- [ ] **Step 4: 통과** — Step2 cmd → PASS. `yarn tsc --noEmit` 0.
+- [ ] **Step 5: 커밋** — `git add` 위 3파일 → `git commit -m "feat(E/#3): DjChangeType + DjQueueChangedEvent optional changeType/limit + AlertMessage dj-removal variant (additive)"`
+
+---
+
+### Task 2: room-tracking reason 를 changeType 기반으로
+
+현재 `trackDjAdminDeregisterDetected(partyroomId)` 가 `reason:'admin'` 하드코딩. changeType 별 reason('admin'|'deactivated'|...) 매핑.
+
+**Files:** Modify `src/shared/lib/analytics/room-tracking.ts`; Test `room-tracking.test.ts`(있으면 확장, 없으면 신설; `track` mock — 기존 analytics 테스트 패턴).
+
+- [ ] **Step 1: 실패 테스트** — `trackDjRemovalDetected(partyroomId, changeType)`(또는 기존 함수에 changeType 인자 추가; 기존 시그니처 영향 최소 — **신규 인자 optional default 'admin'** 로 backward-compat): DEQUEUE_ADMIN→`reason:'admin'`, DEACTIVATE→`reason:'deactivated'`, undefined→`reason:'admin'`(기존 동작 보존), suppression 윈도우 동작 보존(self dequeue skip). DEQUEUE_EXIT→호출 안 함(silent; 호출지에서 분기).
+
+- [ ] **Step 2: 실패 확인** — `yarn vitest run <room-tracking.test>` → FAIL.
+
+- [ ] **Step 3: 구현** — `trackDjAdminDeregisterDetected(partyroomId: number, changeType?: DjChangeType)` 로 확장(기존 호출 무인자 호환): suppression 소비 우선, 그다음 `track('DJ Deregistered', { partyroom_id, reason: mapReason(changeType) })` where `mapReason: DEACTIVATE→'deactivated', DEQUEUE_ADMIN|undefined→'admin'`. 함수명/주석은 'admin' 한정이 아니게 다듬되 export 시그니처 backward-compat(기존 호출지 무인자 그대로 컴파일). `suppressNextSelfDjDeregister`/`consumeSelfDjDeregisterSuppression` 무변경.
+
+- [ ] **Step 4: 통과** — PASS, `tsc` 0.
+- [ ] **Step 5: 커밋** — `feat(E/#3): DJ Deregistered reason 를 changeType 기반 매핑 (admin/deactivated, 무인자 호환)`
+
+---
+
+### Task 3: dj-queue-changed 콜백 — changeType별 알림 분기
+
+**Files:** Modify `src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts`; Test 동 `.hook.test.ts`(확장).
+
+현재 self-removed 검출(`wasInQueue && !stillInQueue`)은 무조건 `trackDjAdminDeregisterDetected(event.partyroomId)`. 변경: `event.changeType` 분기.
+
+- [ ] **Step 1: 실패/회귀 테스트** (기존 test 파일 mock 패턴 재사용; `alert.notify` 검증 위해 store mock 에 `alert:{notify:vi.fn()}` 추가):
+
+  - changeType=DEACTIVATE & self removed → `alert.notify({type:'dj-deactivated', playbackTimeLimitMinutes: <event 값>})` 호출 + `trackDjAdminDeregisterDetected(pid,'DEACTIVATE')`.
+  - changeType=DEQUEUE_ADMIN & self removed → `alert.notify({type:'dj-admin-removed'})` + track(pid,'DEQUEUE_ADMIN').
+  - changeType=DEQUEUE_EXIT & self removed → **silent**: alert.notify 미호출, track 미호출.
+  - changeType undefined(구 메시지) & self removed → **기존 동작 보존**: track 호출(reason 'admin'), alert.notify 미호출(구 메시지엔 안내 신호 없음 — 무동작 안전).
+  - self 여전히 큐/처음부터 없음/prev 없음/me 미설정 → 기존대로 아무것도 안 함(회귀 — 기존 5 테스트 보존).
+  - playbackTimeLimitMinutes 가 0 또는 null/undefined(unlimited) → alert.notify 는 호출하되 playbackTimeLimitMinutes 그대로 전달(렌더에서 graceful — Task4).
+
+- [ ] **Step 2: 실패 확인** — `yarn vitest run src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.test.ts` → FAIL.
+
+- [ ] **Step 3: 구현** — hook 에서 `alert` 도 store 에서 취득(`useCurrentPartyroom((s)=>s.alert)`; penalty 콜백과 동일 접근). self-removed 블록을 changeType 분기로:
+
+  ```ts
+  if (wasInQueue && !stillInQueue) {
+    const ct = event.changeType;
+    if (ct === 'DEQUEUE_EXIT') {
+      // 본인 이탈 → silent (자연스러움)
+    } else if (ct === 'DEACTIVATE') {
+      alert.notify({
+        type: 'dj-deactivated',
+        playbackTimeLimitMinutes: event.playbackTimeLimitMinutes ?? null,
+      });
+      trackDjAdminDeregisterDetected(event.partyroomId, ct);
+    } else if (ct === 'DEQUEUE_ADMIN') {
+      alert.notify({ type: 'dj-admin-removed' });
+      trackDjAdminDeregisterDetected(event.partyroomId, ct);
+    } else {
+      // 구 메시지(changeType 없음) 등 → 기존 동작 보존(분류만, 안내 없음)
+      trackDjAdminDeregisterDetected(event.partyroomId, ct);
+    }
+  }
+  ```
+
+  (DEQUEUE/ENQUEUE/ROTATE 는 self-removed 가 거의 안 나거나 자진/무관 — else 분기로 흡수, 안내 없음. suppression 윈도우는 trackDj... 내부에서 self dequeue 흡수.) 나머지 콜백 로직(currentDj 갱신·캐시 setQueryData) **무변경**.
+
+- [ ] **Step 4: 통과** — PASS(신규+기존 5 회귀), `tsc` 0.
+- [ ] **Step 5: 커밋** — `feat(E/#3): dj-queue-changed self-removed 를 changeType별 alert.notify/track 분기`
+
+---
+
+### Task 4: 알림 렌더 + i18n (ko/en)
+
+**Files:** Modify the `useAlert(cb)` consumer that switches on penalty/grade (구현자: `git grep -ln "useAlert(" src` → penalty(`isPenaltyAlertMessage`)/grade 분기 가진 콜백 파일 식별; 그 switch 에 DJ variant 추가, 기존 penalty/grade UX(토스트/알림 표시)와 동일 표현 재사용); `src/shared/lib/localization/dictionaries/en.json` 먼저 → `ko.json` 미러. Test: 렌더 consumer 테스트 있으면 확장.
+
+- [ ] **Step 1: i18n 키 추가** (en.json 먼저=Dictionary 타입 갱신; ko.json 동일 키). 기존 `dj.para` 섹션에 추가(키 위치는 그 consumer 가 `t.` 로 접근하기 좋은 곳, 기존 penalty/grade 알림 문자열과 동일 섹션 컨벤션):
+  - `dj.para.playback_stopped_time_limit` ko: "재생 시간 제한({minutes}분)을 초과하는 곡으로 재생이 중단되었습니다" / en: "Playback stopped: a track exceeds this room's time limit ({minutes} min)."
+  - `dj.para.playback_stopped_no_limit` (graceful: minutes 0/null/undefined) ko: "재생 가능한 곡이 없어 재생이 중단되었습니다" / en: "Playback stopped: no playable track."
+  - admin: 기존 `dj.para.deleted_queue_by_admin`("관리자에 의해 대기열에서 삭제되었습니다") **재사용**(신규 키 X — DRY). en 동등 문자열 존재 확인, 없으면 동 키 en 보강.
+- [ ] **Step 2: 실패 테스트** — 렌더 consumer 테스트(있으면): `{type:'dj-deactivated', playbackTimeLimitMinutes:5}` → `playback_stopped_time_limit` (processI18nString {minutes:5}) 표시; `playbackTimeLimitMinutes:0|null` → `playback_stopped_no_limit`; `{type:'dj-admin-removed'}` → `deleted_queue_by_admin`. 없으면 이 분기를 검증하는 단위 테스트 신설(consumer 콜백 추출 가능 형태면 그 함수, 아니면 컴포넌트 렌더 테스트 — 기존 penalty 알림 테스트 패턴 따름).
+- [ ] **Step 3: 실패 확인** → FAIL.
+- [ ] **Step 4: 구현** — consumer 의 alert switch 에 `isDjRemovedAlertMessage` 분기: `dj-deactivated` → minutes 유효(>0)면 `processI18nString(t.dj.para.playback_stopped_time_limit,{minutes})` 아니면 `t.dj.para.playback_stopped_no_limit`; `dj-admin-removed` → `t.dj.para.deleted_queue_by_admin`. 표시 수단(토스트/알림 컴포넌트)은 기존 penalty/grade 와 동일 메커니즘 재사용(신규 UI 발명 금지).
+- [ ] **Step 5: 통과 + 전 회귀** — `yarn vitest run` 전체 GREEN, `yarn tsc --noEmit` 0, `yarn eslint src/entities/current-partyroom src/entities/partyroom-client src/shared/api/websocket src/shared/lib/analytics <consumer dir> --quiet` 0 error. `git diff origin/development..HEAD --stat` scope 확인(위 파일+테스트+ko/en json+plan 만; use-playback-deactivated-callback·PR-1/2 코드·배지 무변경).
+- [ ] **Step 6: 커밋** — `feat(E/#3): changeType별 self-removed 알림 렌더 + i18n(ko/en) — deactivate(limit-only·graceful)/admin`
+
+---
+
+## 완료 정의 (DoD)
+
+- DEACTIVATE→"재생시간제한(N분) 초과 중단"(0/null→generic), DEQUEUE_ADMIN→"관리자 제외"(기존 키 재사용), DEQUEUE_EXIT→silent, 구 메시지(changeType 無)→기존 동작 보존(안내 無·track 'admin'). analytics reason changeType 매핑.
+- additive·backward-compat(미지 changeType/필드부재 무동작). use-playback-deactivated-callback 무변경(모달 단일출처). PR-1/2·배지(PR-4) 무관.
+- 전 vitest GREEN·tsc 0·scoped eslint 0. i18n ko/en 키 동기(yarn i18n 미사용). 스코프 경계 보존.

--- a/docs/superpowers/plans/2026-05-19-e3-pr3-changetype-modal.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr3-changetype-modal.md
@@ -18,9 +18,10 @@
 - `src/entities/current-partyroom/model/alert-message.model.ts` — `DjRemovedAlertMessage` variant(들) + `Model` union + type guard.
 - `src/shared/lib/analytics/room-tracking.ts` — `trackDjAdminDeregisterDetected` 가 changeType 기반 reason 도출.
 - `src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts` — self-removed 분기 changeType별 `alert.notify`/track.
-- 알림 렌더 consumer(penalty/grade 를 처리하는 `useAlert(cb)` 콜백 — 구현자가 위치 식별: `git grep -ln "useAlert(" src` → penalty/grade switch 가진 곳, 예상 `widgets/partyroom-chat-panel/...` 또는 전용 alert 핸들러) — DJ variant 렌더 분기.
-- `src/shared/lib/localization/dictionaries/{ko,en}.json` — 신규 키(en 먼저=Dictionary 타입 갱신, ko 미러).
-- 테스트: `use-dj-queue-changed-callback.hook.test.ts`(확장), `alert-message.model` guard, `room-tracking` reason, 렌더 consumer 테스트(있으면 확장).
+- `src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.tsx` — **신규**(렌더). 아키텍처 정정: 단일 `useAlert(cb)` switch 없음 — variant별 전용 훅(`use-penalty-alert.hook.tsx`, `use-grade-adjusted-alert.hook.tsx`)이 각자 `useAlert(useCallback(...))`+단일 `if(isXxx)` 가드로 구성되고 `use-alerts.hook.tsx`(`useAlerts()`)가 모두 호출·집계. 따라서 `use-grade-adjusted-alert.hook.tsx` 를 모델로 `useDjRemovedAlert()` 신설(가드 `isDjRemovedAlertMessage` → `useDialog().openAlertDialog`).
+- `src/entities/current-partyroom/lib/alerts/use-alerts.hook.tsx` — `useDjRemovedAlert()` 를 기존 `usePenaltyAlert()`/`useGradeAdjustedAlert()` 옆에 등록.
+- `src/shared/lib/localization/dictionaries/{ko,en}.json` — 신규 키(en 먼저=Dictionary 타입 갱신, ko 미러). 변수는 **`{{minutes}}`(이중 중괄호, VariableProcessor 컨벤션)**. 기존 `dj.para.deleted_queue_by_admin` 는 ko/en 양쪽 이미 존재(재사용, 보강 불요).
+- 테스트: `use-dj-queue-changed-callback.hook.test.ts`(확장), `alert-message.model.test.ts`(**기존 존재 → describe 블록 확장**, named-import 스타일 일치), `room-tracking.test.ts`(기존 존재 → 확장), `use-dj-removed-alert.hook.test.tsx`(신규, `use-penalty-alert`/grade 테스트의 renderHook+mock 패턴 복제).
 
 ---
 
@@ -28,7 +29,7 @@
 
 ### Task 1: TS 타입 — DjChangeType + 이벤트/알림 모델 (additive)
 
-**Files:** Modify `src/shared/api/websocket/types/partyroom.ts`, `src/entities/current-partyroom/model/alert-message.model.ts`; Test `alert-message.model.test.ts`(없으면 신설, 동 디렉터리 테스트 컨벤션).
+**Files:** Modify `src/shared/api/websocket/types/partyroom.ts`, `src/entities/current-partyroom/model/alert-message.model.ts`; Test `alert-message.model.test.ts`(**기존 존재** — `isPenaltyAlertMessage`/`isGradeAdjustedAlertMessage` 커버 중. `describe('isDjRemovedAlertMessage')` 블록 **추가**, 기존 파일의 named-import 스타일 일치).
 
 - [ ] **Step 1: 실패 테스트** (alert-message.model guard) — 신규 variant guard:
 
@@ -104,7 +105,7 @@ test('기존 grade/penalty guard 회귀', () => {
 
 **Files:** Modify `src/shared/lib/analytics/room-tracking.ts`; Test `room-tracking.test.ts`(있으면 확장, 없으면 신설; `track` mock — 기존 analytics 테스트 패턴).
 
-- [ ] **Step 1: 실패 테스트** — `trackDjRemovalDetected(partyroomId, changeType)`(또는 기존 함수에 changeType 인자 추가; 기존 시그니처 영향 최소 — **신규 인자 optional default 'admin'** 로 backward-compat): DEQUEUE_ADMIN→`reason:'admin'`, DEACTIVATE→`reason:'deactivated'`, undefined→`reason:'admin'`(기존 동작 보존), suppression 윈도우 동작 보존(self dequeue skip). DEQUEUE_EXIT→호출 안 함(silent; 호출지에서 분기).
+- [ ] **Step 1: 실패 테스트** — **함수명 변경 금지**(`trackDjAdminDeregisterDetected` 유지; rename 시 기존 3 테스트 + hook 테스트 mock(`vi.mock(... trackDjAdminDeregisterDetected)`) 깨짐). 기존 함수에 **optional `changeType?: DjChangeType` 인자만 추가**(무인자 호출 backward-compat). 테스트(기존 `room-tracking.test.ts` 의 `describe('DJ deregister attribution')` 확장): DEQUEUE_ADMIN→`reason:'admin'`, DEACTIVATE→`reason:'deactivated'`, 인자 없음(undefined)→`reason:'admin'`(**기존 3 테스트 그대로 green**), suppression 윈도우 동작 보존(self dequeue skip 우선). DEQUEUE_EXIT 는 이 함수 호출 자체를 안 함(호출지=Task3 에서 분기).
 
 - [ ] **Step 2: 실패 확인** — `yarn vitest run <room-tracking.test>` → FAIL.
 
@@ -162,19 +163,21 @@ test('기존 grade/penalty guard 회귀', () => {
 
 ---
 
-### Task 4: 알림 렌더 + i18n (ko/en)
+### Task 4: 알림 렌더 신규 훅 + 등록 + i18n (ko/en)
 
-**Files:** Modify the `useAlert(cb)` consumer that switches on penalty/grade (구현자: `git grep -ln "useAlert(" src` → penalty(`isPenaltyAlertMessage`)/grade 분기 가진 콜백 파일 식별; 그 switch 에 DJ variant 추가, 기존 penalty/grade UX(토스트/알림 표시)와 동일 표현 재사용); `src/shared/lib/localization/dictionaries/en.json` 먼저 → `ko.json` 미러. Test: 렌더 consumer 테스트 있으면 확장.
+**아키텍처(정정)**: 단일 switch consumer 없음. variant별 전용 훅 — `src/entities/current-partyroom/lib/alerts/use-penalty-alert.hook.tsx`(가드 `isPenaltyAlertMessage` → `useDialog().openDialog`), `use-grade-adjusted-alert.hook.tsx`(`isGradeAdjustedAlertMessage` → `useDialog().openAlertDialog`). `use-alerts.hook.tsx`(`useAlerts()`)가 각 훅을 호출·집계. → **신규 `useDjRemovedAlert()` 훅**을 `use-grade-adjusted-alert.hook.tsx` 패턴으로 만들고 `use-alerts.hook.tsx` 에 등록.
 
-- [ ] **Step 1: i18n 키 추가** (en.json 먼저=Dictionary 타입 갱신; ko.json 동일 키). 기존 `dj.para` 섹션에 추가(키 위치는 그 consumer 가 `t.` 로 접근하기 좋은 곳, 기존 penalty/grade 알림 문자열과 동일 섹션 컨벤션):
-  - `dj.para.playback_stopped_time_limit` ko: "재생 시간 제한({minutes}분)을 초과하는 곡으로 재생이 중단되었습니다" / en: "Playback stopped: a track exceeds this room's time limit ({minutes} min)."
-  - `dj.para.playback_stopped_no_limit` (graceful: minutes 0/null/undefined) ko: "재생 가능한 곡이 없어 재생이 중단되었습니다" / en: "Playback stopped: no playable track."
-  - admin: 기존 `dj.para.deleted_queue_by_admin`("관리자에 의해 대기열에서 삭제되었습니다") **재사용**(신규 키 X — DRY). en 동등 문자열 존재 확인, 없으면 동 키 en 보강.
-- [ ] **Step 2: 실패 테스트** — 렌더 consumer 테스트(있으면): `{type:'dj-deactivated', playbackTimeLimitMinutes:5}` → `playback_stopped_time_limit` (processI18nString {minutes:5}) 표시; `playbackTimeLimitMinutes:0|null` → `playback_stopped_no_limit`; `{type:'dj-admin-removed'}` → `deleted_queue_by_admin`. 없으면 이 분기를 검증하는 단위 테스트 신설(consumer 콜백 추출 가능 형태면 그 함수, 아니면 컴포넌트 렌더 테스트 — 기존 penalty 알림 테스트 패턴 따름).
-- [ ] **Step 3: 실패 확인** → FAIL.
-- [ ] **Step 4: 구현** — consumer 의 alert switch 에 `isDjRemovedAlertMessage` 분기: `dj-deactivated` → minutes 유효(>0)면 `processI18nString(t.dj.para.playback_stopped_time_limit,{minutes})` 아니면 `t.dj.para.playback_stopped_no_limit`; `dj-admin-removed` → `t.dj.para.deleted_queue_by_admin`. 표시 수단(토스트/알림 컴포넌트)은 기존 penalty/grade 와 동일 메커니즘 재사용(신규 UI 발명 금지).
-- [ ] **Step 5: 통과 + 전 회귀** — `yarn vitest run` 전체 GREEN, `yarn tsc --noEmit` 0, `yarn eslint src/entities/current-partyroom src/entities/partyroom-client src/shared/api/websocket src/shared/lib/analytics <consumer dir> --quiet` 0 error. `git diff origin/development..HEAD --stat` scope 확인(위 파일+테스트+ko/en json+plan 만; use-playback-deactivated-callback·PR-1/2 코드·배지 무변경).
-- [ ] **Step 6: 커밋** — `feat(E/#3): changeType별 self-removed 알림 렌더 + i18n(ko/en) — deactivate(limit-only·graceful)/admin`
+**Files:** Create `src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.tsx` + `use-dj-removed-alert.hook.test.tsx`; Modify `src/entities/current-partyroom/lib/alerts/use-alerts.hook.tsx`, `src/shared/lib/localization/dictionaries/en.json`(먼저=Dictionary 타입), `src/shared/lib/localization/dictionaries/ko.json`(미러).
+
+- [ ] **Step 1: i18n 키 추가** (en.json 먼저 → ko.json 동일 키). 기존 `dj.para` 섹션(ko L207/en L220 존재)에 추가. **변수는 이중 중괄호 `{{minutes}}`**(VariableProcessor 컨벤션 — `dj.title.time_limit` 등이 `{{minutes}}` 사용; 단일 `{}`면 치환 실패):
+  - `dj.para.playback_stopped_time_limit` ko: `"재생 시간 제한({{minutes}}분)을 초과하는 곡으로 재생이 중단되었습니다"` / en: `"Playback stopped: a track exceeds this room's time limit ({{minutes}} min)."`
+  - `dj.para.playback_stopped_no_limit` (graceful: minutes 0/null/undefined) ko: `"재생 가능한 곡이 없어 재생이 중단되었습니다"` / en: `"Playback stopped: no playable track."`
+  - admin: 기존 `dj.para.deleted_queue_by_admin` ko/en **양쪽 이미 존재**(en L229 "You have been removed from the queue by the administrator") → **재사용**(신규 키 X·보강 불요).
+- [ ] **Step 2: 실패 테스트** `use-dj-removed-alert.hook.test.tsx` — `use-penalty-alert`/`use-grade-adjusted-alert` 테스트의 renderHook + store/`useDialog` mock 패턴 복제. `alert.notify({type:'dj-deactivated', playbackTimeLimitMinutes:5})` → `openAlertDialog` 가 `processI18nString(t.dj.para.playback_stopped_time_limit,{minutes:'5'})` 내용으로 호출; `playbackTimeLimitMinutes:0|null` → `playback_stopped_no_limit`; `{type:'dj-admin-removed'}` → `deleted_queue_by_admin`; 비-DJ variant(penalty/grade)는 무시(가드).
+- [ ] **Step 3: 실패 확인** — `yarn vitest run src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.test.tsx` → FAIL.
+- [ ] **Step 4: 구현** — `use-dj-removed-alert.hook.tsx`: `use-grade-adjusted-alert.hook.tsx` 구조 그대로(`useAlert(useCallback(cb,[deps]))`, `useDialog().openAlertDialog`, `useI18n()`). 콜백: `if(!AlertMessage.isDjRemovedAlertMessage(message)) return;` 그다음 `message.type==='dj-deactivated'` 면 `const m = message.playbackTimeLimitMinutes; const content = (typeof m==='number' && m>0) ? processI18nString(t.dj.para.playback_stopped_time_limit, { minutes: String(m) }) : t.dj.para.playback_stopped_no_limit;` (★`processI18nString` 의 vars 는 `Record<string,string>` → 반드시 `String(m)`), `'dj-admin-removed'` 면 `t.dj.para.deleted_queue_by_admin`; `openAlertDialog` 로 표시(grade 훅과 동일 호출 형태). `use-alerts.hook.tsx` 에 `useDjRemovedAlert()` 추가(usePenaltyAlert/useGradeAdjustedAlert 옆, 동일 호출 컨벤션).
+- [ ] **Step 5: 통과 + 전 회귀** — Step3 cmd PASS. `yarn vitest run` 전체 GREEN, `yarn tsc --noEmit` 0, `yarn eslint src/entities/current-partyroom src/entities/partyroom-client src/shared/api/websocket src/shared/lib/analytics --quiet` 0 error. `git diff origin/development..HEAD --stat` scope(Task1~4 파일+테스트+ko/en json+plan 만; `use-playback-deactivated-callback`·PR-1/2 코드·배지 무변경).
+- [ ] **Step 6: 커밋** — `feat(E/#3): useDjRemovedAlert 신규 훅 + use-alerts 등록 + i18n(ko/en) — deactivate(limit-only·graceful)/admin`
 
 ---
 

--- a/src/entities/current-partyroom/lib/alerts/use-alerts.hook.tsx
+++ b/src/entities/current-partyroom/lib/alerts/use-alerts.hook.tsx
@@ -1,7 +1,9 @@
+import useDjRemovedAlert from './use-dj-removed-alert.hook';
 import useGradeAdjustedAlert from './use-grade-adjusted-alert.hook';
 import usePenaltyAlert from './use-penalty-alert.hook';
 
 export default function useAlerts() {
   useGradeAdjustedAlert();
   usePenaltyAlert();
+  useDjRemovedAlert();
 }

--- a/src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.test.tsx
+++ b/src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.test.tsx
@@ -1,0 +1,107 @@
+vi.mock('@/shared/lib/store/stores.context');
+vi.mock('@/shared/lib/localization/i18n.context');
+vi.mock('@/shared/ui/components/dialog');
+
+import { renderHook, act } from '@testing-library/react';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { processI18nString } from '@/shared/lib/localization/renderer/processors/variable-processor-util';
+import { useDialog } from '@/shared/ui/components/dialog';
+import useDjRemovedAlert from './use-dj-removed-alert.hook';
+
+const mockOpenAlertDialog = vi.fn();
+let alertCallback: (...args: any[]) => void;
+
+vi.mock('./use-alert.hook', () => ({
+  __esModule: true,
+  default: vi.fn((cb: (...args: any[]) => void) => {
+    alertCallback = cb;
+  }),
+}));
+
+const t = {
+  dj: {
+    title: {
+      dj_queue: 'DJ Queue',
+    },
+    para: {
+      playback_stopped_time_limit:
+        "Playback stopped: a track exceeds this room's time limit ({{minutes}} min).",
+      playback_stopped_no_limit: 'Playback stopped: no playable track.',
+      deleted_queue_by_admin: 'You have been removed from the queue by the administrator',
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useI18n as Mock).mockReturnValue(t);
+  (useDialog as Mock).mockReturnValue({ openAlertDialog: mockOpenAlertDialog });
+});
+
+describe('useDjRemovedAlert', () => {
+  test('dj-deactivated + playbackTimeLimitMinutes=5 → 시간 제한 메시지로 다이얼로그를 연다', () => {
+    renderHook(() => useDjRemovedAlert());
+
+    act(() => {
+      alertCallback({ type: 'dj-deactivated', playbackTimeLimitMinutes: 5 });
+    });
+
+    expect(mockOpenAlertDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: processI18nString(t.dj.para.playback_stopped_time_limit, { minutes: '5' }),
+      })
+    );
+  });
+
+  test('dj-deactivated + playbackTimeLimitMinutes=0 → no_limit 메시지로 다이얼로그를 연다', () => {
+    renderHook(() => useDjRemovedAlert());
+
+    act(() => {
+      alertCallback({ type: 'dj-deactivated', playbackTimeLimitMinutes: 0 });
+    });
+
+    expect(mockOpenAlertDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: t.dj.para.playback_stopped_no_limit,
+      })
+    );
+  });
+
+  test('dj-deactivated + playbackTimeLimitMinutes=null → no_limit 메시지로 다이얼로그를 연다', () => {
+    renderHook(() => useDjRemovedAlert());
+
+    act(() => {
+      alertCallback({ type: 'dj-deactivated', playbackTimeLimitMinutes: null });
+    });
+
+    expect(mockOpenAlertDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: t.dj.para.playback_stopped_no_limit,
+      })
+    );
+  });
+
+  test('dj-admin-removed → deleted_queue_by_admin 메시지로 다이얼로그를 연다', () => {
+    renderHook(() => useDjRemovedAlert());
+
+    act(() => {
+      alertCallback({ type: 'dj-admin-removed' });
+    });
+
+    expect(mockOpenAlertDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: t.dj.para.deleted_queue_by_admin,
+      })
+    );
+  });
+
+  test('DJ 관련이 아닌 메시지는 무시한다 (다이얼로그 미호출)', () => {
+    renderHook(() => useDjRemovedAlert());
+
+    act(() => {
+      alertCallback({ type: 'grade-adjusted', prev: 'CLUBBER', next: 'MODERATOR' });
+    });
+
+    expect(mockOpenAlertDialog).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.tsx
+++ b/src/entities/current-partyroom/lib/alerts/use-dj-removed-alert.hook.tsx
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { processI18nString } from '@/shared/lib/localization/renderer/processors/variable-processor-util';
+import { useDialog } from '@/shared/ui/components/dialog';
+import useAlert from './use-alert.hook';
+import * as AlertMessage from '../../model/alert-message.model';
+
+export default function useDjRemovedAlert() {
+  const t = useI18n();
+  const { openAlertDialog } = useDialog();
+
+  useAlert(
+    useCallback(
+      (message) => {
+        if (!AlertMessage.isDjRemovedAlertMessage(message)) return;
+
+        let content: string;
+        if (message.type === 'dj-deactivated') {
+          const m = message.playbackTimeLimitMinutes;
+          content =
+            typeof m === 'number' && m > 0
+              ? processI18nString(t.dj.para.playback_stopped_time_limit, { minutes: String(m) })
+              : t.dj.para.playback_stopped_no_limit;
+        } else {
+          // 'dj-admin-removed'
+          content = t.dj.para.deleted_queue_by_admin;
+        }
+
+        openAlertDialog({
+          title: t.dj.title.dj_queue,
+          content,
+        });
+      },
+      [t, openAlertDialog]
+    )
+  );
+}

--- a/src/entities/current-partyroom/model/alert-message.model.test.ts
+++ b/src/entities/current-partyroom/model/alert-message.model.test.ts
@@ -2,6 +2,7 @@ import { GradeType, PenaltyType } from '@/shared/api/http/types/@enums';
 import {
   isPenaltyAlertMessage,
   isGradeAdjustedAlertMessage,
+  isDjRemovedAlertMessage,
   type Model,
 } from './alert-message.model';
 
@@ -43,6 +44,43 @@ describe('alert-message model', () => {
     ])('PenaltyType.%s → false', (type) => {
       const message: Model = { type, reason: '규칙 위반' };
       expect(isGradeAdjustedAlertMessage(message)).toBe(false);
+    });
+  });
+
+  describe('isDjRemovedAlertMessage', () => {
+    test('dj-deactivated + playbackTimeLimitMinutes 숫자 → true, 다른 가드는 false', () => {
+      const message: Model = { type: 'dj-deactivated', playbackTimeLimitMinutes: 5 };
+      expect(isDjRemovedAlertMessage(message)).toBe(true);
+      expect(isPenaltyAlertMessage(message)).toBe(false);
+      expect(isGradeAdjustedAlertMessage(message)).toBe(false);
+    });
+
+    test('dj-deactivated + playbackTimeLimitMinutes null → true', () => {
+      const message: Model = { type: 'dj-deactivated', playbackTimeLimitMinutes: null };
+      expect(isDjRemovedAlertMessage(message)).toBe(true);
+    });
+
+    test('dj-admin-removed → true', () => {
+      const message: Model = { type: 'dj-admin-removed' };
+      expect(isDjRemovedAlertMessage(message)).toBe(true);
+    });
+
+    test('grade-adjusted 타입은 false', () => {
+      const message: Model = {
+        type: 'grade-adjusted',
+        prev: GradeType.LISTENER,
+        next: GradeType.CLUBBER,
+      };
+      expect(isDjRemovedAlertMessage(message)).toBe(false);
+    });
+
+    it.each([
+      PenaltyType.CHAT_BAN_30_SECONDS,
+      PenaltyType.ONE_TIME_EXPULSION,
+      PenaltyType.PERMANENT_EXPULSION,
+    ])('PenaltyType.%s → false', (type) => {
+      const message: Model = { type, reason: '규칙 위반' };
+      expect(isDjRemovedAlertMessage(message)).toBe(false);
     });
   });
 });

--- a/src/entities/current-partyroom/model/alert-message.model.ts
+++ b/src/entities/current-partyroom/model/alert-message.model.ts
@@ -1,6 +1,6 @@
 import { GradeType, PenaltyType } from '@/shared/api/http/types/@enums';
 
-export type Model = PenaltyAlertMessage | GradeAdjustedAlertMessage;
+export type Model = PenaltyAlertMessage | GradeAdjustedAlertMessage | DjRemovedAlertMessage;
 
 type PenaltyAlertMessage = {
   type: Exclude<PenaltyType, PenaltyType.CHAT_MESSAGE_REMOVAL>;
@@ -13,6 +13,10 @@ type GradeAdjustedAlertMessage = {
   next: GradeType;
 };
 
+type DjRemovedAlertMessage =
+  | { type: 'dj-deactivated'; playbackTimeLimitMinutes: number | null }
+  | { type: 'dj-admin-removed' };
+
 export const isPenaltyAlertMessage = (message: Model): message is PenaltyAlertMessage => {
   return Object.values(PenaltyType).includes(message.type as PenaltyType);
 };
@@ -22,3 +26,6 @@ export const isGradeAdjustedAlertMessage = (
 ): message is GradeAdjustedAlertMessage => {
   return message.type === 'grade-adjusted';
 };
+
+export const isDjRemovedAlertMessage = (message: Model): message is DjRemovedAlertMessage =>
+  message.type === 'dj-deactivated' || message.type === 'dj-admin-removed';

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.test.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.test.ts
@@ -7,20 +7,22 @@ import { renderWithClient } from '@/shared/api/__test__/test-utils';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import { QueueStatus } from '@/shared/api/http/types/@enums';
 import { DjingQueue } from '@/shared/api/http/types/partyrooms';
-import { PartyroomEventType } from '@/shared/api/websocket/types/partyroom';
+import { DjChangeType, PartyroomEventType } from '@/shared/api/websocket/types/partyroom';
 import { trackDjAdminDeregisterDetected } from '@/shared/lib/analytics/room-tracking';
 import { useStores } from '@/shared/lib/store/stores.context';
 import useDjQueueChangedCallback from './use-dj-queue-changed-callback.hook';
 
 const updateCurrentDj = vi.fn();
 const mockGetState = vi.fn();
+const alertNotify = vi.fn();
+const alert = { notify: alertNotify };
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetState.mockReturnValue({ me: undefined });
   (useStores as Mock).mockReturnValue({
     useCurrentPartyroom: Object.assign(
-      (selector: (...args: any[]) => any) => selector({ id: undefined, updateCurrentDj }),
+      (selector: (...args: any[]) => any) => selector({ id: undefined, updateCurrentDj, alert }),
       { getState: mockGetState }
     ),
   });
@@ -40,12 +42,18 @@ const createDj = (crewId: number, orderNumber: number) => ({
   avatarIconUri: `user${crewId}.png`,
 });
 
-const createEvent = (djs = [createDj(2, 2), createDj(1, 1)]) => ({
+const createEvent = (
+  djs = [createDj(2, 2), createDj(1, 1)],
+  changeType?: DjChangeType,
+  playbackTimeLimitMinutes?: number | null
+) => ({
   eventType: PartyroomEventType.DJ_QUEUE_CHANGED as const,
   partyroomId: 123,
   id: 'event-id',
   timestamp: Date.now(),
   djs,
+  ...(changeType !== undefined ? { changeType } : {}),
+  ...(playbackTimeLimitMinutes !== undefined ? { playbackTimeLimitMinutes } : {}),
 });
 
 describe('useDjQueueChangedCallback', () => {
@@ -71,7 +79,7 @@ describe('useDjQueueChangedCallback', () => {
   });
 
   describe('self admin deregister detection (Med3)', () => {
-    test('내가 큐에 있다가 사라지면 trackDjAdminDeregisterDetected 호출', () => {
+    test('내가 큐에 있다가 사라지면 trackDjAdminDeregisterDetected 호출 (changeType 없음 → undefined)', () => {
       mockGetState.mockReturnValue({ me: { crewId: 1 } });
       const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
       queryClient.setQueryData(
@@ -79,10 +87,11 @@ describe('useDjQueueChangedCallback', () => {
         createQueue([createDj(1, 1), createDj(2, 2)])
       );
 
-      // 새 이벤트에서는 crewId=1 이 사라짐
+      // 새 이벤트에서는 crewId=1 이 사라짐 (changeType 없음 = 구 메시지)
       result.current(createEvent([createDj(2, 1)]));
 
-      expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123);
+      expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, undefined);
+      expect(alertNotify).not.toHaveBeenCalled();
     });
 
     test('내가 여전히 큐에 있으면 호출 안 함', () => {
@@ -96,6 +105,7 @@ describe('useDjQueueChangedCallback', () => {
       result.current(createEvent([createDj(1, 1), createDj(2, 2), createDj(3, 3)]));
 
       expect(trackDjAdminDeregisterDetected).not.toHaveBeenCalled();
+      expect(alertNotify).not.toHaveBeenCalled();
     });
 
     test('내가 처음부터 큐에 없었으면 호출 안 함', () => {
@@ -109,6 +119,7 @@ describe('useDjQueueChangedCallback', () => {
       result.current(createEvent([createDj(2, 1)]));
 
       expect(trackDjAdminDeregisterDetected).not.toHaveBeenCalled();
+      expect(alertNotify).not.toHaveBeenCalled();
     });
 
     test('me.crewId 미설정 시 호출 안 함 (입장 직후 race)', () => {
@@ -119,6 +130,7 @@ describe('useDjQueueChangedCallback', () => {
       result.current(createEvent([]));
 
       expect(trackDjAdminDeregisterDetected).not.toHaveBeenCalled();
+      expect(alertNotify).not.toHaveBeenCalled();
     });
 
     test('이전 캐시가 없으면 (첫 이벤트) 호출 안 함', () => {
@@ -128,6 +140,120 @@ describe('useDjQueueChangedCallback', () => {
       result.current(createEvent([createDj(2, 1)]));
 
       expect(trackDjAdminDeregisterDetected).not.toHaveBeenCalled();
+      expect(alertNotify).not.toHaveBeenCalled();
+    });
+
+    describe('changeType별 분기', () => {
+      test('DEACTIVATE → alert.notify(dj-deactivated) + track(DEACTIVATE)', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)], 'DEACTIVATE', 3));
+
+        expect(alertNotify).toHaveBeenCalledWith({
+          type: 'dj-deactivated',
+          playbackTimeLimitMinutes: 3,
+        });
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, 'DEACTIVATE');
+      });
+
+      test('DEACTIVATE + playbackTimeLimitMinutes=0 → playbackTimeLimitMinutes=0 전달', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)], 'DEACTIVATE', 0));
+
+        expect(alertNotify).toHaveBeenCalledWith({
+          type: 'dj-deactivated',
+          playbackTimeLimitMinutes: 0,
+        });
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, 'DEACTIVATE');
+      });
+
+      test('DEACTIVATE + playbackTimeLimitMinutes=null → playbackTimeLimitMinutes=null 전달', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)], 'DEACTIVATE', null));
+
+        expect(alertNotify).toHaveBeenCalledWith({
+          type: 'dj-deactivated',
+          playbackTimeLimitMinutes: null,
+        });
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, 'DEACTIVATE');
+      });
+
+      test('DEACTIVATE + playbackTimeLimitMinutes 미제공 → playbackTimeLimitMinutes=null 전달 (?? null)', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        // playbackTimeLimitMinutes 필드 없음
+        result.current(createEvent([createDj(2, 1)], 'DEACTIVATE'));
+
+        expect(alertNotify).toHaveBeenCalledWith({
+          type: 'dj-deactivated',
+          playbackTimeLimitMinutes: null,
+        });
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, 'DEACTIVATE');
+      });
+
+      test('DEQUEUE_ADMIN → alert.notify(dj-admin-removed) + track(DEQUEUE_ADMIN)', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)], 'DEQUEUE_ADMIN'));
+
+        expect(alertNotify).toHaveBeenCalledWith({ type: 'dj-admin-removed' });
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, 'DEQUEUE_ADMIN');
+      });
+
+      test('DEQUEUE_EXIT → silent: alert.notify 미호출, track 미호출', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)], 'DEQUEUE_EXIT'));
+
+        expect(alertNotify).not.toHaveBeenCalled();
+        expect(trackDjAdminDeregisterDetected).not.toHaveBeenCalled();
+      });
+
+      test('changeType 없음(undefined) → alert.notify 미호출; track(123, undefined) 호출', () => {
+        mockGetState.mockReturnValue({ me: { crewId: 1 } });
+        const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+        queryClient.setQueryData(
+          [QueryKeys.DjingQueue, 123],
+          createQueue([createDj(1, 1), createDj(2, 2)])
+        );
+
+        result.current(createEvent([createDj(2, 1)]));
+
+        expect(alertNotify).not.toHaveBeenCalled();
+        expect(trackDjAdminDeregisterDetected).toHaveBeenCalledWith(123, undefined);
+      });
     });
   });
 });

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts
@@ -8,21 +8,34 @@ import { useStores } from '@/shared/lib/store/stores.context';
 export default function useDjQueueChangedCallback() {
   const queryClient = useQueryClient();
   const { useCurrentPartyroom } = useStores();
-  const updateCurrentDj = useCurrentPartyroom((state) => state.updateCurrentDj);
+  const [updateCurrentDj, alert] = useCurrentPartyroom((s) => [s.updateCurrentDj, s.alert]);
 
   return (event: DjQueueChangedEvent) => {
     const queryKey = [QueryKeys.DjingQueue, event.partyroomId];
 
-    // self 가 큐에서 빠졌는지 검출 — 본인이 unregister 하지 않았는데 사라졌다면
-    // admin 강제 해제로 분류. trackDjAdminDeregisterDetected 내부에서 직전
-    // self mutation 의 suppression 윈도우를 확인.
+    // self 가 큐에서 빠졌는지 검출 — changeType별로 분기하여
+    // alert 안내 및 tracking 처리.
     const prev = queryClient.getQueryData<DjingQueue>(queryKey);
     const myCrewId = useCurrentPartyroom.getState().me?.crewId;
     if (prev && myCrewId !== undefined) {
       const wasInQueue = prev.djs.some((d) => d.crewId === myCrewId);
       const stillInQueue = event.djs.some((d) => d.crewId === myCrewId);
       if (wasInQueue && !stillInQueue) {
-        trackDjAdminDeregisterDetected(event.partyroomId);
+        const ct = event.changeType;
+        if (ct === 'DEQUEUE_EXIT') {
+          // 본인 이탈 → silent
+        } else if (ct === 'DEACTIVATE') {
+          alert.notify({
+            type: 'dj-deactivated',
+            playbackTimeLimitMinutes: event.playbackTimeLimitMinutes ?? null,
+          });
+          trackDjAdminDeregisterDetected(event.partyroomId, ct);
+        } else if (ct === 'DEQUEUE_ADMIN') {
+          alert.notify({ type: 'dj-admin-removed' });
+          trackDjAdminDeregisterDetected(event.partyroomId, ct);
+        } else {
+          trackDjAdminDeregisterDetected(event.partyroomId, ct); // 구 메시지 등 → 분류만(안내 없음)
+        }
       }
     }
 

--- a/src/shared/api/websocket/types/partyroom.ts
+++ b/src/shared/api/websocket/types/partyroom.ts
@@ -168,6 +168,15 @@ export type CrewProfileChangedEvent = WebSocketEventBase & {
   avatar: CrewAvatar;
 };
 
+/** DJ 큐 변경 사유 */
+export type DjChangeType =
+  | 'ENQUEUE'
+  | 'DEQUEUE'
+  | 'DEQUEUE_ADMIN'
+  | 'DEQUEUE_EXIT'
+  | 'ROTATE'
+  | 'DEACTIVATE';
+
 /** DJ 큐 변경 이벤트 */
 export type DjQueueChangedEvent = WebSocketEventBase & {
   eventType: PartyroomEventType.DJ_QUEUE_CHANGED;
@@ -177,6 +186,8 @@ export type DjQueueChangedEvent = WebSocketEventBase & {
     nickname: string;
     avatarIconUri: string;
   }>;
+  changeType?: DjChangeType;
+  playbackTimeLimitMinutes?: number | null;
 };
 
 // ──────────────────────────────────────────────

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -6,7 +6,7 @@ export type AuthorityTierLabel = `${AuthorityTier}`;
 export type OAuthProviderLabel = OAuth2Provider;
 export type ReactionTypeLabel = 'like' | 'dislike' | 'grab';
 export type TrackSource = 'search' | 'grab';
-export type DjDeregisterReason = 'self' | 'admin';
+export type DjDeregisterReason = 'self' | 'admin' | 'deactivated';
 export type StageTypeLabel = 'main' | 'general';
 export type EntrySource = 'list' | 'link' | 'direct';
 

--- a/src/shared/lib/analytics/room-tracking.test.ts
+++ b/src/shared/lib/analytics/room-tracking.test.ts
@@ -1,6 +1,7 @@
 import * as amplitude from '@amplitude/analytics-browser';
 
 import { StageType } from '@/shared/api/http/types/@enums';
+import type { DjChangeType } from '@/shared/api/websocket/types/partyroom';
 
 import { __preloadSdkForTests, __resetForTests } from './index';
 import {
@@ -205,6 +206,40 @@ describe('room-tracking', () => {
         reason: 'admin',
       });
       vi.useRealTimers();
+    });
+
+    describe('changeType 기반 reason 매핑', () => {
+      test('DEQUEUE_ADMIN → reason: admin', () => {
+        const changeType: DjChangeType = 'DEQUEUE_ADMIN';
+        trackDjAdminDeregisterDetected(42, changeType);
+        expect(amplitude.track).toHaveBeenCalledWith('DJ Deregistered', {
+          partyroom_id: 42,
+          reason: 'admin',
+        });
+      });
+
+      test('DEACTIVATE → reason: deactivated', () => {
+        const changeType: DjChangeType = 'DEACTIVATE';
+        trackDjAdminDeregisterDetected(42, changeType);
+        expect(amplitude.track).toHaveBeenCalledWith('DJ Deregistered', {
+          partyroom_id: 42,
+          reason: 'deactivated',
+        });
+      });
+
+      test('인자 없음 (legacy) → reason: admin', () => {
+        trackDjAdminDeregisterDetected(42);
+        expect(amplitude.track).toHaveBeenCalledWith('DJ Deregistered', {
+          partyroom_id: 42,
+          reason: 'admin',
+        });
+      });
+
+      test('suppression 이 changeType=DEACTIVATE 도 차단함', () => {
+        suppressNextSelfDjDeregister(5000);
+        trackDjAdminDeregisterDetected(42, 'DEACTIVATE');
+        expect(amplitude.track).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/shared/lib/analytics/room-tracking.ts
+++ b/src/shared/lib/analytics/room-tracking.ts
@@ -1,4 +1,5 @@
 import type { StageType } from '@/shared/api/http/types/@enums';
+import type { DjChangeType } from '@/shared/api/websocket/types/partyroom';
 
 import type { EntrySource } from './events';
 import { identify, track } from './index';
@@ -115,11 +116,23 @@ function consumeSelfDjDeregisterSuppression(now: number = Date.now()): boolean {
   return false;
 }
 
-export function trackDjAdminDeregisterDetected(partyroomId: number): void {
+/**
+ * DJ 강제 해제 이벤트를 추적한다.
+ *
+ * changeType 에 따라 reason 을 결정한다:
+ *  - `'DEACTIVATE'` → `'deactivated'` (DJ 비활성화에 의한 자동 해제)
+ *  - 그 외 / 미지정  → `'admin'` (관리자 강제 해제 또는 알 수 없음)
+ *
+ * suppression 이 활성화되어 있으면 self-removal 중복 방지를 위해 즉시 반환한다.
+ */
+export function trackDjAdminDeregisterDetected(
+  partyroomId: number,
+  changeType?: DjChangeType
+): void {
   if (consumeSelfDjDeregisterSuppression()) return;
   track('DJ Deregistered', {
     partyroom_id: partyroomId,
-    reason: 'admin',
+    reason: changeType === 'DEACTIVATE' ? 'deactivated' : 'admin',
   });
 }
 

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -227,6 +227,8 @@
       "delete_dj_queue": "Remove from DJ Queue",
       "write_reason": "Please provide a reason (at least 2 characters)",
       "deleted_queue_by_admin": "You have been removed from the queue by the administrator",
+      "playback_stopped_time_limit": "Playback stopped: a track exceeds this room's time limit ({{minutes}} min).",
+      "playback_stopped_no_limit": "Playback stopped: no playable track.",
       "locked_queue_by_admin": "The current DJ queue is locked by an admin",
       "skipped_song_by_admin": "According to the admin policy, songs longer than {{count}} minutes will be automatically skipped",
       "dj_in_order": "DJing **one person at a time** \n from the waiting list, in order",

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -227,6 +227,8 @@
       "delete_dj_queue": "DJ 대기열에서 삭제합니다",
       "write_reason": "사유를 작성해주세요(최소 2자)",
       "deleted_queue_by_admin": "관리자에 의해 대기열에서 삭제되었습니다",
+      "playback_stopped_time_limit": "재생 시간 제한({{minutes}}분)을 초과하는 곡으로 재생이 중단되었습니다",
+      "playback_stopped_no_limit": "재생 가능한 곡이 없어 재생이 중단되었습니다",
       "locked_queue_by_admin": "관리자에 의해 현재 DJ 대기열이 잠금 상태예요",
       "skipped_song_by_admin": "어드민 정책에 따라 {{count}}분 이상의 곡은 자동으로 스킵됩니다",
       "dj_in_order": "대기 중인 DJ **한명씩**\n **순서대로** 음악을 디제잉 합니다",


### PR DESCRIPTION
## 배경 (E/#3 시리즈 PR-3/4)

PR-1(platform #238)·PR-2(platform #240, dj-queue-changed 에 `changeType`+DEACTIVATE `playbackTimeLimitMinutes` additive) develop 머지 완료. 노트 UX 갭: 큐에서 빠지는 사용자가 "왜 빠졌는지" 안내 없음. PR-3 = **web UX**: PR-2 contract 소비해 self-removed 시 changeType별 안내. (PR-4=반응형 배지, 별 PR.)

## 변경 (canonical alert.notify 확장, additive)

- 타입(additive): `DjChangeType` union + `DjQueueChangedEvent` optional `changeType?`/`playbackTimeLimitMinutes?`; `AlertMessage.Model` += `DjRemovedAlertMessage`(`dj-deactivated`{limit}|`dj-admin-removed`) + `isDjRemovedAlertMessage`.
- `use-dj-queue-changed-callback`: self-removed 분기 — **DEACTIVATE**→`alert.notify(dj-deactivated, limit ?? null)` / **DEQUEUE_ADMIN**→`alert.notify(dj-admin-removed)` / **DEQUEUE_EXIT**→silent / 구메시지·미지→track-only(안내 無, backward-compat).
- 신규 `useDjRemovedAlert` 훅(grade-hook 패턴 그대로, `useDialog().openAlertDialog`) → `use-alerts.hook` 에 등록(penalty/grade 와 동일 집계, `parties/(room)/[id]/page` 마운트 확인). DEACTIVATE: `playbackTimeLimit`>0 → "재생 시간 제한({{minutes}}분) 초과로 중단", 0/null/부재 → "재생 가능한 곡이 없어 중단"(graceful, unlimited 대응). admin → 기존 `dj.para.deleted_queue_by_admin` **재사용**.
- analytics: `trackDjAdminDeregisterDetected(pid, changeType?)` reason `DEACTIVATE→'deactivated'` else `'admin'`(무인자 호환). `DjDeregisterReason` += `'deactivated'`(additive).
- i18n: `dj.para.playback_stopped_time_limit`/`playback_stopped_no_limit` ko/en 직접 추가(`{{minutes}}`, yarn i18n 미사용, 양국어 parity). `use-playback-deactivated-callback` **무변경**(state-reset 유지·모달 단일출처).

## 검증

- 전 vitest **1262/1262** GREEN(230 files) · `tsc --noEmit` 0 · scoped eslint 0. 신규/확장 단위: alert-message guard, room-tracking reason, dj-queue-changed 분기(14), useDjRemovedAlert(5). 기존 회귀 보존(legacy 2-arg·penalty/grade guard·suppression).
- plan/spec 리뷰(2회) + 태스크별 spec(+substantive 2단) 리뷰 + 최종 종합 ✅. additive·backward-compat(미지 changeType/필드부재 무동작). 스코프=web UX only(PR-4 배지·PR-1/2·playback-deactivated 무변경).

Refs E/#3 (Cluster E). 시리즈: PR-1 #238·PR-2 #240(merged) → **PR-3(본 PR)** → PR-4(반응형 배지). 후속 advisory: useDjRemovedAlert 테스트에 title assertion 보강(소형, 비차단).