### PR TITLE
feat(E/#3): 플레이리스트 over-limit 트랙 반응형 배지 (시리즈 마지막)

### DIFF
--- a/docs/superpowers/plans/2026-05-19-e3-pr4-overlimit-badge.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr4-overlimit-badge.md
@@ -32,9 +32,10 @@
 
 - [ ] **Step 1: 실패 테스트** `parse-duration.test.ts`:
 
-  - `'3:45'` → 225, `'0:00'` → 0, `'1:02:03'` → 3723, `'12:34'` → 754.
-  - 무효: `''`, `'abc'`, `'1:2:3:4'`, `undefined as any`, `'1:60'`(분/초 비정상은 허용 or null — **정책: 숫자 파싱 가능하면 산술 그대로**(`1:60`→120) `parseInt` 기반, 토큰 비숫자/빈 → `null`). null 케이스: `'abc'`,`''`,`'1:'`(빈 토큰 NaN)→`null`.
-  - (테스트는 위 계약을 명시 assert.)
+  - 유효: `'3:45'` → 225, `'0:00'` → 0, `'1:02:03'` → 3723, `'12:34'` → 754, `'1:60'` → 120.
+  - null: `''`, `'abc'`, `'1:2:3:4'`, `'1:'`, `undefined as any` → `null`.
+  - **계약(Step 3 구현과 정확히 일치):** `:` 로 split 한 각 토큰이 `/^\d+$/`(음수·소수·빈 토큰 불가, 비음 정수만) 통과해야 함. 토큰 개수 2 또는 3 만 허용(그 외 `null`). 값은 positional base-60 누적(`acc*60+n`)이라 분/초 범위 검증 없음 → `'1:60'`=120. `parseInt`/범위검증/NaN 토큰 같은 메커니즘 표현 쓰지 말 것 — 위 정수·개수 규칙이 전부.
+  - (테스트는 위 유효/`null` 값들을 그대로 assert.)
 
 - [ ] **Step 2: 실패 확인** — `yarn vitest run src/features/playlist/list-tracks/lib/parse-duration.test.ts` → FAIL(모듈 없음).
 
@@ -51,7 +52,7 @@
   }
   ```
 - [ ] **Step 4: 통과** — Step2 cmd → PASS. `yarn tsc --noEmit` 0.
-- [ ] **Step 5: i18n** — `en.json` 먼저 → `ko.json` 동일 키. `dj.para` 섹션(기존 playback*stopped*\* 인근):
+- [ ] **Step 5: i18n** — `en.json` 먼저 → `ko.json` 동일 키. `dj.para` 섹션의 `playback_stopped_no_limit` **바로 옆**에 삽입(E/#3 키 클러스터·parity 육안검증 용이):
   - `dj.para.not_playable_in_room` en: `"Not playable here (exceeds this room's time limit)"` ko: `"이 방에선 재생 안 돼요 (재생 시간 제한 초과)"`
     (변수 없음. JSON 스타일/순서 sibling 일치. parity 확인.)
 - [ ] **Step 6: 커밋** — `git add` parse-duration(.ts/.test.ts) en.json ko.json → `git commit -m "feat(E/#3): parseDurationToSeconds 유틸 + not_playable_in_room i18n(ko/en)"`
@@ -65,13 +66,13 @@
 - [ ] **Step 1: 실패/회귀 테스트**
 
   - `Track`: prop `isOverRoomLimit=true` → `t.dj.para.not_playable_in_room` 텍스트(배지) 렌더 + 디밍 class 적용; `false`/미전달 → 배지 없음, 기존 렌더(name/duration/menu/DnD) 무변경. (mock `useI18n` 기존 컴포넌트 테스트 패턴.)
-  - `TracksInPlaylist`: `useFetchPartyroomDetailSummary` mock 으로 `playbackTimeLimit=5`(분), 트랙들 duration 문자열 — `'6:00'`(>5분)→ 그 Track 에 `isOverRoomLimit=true`, `'3:00'`→false; summary 없음/limit 0/파싱 불가 → 전부 false(비차단·fail-safe); partyroomId 없을 때 query `enabled=false` → 배지 없음. (route param mock 은 `main-panel` 테스트나 기존 라우트 mock 패턴 따름.)
+  - `TracksInPlaylist`: `useFetchPartyroomDetailSummary` mock 으로 `playbackTimeLimit=5`(분), 트랙들 duration 문자열 — `'6:00'`(>5분)→ 그 Track 에 `isOverRoomLimit=true`, `'3:00'`→false; summary 없음/limit 0/파싱 불가 → 전부 false(비차단·fail-safe); partyroomId 없을 때(로비) query `enabled=false` → 배지 없음. (RTL+`useI18n` mock·route param mock 은 in-repo 실존 테스트 `src/app/parties/playlist-action.provider.test.tsx` 또는 `src/app/parties/(room)/[id]/layout.test.tsx` 의 컨벤션을 그대로 미러 — 새 컨벤션 발명 금지.)
 
 - [ ] **Step 2: 실패 확인** — `yarn vitest run src/features/playlist/list-tracks` → FAIL.
 
 - [ ] **Step 3: 구현**
 
-  - `tracks.component.tsx`: 현재 방 id 취득 — `main-panel.component.tsx` 와 동일 패턴(`useParams`→`Number(params.id)`; import 위치/방식 그 파일 참조). `const { data: summary } = useFetchPartyroomDetailSummary(partyroomId, !!partyroomId);` `const limitMin = summary?.playbackTimeLimit ?? 0;` 각 트랙 렌더 시 `const sec = parseDurationToSeconds(track.duration); const isOverRoomLimit = limitMin > 0 && sec !== null && sec > limitMin * 60;` → `<Track ... isOverRoomLimit={isOverRoomLimit} />`. (DnD/SortableContext/items/menuItems 로직 무변경 — prop 1개 추가만.)
+  - `tracks.component.tsx`: 현재 방 id 취득 — `main-panel.component.tsx` 와 동일 패턴(`useParams<{id:string}>()`→`Number(params.id)`). **주의:** `TracksInPlaylist`(MyPlaylist) 는 `src/app/parties/layout.tsx` 아래 마운트되어 **로비+방 양쪽**에서 렌더됨 — 로비에선 `[id]` 세그먼트 없어 `params.id===undefined`→`Number(undefined)=NaN`→`!!NaN=false`→`enabled:false`→배지 없음. 이는 **정상 동작**(로비 무배지를 버그로 오인해 "고치지" 말 것). `useFetchPartyroomDetailSummary` 는 **배럴** `@/features/partyroom/get-summary` 에서 import(`main-panel` 과 동일, deep path 금지). `const { data: summary } = useFetchPartyroomDetailSummary(partyroomId, !!partyroomId);` `const limitMin = summary?.playbackTimeLimit ?? 0;` 각 트랙 렌더 시 `const sec = parseDurationToSeconds(track.duration); const isOverRoomLimit = limitMin > 0 && sec !== null && sec > limitMin * 60;` → `<Track ... isOverRoomLimit={isOverRoomLimit} />`. (DnD/SortableContext/items/menuItems 로직 무변경 — prop 1개 추가만.)
   - `track.component.tsx`: `TrackProps` 에 `isOverRoomLimit?: boolean` 추가. true 시: duration Typography 인근(또는 트랙 행)에 작은 배지 — 기존 `Typography`(type='caption1') + `cn` 으로 경고색/디밍(예: 트랙 행 `opacity-50` + duration 옆 `t.dj.para.not_playable_in_room` 작은 텍스트). 신규 UI 컴포넌트 발명 금지 — 기존 Typography/색 토큰/cn 재사용. `useI18n()` 추가(컴포넌트 'use client'). 기존 thumbnail/menu/DnD/attributes **무변경**.
 
 - [ ] **Step 4: 통과 + 전 회귀** — Step2 cmd PASS. `yarn vitest run` 전체 GREEN. `yarn tsc --noEmit` 0. `yarn eslint src/features/playlist/list-tracks src/shared/lib/localization --quiet` 0 error.

--- a/docs/superpowers/plans/2026-05-19-e3-pr4-overlimit-badge.md
+++ b/docs/superpowers/plans/2026-05-19-e3-pr4-overlimit-badge.md
@@ -1,0 +1,92 @@
+# E/#3 PR-4 — 플레이리스트 over-limit 반응형 배지 (web, 마지막) 구현 계획
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development. Checkbox(`- [ ]`) steps.
+
+**Goal:** 플레이리스트 트랙 UI 에서 트랙 길이가 **현재 방 `playbackTimeLimit`** 초과면 "이 방에선 재생 안 됨" 배지/디밍 표시. 방 limit 기준 **반응형**(react-query), **비차단**(추가/메뉴 동작 무변경). over-limit 곡이 조용히 안 나오던 잔여 UX 갭(E/#3) 해소. E/#3 시리즈 **마지막 PR**.
+
+**Architecture:** 신규 데이터 플럼 발명 금지 — 기존 `useFetchPartyroomDetailSummary(partyroomId, enabled)`(→ `PartyroomDetailSummary.playbackTimeLimit: number`, **분 단위**) 재사용(이미 `widgets/partyroom-detail/main-panel` 에서 `Number(params.id)` 로 사용; react-query 캐시 `[QueryKeys.PartyroomDetailSummary, id]` 로 dedupe·반응형). `PlaylistTrack.duration` 은 표시 **문자열**("[H:]M:SS") — 숫자 필드 없음 → 관용 파서로 초 변환(파싱 실패=배지 없음, fail-safe). 비교: `durationSec > limitMin*60`. `TracksInPlaylist`(리스트)가 limit 1회 계산→`Track` 에 파생 `isOverRoomLimit:boolean` prop 전달(트랙별 쿼리 N회 회피).
+
+**Tech Stack:** Next.js/TS, react-query, vitest, i18n(`useI18n()` 타입 dict, ko/en json 직접·`yarn i18n` 금지). pfplay-web 2-tier `development`=stg.
+
+**Spec:** `pfplay-platform/docs/superpowers/specs/2026-05-19-e3-track-skip-deactivate-cascade-design.md` §3-4. **Scope:** PR-4=web 배지 only. PR-1/2/3 코드 무변경. 트랙 추가 차단/검증 **안 함**(비차단).
+
+---
+
+## File Structure
+
+- `src/features/playlist/list-tracks/lib/parse-duration.ts` — 신규 `parseDurationToSeconds(duration:string): number | null` (관용 split, 실패 null).
+- `src/features/playlist/list-tracks/ui/tracks.component.tsx` — 현재 방 partyroomId(route)·`useFetchPartyroomDetailSummary` 로 limitMin 취득, `Track` 에 `isOverRoomLimit` 전달.
+- `src/features/playlist/list-tracks/ui/track.component.tsx` — `isOverRoomLimit` prop, true 시 배지/디밍 렌더(비차단·기존 메뉴/DnD 무변경).
+- `src/shared/lib/localization/dictionaries/{en,ko}.json` — `dj.para.not_playable_in_room` (en 먼저=Dictionary 타입, ko 미러, parity).
+- 테스트: `parse-duration.test.ts`(신규), `track.component.test.tsx`/`tracks.component.test.tsx`(있으면 확장, 없으면 신설; 기존 컴포넌트 테스트 컨벤션).
+
+---
+
+## Chunk 1: over-limit 반응형 배지
+
+### Task 1: duration 파서 + i18n 키
+
+**Files:** Create `src/features/playlist/list-tracks/lib/parse-duration.ts` + `parse-duration.test.ts`; Modify `dictionaries/en.json` 먼저 → `ko.json`.
+
+기존 참고: `src/features/playlist/add-tracks/ui/search-list-item.component.tsx:43` `formatDuration(duration)` 가 `duration.split(':')` (times 배열) 패턴 사용 — 동일 split 관용 채택.
+
+- [ ] **Step 1: 실패 테스트** `parse-duration.test.ts`:
+
+  - `'3:45'` → 225, `'0:00'` → 0, `'1:02:03'` → 3723, `'12:34'` → 754.
+  - 무효: `''`, `'abc'`, `'1:2:3:4'`, `undefined as any`, `'1:60'`(분/초 비정상은 허용 or null — **정책: 숫자 파싱 가능하면 산술 그대로**(`1:60`→120) `parseInt` 기반, 토큰 비숫자/빈 → `null`). null 케이스: `'abc'`,`''`,`'1:'`(빈 토큰 NaN)→`null`.
+  - (테스트는 위 계약을 명시 assert.)
+
+- [ ] **Step 2: 실패 확인** — `yarn vitest run src/features/playlist/list-tracks/lib/parse-duration.test.ts` → FAIL(모듈 없음).
+
+- [ ] **Step 3: 구현** `parse-duration.ts`:
+  ```ts
+  /** "[H:]M:SS" 표시 문자열 → 총 초. 토큰이 비숫자/빈값이거나 형식 불명이면 null(배지 미표시 fail-safe). */
+  export function parseDurationToSeconds(duration: string): number | null {
+    if (typeof duration !== 'string') return null;
+    const parts = duration.trim().split(':');
+    if (parts.length < 2 || parts.length > 3) return null;
+    const nums = parts.map((p) => (/^\d+$/.test(p.trim()) ? Number(p.trim()) : NaN));
+    if (nums.some((n) => Number.isNaN(n))) return null;
+    return nums.reduce((acc, n) => acc * 60 + n, 0);
+  }
+  ```
+- [ ] **Step 4: 통과** — Step2 cmd → PASS. `yarn tsc --noEmit` 0.
+- [ ] **Step 5: i18n** — `en.json` 먼저 → `ko.json` 동일 키. `dj.para` 섹션(기존 playback*stopped*\* 인근):
+  - `dj.para.not_playable_in_room` en: `"Not playable here (exceeds this room's time limit)"` ko: `"이 방에선 재생 안 돼요 (재생 시간 제한 초과)"`
+    (변수 없음. JSON 스타일/순서 sibling 일치. parity 확인.)
+- [ ] **Step 6: 커밋** — `git add` parse-duration(.ts/.test.ts) en.json ko.json → `git commit -m "feat(E/#3): parseDurationToSeconds 유틸 + not_playable_in_room i18n(ko/en)"`
+
+---
+
+### Task 2: TracksInPlaylist 가 방 limit 계산 → Track 배지
+
+**Files:** Modify `tracks.component.tsx`, `track.component.tsx`; Test: `track.component.test.tsx`/`tracks.component.test.tsx`(기존 있으면 확장, 없으면 신설 — 기존 RTL/vitest 컴포넌트 테스트 컨벤션 따름).
+
+- [ ] **Step 1: 실패/회귀 테스트**
+
+  - `Track`: prop `isOverRoomLimit=true` → `t.dj.para.not_playable_in_room` 텍스트(배지) 렌더 + 디밍 class 적용; `false`/미전달 → 배지 없음, 기존 렌더(name/duration/menu/DnD) 무변경. (mock `useI18n` 기존 컴포넌트 테스트 패턴.)
+  - `TracksInPlaylist`: `useFetchPartyroomDetailSummary` mock 으로 `playbackTimeLimit=5`(분), 트랙들 duration 문자열 — `'6:00'`(>5분)→ 그 Track 에 `isOverRoomLimit=true`, `'3:00'`→false; summary 없음/limit 0/파싱 불가 → 전부 false(비차단·fail-safe); partyroomId 없을 때 query `enabled=false` → 배지 없음. (route param mock 은 `main-panel` 테스트나 기존 라우트 mock 패턴 따름.)
+
+- [ ] **Step 2: 실패 확인** — `yarn vitest run src/features/playlist/list-tracks` → FAIL.
+
+- [ ] **Step 3: 구현**
+
+  - `tracks.component.tsx`: 현재 방 id 취득 — `main-panel.component.tsx` 와 동일 패턴(`useParams`→`Number(params.id)`; import 위치/방식 그 파일 참조). `const { data: summary } = useFetchPartyroomDetailSummary(partyroomId, !!partyroomId);` `const limitMin = summary?.playbackTimeLimit ?? 0;` 각 트랙 렌더 시 `const sec = parseDurationToSeconds(track.duration); const isOverRoomLimit = limitMin > 0 && sec !== null && sec > limitMin * 60;` → `<Track ... isOverRoomLimit={isOverRoomLimit} />`. (DnD/SortableContext/items/menuItems 로직 무변경 — prop 1개 추가만.)
+  - `track.component.tsx`: `TrackProps` 에 `isOverRoomLimit?: boolean` 추가. true 시: duration Typography 인근(또는 트랙 행)에 작은 배지 — 기존 `Typography`(type='caption1') + `cn` 으로 경고색/디밍(예: 트랙 행 `opacity-50` + duration 옆 `t.dj.para.not_playable_in_room` 작은 텍스트). 신규 UI 컴포넌트 발명 금지 — 기존 Typography/색 토큰/cn 재사용. `useI18n()` 추가(컴포넌트 'use client'). 기존 thumbnail/menu/DnD/attributes **무변경**.
+
+- [ ] **Step 4: 통과 + 전 회귀** — Step2 cmd PASS. `yarn vitest run` 전체 GREEN. `yarn tsc --noEmit` 0. `yarn eslint src/features/playlist/list-tracks src/shared/lib/localization --quiet` 0 error.
+- [ ] **Step 5: 커밋** — `git add` tracks/track(.tsx/.test) → `git commit -m "feat(E/#3): 플레이리스트 트랙 over-limit 반응형 배지 (방 limit 기준·비차단)"`
+
+---
+
+### Task 3: 전 회귀 + scope 확인
+
+- [ ] **Step 1:** `yarn vitest run` 전체 GREEN · `yarn tsc --noEmit` 0 · `yarn eslint src/features/playlist src/shared/lib/localization --quiet` 0 error.
+- [ ] **Step 2:** `git diff origin/development..HEAD --stat` — 변경 = parse-duration(.ts/.test), tracks/track(.tsx/+test), en/ko json, plan 만. PR-1/2/3 코드·alert·dj-queue-changed·partyroom summary 쿼리 자체·트랙 추가/메뉴 로직 **무변경**. `git log --oneline origin/develop..HEAD`(=development).
+
+---
+
+## 완료 정의 (DoD)
+
+- 방 안에서 트랙 duration > 방 playbackTimeLimit(분)→ "이 방에선 재생 안 돼요" 배지+디밍. 방/limit/파싱 불가 시 배지 없음(비차단·fail-safe). 추가/메뉴/DnD 동작 무변경. react-query 기반 반응형(limit 변경 시 갱신).
+- 신규 파서 단위테스트 + 컴포넌트 테스트 GREEN, 전 vitest·tsc 0·scoped eslint 0. i18n ko/en parity(yarn i18n 미사용). 스코프=web 배지 only. **E/#3 시리즈 완결**(PR-1·IT#239·PR-2·PR-3 머지됨; 본 PR 머지 후 로드맵 LIVE·메모리 E/#3 종결 갱신).

--- a/src/features/playlist/list-tracks/lib/parse-duration.test.ts
+++ b/src/features/playlist/list-tracks/lib/parse-duration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDurationToSeconds } from './parse-duration';
+
+describe('parseDurationToSeconds', () => {
+  it('parses valid colon-separated durations to total seconds', () => {
+    expect(parseDurationToSeconds('3:45')).toBe(225);
+    expect(parseDurationToSeconds('0:00')).toBe(0);
+    expect(parseDurationToSeconds('1:02:03')).toBe(3723);
+    expect(parseDurationToSeconds('12:34')).toBe(754);
+    expect(parseDurationToSeconds('1:60')).toBe(120);
+  });
+
+  it('returns null for malformed or non-string input', () => {
+    expect(parseDurationToSeconds('')).toBeNull();
+    expect(parseDurationToSeconds('abc')).toBeNull();
+    expect(parseDurationToSeconds('1:2:3:4')).toBeNull();
+    expect(parseDurationToSeconds('1:')).toBeNull();
+    expect(parseDurationToSeconds(undefined as any)).toBeNull();
+  });
+});

--- a/src/features/playlist/list-tracks/lib/parse-duration.ts
+++ b/src/features/playlist/list-tracks/lib/parse-duration.ts
@@ -1,0 +1,9 @@
+/** "[H:]M:SS" 표시 문자열 → 총 초. 토큰이 비숫자/빈값이거나 형식 불명이면 null(배지 미표시 fail-safe). */
+export function parseDurationToSeconds(duration: string): number | null {
+  if (typeof duration !== 'string') return null;
+  const parts = duration.trim().split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+  const nums = parts.map((p) => (/^\d+$/.test(p.trim()) ? Number(p.trim()) : NaN));
+  if (nums.some((n) => Number.isNaN(n))) return null;
+  return nums.reduce((acc, n) => acc * 60 + n, 0);
+}

--- a/src/features/playlist/list-tracks/ui/track.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.test.tsx
@@ -1,0 +1,67 @@
+vi.mock('@/shared/lib/localization/i18n.context');
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: { 'data-dnd': 'attr' },
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+  }),
+}));
+vi.mock('@/entities/music-preview', () => ({
+  convertPlaylistTrackToPreview: (t: unknown) => t,
+}));
+vi.mock('@/entities/music-preview/index.ui', () => ({
+  ThumbnailWithPreview: () => <div data-testid='thumb' />,
+}));
+vi.mock('@/shared/ui/components/icon-menu', () => ({
+  IconMenu: () => <div data-testid='icon-menu' />,
+}));
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PlaylistTrack } from '@/shared/api/http/types/playlists';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import Track from './track.component';
+
+const NOT_PLAYABLE = 'Not playable here (exceeds this room limit)';
+
+const track = {
+  linkId: 'l1',
+  trackId: 1,
+  name: 'My Song',
+  duration: '6:00',
+  thumbnailImage: null,
+} as unknown as PlaylistTrack;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useI18n as Mock).mockReturnValue({
+    dj: { para: { not_playable_in_room: NOT_PLAYABLE } },
+  });
+});
+
+describe('Track over-limit 배지', () => {
+  test('isOverRoomLimit=true 면 not_playable 배지 텍스트를 렌더하고 행을 dim 처리한다', () => {
+    const { container } = render(<Track track={track} menuItems={[]} isOverRoomLimit={true} />);
+
+    expect(screen.getByText(NOT_PLAYABLE)).toBeInTheDocument();
+    expect(container.querySelector('.opacity-50')).not.toBeNull();
+  });
+
+  test('isOverRoomLimit=false 면 배지 텍스트가 없고 dim 처리하지 않는다', () => {
+    const { container } = render(<Track track={track} menuItems={[]} isOverRoomLimit={false} />);
+
+    expect(screen.queryByText(NOT_PLAYABLE)).not.toBeInTheDocument();
+    expect(container.querySelector('.opacity-50')).toBeNull();
+  });
+
+  test('isOverRoomLimit 생략 시 기존 렌더(트랙명/재생시간/DnD attr) 유지', () => {
+    const { container } = render(<Track track={track} menuItems={[]} />);
+
+    expect(screen.queryByText(NOT_PLAYABLE)).not.toBeInTheDocument();
+    expect(screen.getByText('My Song')).toBeInTheDocument();
+    expect(screen.getByText('6:00')).toBeInTheDocument();
+    expect(container.querySelector('[data-dnd="attr"]')).not.toBeNull();
+  });
+});

--- a/src/features/playlist/list-tracks/ui/track.component.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.tsx
@@ -5,6 +5,7 @@ import { convertPlaylistTrackToPreview } from '@/entities/music-preview';
 import { ThumbnailWithPreview } from '@/entities/music-preview/index.ui';
 import { PlaylistTrack } from '@/shared/api/http/types/playlists';
 import { cn } from '@/shared/lib/functions/cn';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { IconMenu } from '@/shared/ui/components/icon-menu';
 import { MenuItem } from '@/shared/ui/components/menu';
 import { Typography } from '@/shared/ui/components/typography';
@@ -13,9 +14,11 @@ import { PFDragAndDrop, PFMoreVert } from '@/shared/ui/icons';
 type TrackProps = {
   track: PlaylistTrack;
   menuItems: MenuItem[];
+  isOverRoomLimit?: boolean;
 };
 
-const Track = ({ track, menuItems }: TrackProps) => {
+const Track = ({ track, menuItems, isOverRoomLimit = false }: TrackProps) => {
+  const t = useI18n();
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: track.linkId,
   });
@@ -31,7 +34,10 @@ const Track = ({ track, menuItems }: TrackProps) => {
   return (
     <div
       ref={setNodeRef}
-      className='relative grid grid-cols-[24px_1fr_32px] items-center gap-2 cursor-default'
+      className={cn(
+        'relative grid grid-cols-[24px_1fr_32px] items-center gap-2 cursor-default',
+        isOverRoomLimit && 'opacity-50'
+      )}
       style={style}
       {...attributes}
     >
@@ -60,6 +66,11 @@ const Track = ({ track, menuItems }: TrackProps) => {
           <Typography type='caption1' className='text-gray-400'>
             {track.duration}
           </Typography>
+          {isOverRoomLimit && (
+            <Typography type='caption1' overflow='ellipsis' className='text-red-300'>
+              {t.dj.para.not_playable_in_room}
+            </Typography>
+          )}
         </div>
       </div>
 

--- a/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
@@ -82,6 +82,15 @@ describe('TracksInPlaylist over-limit 계산', () => {
     expect(under?.isOverRoomLimit).toBe(false);
   });
 
+  test('limit 5분: 정확히 5:00 트랙은 isOverRoomLimit=false (strict > 경계값)', () => {
+    setTracks([makeTrack('t1', '5:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    const exact = lastTrackProps.find((p) => p.duration === '5:00');
+    expect(exact?.isOverRoomLimit).toBe(false);
+  });
+
   test('summary undefined 면 모든 트랙 false (fail-safe)', () => {
     setSummary(undefined);
     setTracks([makeTrack('t1', '6:00')]);

--- a/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
@@ -1,0 +1,131 @@
+let paramsValue: { id?: string } = { id: '7' };
+
+vi.mock('next/navigation', () => ({
+  useParams: () => paramsValue,
+}));
+vi.mock('@/shared/lib/localization/i18n.context');
+vi.mock('@/features/partyroom/get-summary', () => ({
+  useFetchPartyroomDetailSummary: vi.fn(),
+}));
+vi.mock('@/entities/playlist', () => ({
+  usePlaylistAction: () => ({
+    removeTrack: vi.fn(),
+    moveTrack: vi.fn(),
+    changeTrackOrder: vi.fn(),
+  }),
+}));
+vi.mock('../api/use-fetch-playlist-tracks.query', () => ({
+  useFetchPlaylistTracks: vi.fn(),
+}));
+
+let lastTrackProps: Array<{ duration: string; isOverRoomLimit?: boolean }> = [];
+vi.mock('./track.component', () => ({
+  default: (props: { track: { duration: string }; isOverRoomLimit?: boolean }) => {
+    lastTrackProps.push({
+      duration: props.track.duration,
+      isOverRoomLimit: props.isOverRoomLimit,
+    });
+    return <div data-testid='track' />;
+  },
+}));
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useFetchPartyroomDetailSummary } from '@/features/partyroom/get-summary';
+import { Playlist, PlaylistTrack } from '@/shared/api/http/types/playlists';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import TracksInPlaylist from './tracks.component';
+import { useFetchPlaylistTracks } from '../api/use-fetch-playlist-tracks.query';
+
+const playlist = { id: 1 } as Playlist;
+
+function makeTrack(linkId: string, duration: string): PlaylistTrack {
+  return {
+    linkId,
+    trackId: Number(linkId.replace(/\D/g, '')) || 1,
+    name: `track-${linkId}`,
+    duration,
+    thumbnailImage: null,
+  } as unknown as PlaylistTrack;
+}
+
+function setTracks(tracks: PlaylistTrack[]) {
+  (useFetchPlaylistTracks as Mock).mockReturnValue({ data: { content: tracks } });
+}
+
+function setSummary(summary: unknown) {
+  // 실제 react-query 처럼 enabled=false 면 data 미해소(undefined)
+  (useFetchPartyroomDetailSummary as Mock).mockImplementation((_id: number, enabled: boolean) => ({
+    data: enabled ? summary : undefined,
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lastTrackProps = [];
+  paramsValue = { id: '7' };
+  (useI18n as Mock).mockReturnValue({
+    playlist: { btn: { delete_playlist: 'd', move_playlist: 'm' } },
+  });
+  setSummary({ playbackTimeLimit: 5 });
+});
+
+describe('TracksInPlaylist over-limit 계산', () => {
+  test('limit 5분: 6:00 트랙은 isOverRoomLimit=true, 3:00 트랙은 false', () => {
+    setTracks([makeTrack('t1', '6:00'), makeTrack('t2', '3:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    const over = lastTrackProps.find((p) => p.duration === '6:00');
+    const under = lastTrackProps.find((p) => p.duration === '3:00');
+    expect(over?.isOverRoomLimit).toBe(true);
+    expect(under?.isOverRoomLimit).toBe(false);
+  });
+
+  test('summary undefined 면 모든 트랙 false (fail-safe)', () => {
+    setSummary(undefined);
+    setTracks([makeTrack('t1', '6:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(lastTrackProps[0].isOverRoomLimit).toBe(false);
+  });
+
+  test('playbackTimeLimit 0 이면 모든 트랙 false (fail-safe)', () => {
+    setSummary({ playbackTimeLimit: 0 });
+    setTracks([makeTrack('t1', '6:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(lastTrackProps[0].isOverRoomLimit).toBe(false);
+  });
+
+  test('파싱 불가 duration 이면 false (fail-safe)', () => {
+    setTracks([makeTrack('t1', 'LIVE')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(lastTrackProps[0].isOverRoomLimit).toBe(false);
+  });
+
+  test('로비(params.id undefined)면 query를 enabled=false 로 호출하고 배지 없음', () => {
+    paramsValue = {};
+    setTracks([makeTrack('t1', '6:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    const [, enabled] = (useFetchPartyroomDetailSummary as Mock).mock.calls[0];
+    expect(enabled).toBe(false);
+    expect(lastTrackProps[0].isOverRoomLimit).toBe(false);
+  });
+
+  test('방 안(params.id 존재)이면 query를 enabled=true 로 호출한다', () => {
+    setTracks([makeTrack('t1', '3:00')]);
+
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    const [partyroomId, enabled] = (useFetchPartyroomDetailSummary as Mock).mock.calls[0];
+    expect(partyroomId).toBe(7);
+    expect(enabled).toBe(true);
+  });
+});

--- a/src/features/playlist/list-tracks/ui/tracks.component.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import {
   DndContext,
@@ -15,6 +16,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { usePlaylistAction } from '@/entities/playlist';
+import { useFetchPartyroomDetailSummary } from '@/features/partyroom/get-summary';
 import { Playlist, PlaylistTrack } from '@/shared/api/http/types/playlists';
 import { errorLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
@@ -22,6 +24,7 @@ import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { PFAddPlaylist, PFDelete } from '@/shared/ui/icons';
 import Track from './track.component';
 import { useFetchPlaylistTracks } from '../api/use-fetch-playlist-tracks.query';
+import { parseDurationToSeconds } from '../lib/parse-duration';
 
 const logger = withDebugger(0);
 const errorLogger = logger(errorLog);
@@ -32,6 +35,10 @@ type TracksInPlaylistProps = {
 
 const TracksInPlaylist = ({ playlist }: TracksInPlaylistProps) => {
   const t = useI18n();
+  const params = useParams<{ id: string }>();
+  const partyroomId = Number(params.id);
+  const { data: summary } = useFetchPartyroomDetailSummary(partyroomId, !!partyroomId);
+  const limitMin = summary?.playbackTimeLimit ?? 0;
   const { data } = useFetchPlaylistTracks(playlist.id);
   const playlistAction = usePlaylistAction();
 
@@ -88,24 +95,29 @@ const TracksInPlaylist = ({ playlist }: TracksInPlaylistProps) => {
         strategy={verticalListSortingStrategy}
       >
         <div className='flex flex-col gap-3'>
-          {items.map((track) => (
-            <Track
-              key={track.linkId}
-              track={track}
-              menuItems={[
-                {
-                  onClickItem: () => playlistAction.removeTrack(playlist.id, track.trackId),
-                  label: t.playlist.btn.delete_playlist,
-                  Icon: <PFDelete />,
-                },
-                {
-                  onClickItem: () => playlistAction.moveTrack(playlist.id, track.trackId),
-                  label: t.playlist.btn.move_playlist,
-                  Icon: <PFAddPlaylist />,
-                },
-              ]}
-            />
-          ))}
+          {items.map((track) => {
+            const sec = parseDurationToSeconds(track.duration);
+            const isOverRoomLimit = limitMin > 0 && sec !== null && sec > limitMin * 60;
+            return (
+              <Track
+                key={track.linkId}
+                track={track}
+                isOverRoomLimit={isOverRoomLimit}
+                menuItems={[
+                  {
+                    onClickItem: () => playlistAction.removeTrack(playlist.id, track.trackId),
+                    label: t.playlist.btn.delete_playlist,
+                    Icon: <PFDelete />,
+                  },
+                  {
+                    onClickItem: () => playlistAction.moveTrack(playlist.id, track.trackId),
+                    label: t.playlist.btn.move_playlist,
+                    Icon: <PFAddPlaylist />,
+                  },
+                ]}
+              />
+            );
+          })}
         </div>
       </SortableContext>
     </DndContext>

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -229,6 +229,7 @@
       "deleted_queue_by_admin": "You have been removed from the queue by the administrator",
       "playback_stopped_time_limit": "Playback stopped: a track exceeds this room's time limit ({{minutes}} min).",
       "playback_stopped_no_limit": "Playback stopped: no playable track.",
+      "not_playable_in_room": "Not playable here (exceeds this room's time limit)",
       "locked_queue_by_admin": "The current DJ queue is locked by an admin",
       "skipped_song_by_admin": "According to the admin policy, songs longer than {{count}} minutes will be automatically skipped",
       "dj_in_order": "DJing **one person at a time** \n from the waiting list, in order",

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -229,6 +229,7 @@
       "deleted_queue_by_admin": "관리자에 의해 대기열에서 삭제되었습니다",
       "playback_stopped_time_limit": "재생 시간 제한({{minutes}}분)을 초과하는 곡으로 재생이 중단되었습니다",
       "playback_stopped_no_limit": "재생 가능한 곡이 없어 재생이 중단되었습니다",
+      "not_playable_in_room": "이 방에선 재생 안 돼요 (재생 시간 제한 초과)",
       "locked_queue_by_admin": "관리자에 의해 현재 DJ 대기열이 잠금 상태예요",
       "skipped_song_by_admin": "어드민 정책에 따라 {{count}}분 이상의 곡은 자동으로 스킵됩니다",
       "dj_in_order": "대기 중인 DJ **한명씩**\n **순서대로** 음악을 디제잉 합니다",


### PR DESCRIPTION
## 요약
E/#3 시리즈의 **마지막 PR(PR-4, web)**. 백엔드 PR-1/2/3(스킵·클린 deactivate·changeType 모달/토스트) 머지 완료 상태에서 남은 UX 갭을 닫는다: 플레이리스트 트랙 중 길이가 **현재 방 `playbackTimeLimit`(분)**를 초과하는 곡을 디밍 + "이 방에선 재생 안 돼요" 캡션으로 표시.

- **비차단**: 추가/메뉴/DnD 동작 무변경, 표시만 추가
- **반응형**: 기존 `useFetchPartyroomDetailSummary` react-query 캐시 재사용(방 limit 변경 시 자동 갱신, 중복 fetch 없음 — 기존 소비자와 동일 캐시키)
- **fail-safe**: 로비(방 id 없음→쿼리 disabled)/summary 없음/limit 0(무제한)/duration 파싱 불가 → 배지 없음
- 신규 leaf util `parseDurationToSeconds`("[H:]M:SS"→초, 실패 null) + i18n `dj.para.not_playable_in_room`(ko/en)

## 백엔드 의미 일치 검증
web 판정 `limitMin > 0 && sec > limitMin*60`(strict `>`)이 백엔드 스킵 술어 `PlaybackTimeLimit.exceedsDuration` = `duration.toSeconds() > limitMinutes*60L`(strict `>` + `isUnlimited()`=0 가드)와 **연산자·단위·무제한 의미 정확히 일치**. 경계값(== limit) 트랙은 양쪽 모두 재생 가능으로 취급.

## 테스트
- 신규 단위테스트(parse-duration 2) + 컴포넌트테스트(track 3 / tracks 7): over/under/**경계값(== limit, strict > 검증)**/fail-safe(summary 없음·limit 0·파싱 불가)/로비(enabled=false) 전부 커버
- 전 vitest **1274/1274 PASS**, `tsc --noEmit` 0, scoped eslint 0
- 스코프: web 배지 only. PR-1/2/3·alert·dj-queue-changed·summary 쿼리 구현 무변경. 트랙 추가 검증은 의도적 제외(비차단 설계)

## Test plan
- [ ] 방 입장 후 limit 초과 곡이 디밍+캡션으로 표시되는지
- [ ] 방 limit을 늘리면(편집) 배지가 반응형으로 사라지는지
- [ ] 로비(방 밖) 플레이리스트에는 배지 없음
- [ ] 무제한(limit 0) 방에서는 배지 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)