### PR TITLE
feat(amplitude): 게스트 미식별·멤버만 식별 (B′ — device_id 병합으로 콘솔 단일 user)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-amplitude-guest-anonymous-identity-bprime.md
+++ b/docs/superpowers/plans/2026-05-20-amplitude-guest-anonymous-identity-bprime.md
@@ -29,7 +29,7 @@
 
 - Modify: `src/shared/lib/analytics/auth-tracking.ts` (`identifyAuthenticatedUser` 본문, `getCurrentUserId` import 제거)
 - Modify: `src/shared/lib/analytics/index.ts` (`getCurrentUserId` export + JSDoc 삭제)
-- Modify: `src/shared/lib/analytics/events.ts` (`UserPropertySet` 의 `canonical_user_id` 멤버 + JSDoc 삭제)
+- Modify: `src/shared/lib/analytics/events.ts` (`UserPropertySetOnce` 의 `canonical_user_id` 멤버 + JSDoc 삭제 — **`UserPropertySet` 아님**, 리뷰 정정. 실제 위치 `events.ts:99-104` 영역, grep 으로 앵커 확인)
 - Test: `src/shared/lib/analytics/auth-tracking.test.ts` (canonical describe 삭제 + identify 단순화 assert), `src/shared/lib/analytics/index.test.ts` (`getCurrentUserId` describe 삭제)
 
 - [ ] **Step 1: 현행 확인 (편집 전 앵커)**
@@ -77,10 +77,10 @@
       `getCurrentUserId` export 함수 + 그 위 JSDoc(`현재 amplitude user_id ...`) 삭제. `__resetForTests`/`__preloadSdkForTests` 는 유지.
 
 - [ ] **Step 6: 구현 — `events.ts` `canonical_user_id` 타입 제거**
-      `UserPropertySet`(setOnce/set 에 쓰이는 타입) 에서 `canonical_user_id?: string;` 멤버 + 그 JSDoc 삭제. `identify`(index.ts)는 키를 제네릭 순회하므로 런타임 영향 없음 — 타입만 정리.
+      **`UserPropertySetOnce`** 타입(≈`events.ts:99-104`, `UserPropertySet` 아님 — `UserPropertySet`엔 `auth_type`/`authority_tier`/`oauth_provider`만 있음)에서 `canonical_user_id?: string;` 멤버 + 그 JSDoc(≈:99-103) 삭제. `identify`(index.ts)는 키를 제네릭 `Object.entries` 순회(검증됨)하므로 런타임 영향 없음 — 타입만 정리.
 
-- [ ] **Step 7: `index.test.ts` 의 `getCurrentUserId` describe 삭제**
-      해당 describe/it 블록 전체 삭제(의도된 삭제 — coverage 회귀 아님, spec §테스트 명시).
+- [ ] **Step 7: `index.test.ts` 의 `getCurrentUserId` 테스트 + import 삭제**
+      해당 `getCurrentUserId` describe/it 블록 전체 삭제(의도된 삭제 — coverage 회귀 아님, spec §테스트 명시). **+ 상단 import 목록(≈`index.test.ts:3-12`)에서 `getCurrentUserId` 도 제거**(미제거 시 unused-import tsc/eslint 실패 — 리뷰 정정).
 
 - [ ] **Step 8: 통과 확인**
       Run: `yarn vitest run src/shared/lib/analytics` → GREEN
@@ -156,7 +156,7 @@
 **Files:**
 
 - Modify: `src/app/_providers/analytics.provider.tsx`
-- Test: `src/app/_providers/analytics.provider.test.tsx` (**신규** — `src/app/_providers/` 엔 `handle-bubbled-error.test.tsx` 만 존재; 그 파일/기존 RTL 컨벤션 미러)
+- Test: `src/app/_providers/analytics.provider.test.tsx` (**신규**). ⚠️ 리뷰 정정: `src/app/_providers/handle-bubbled-error.test.tsx` 는 컴포넌트 렌더 안 함(순수 함수 호출) — **미러 대상 아님**. `test-utils.tsx` 의 `renderWithClient` 는 hook 전용(`renderHook`) — 사용 불가. **올바른 미러**: 실제 컴포넌트-렌더 테스트 `src/features/system-announcement/ui/hydrate-announcements-from-status.test.tsx`(또는 `src/widgets/partyroom-crews-panel/ui/partyroom-crews-panel.component.test.tsx`) — RTL `render`+`screen` (`@testing-library/react`) + 수동 `QueryClient`/`QueryClientProvider` 래퍼로 `[QueryKeys.Me]` 캐시 주입.
 
 - [ ] **Step 1: 현행 확인**
       Read `analytics.provider.tsx`. 앵커: QueryCache `subscribe` 콜백(게스트/멤버 공통 `identifyAuthenticatedUser({ uid: me.uid, authorityTier: me.authorityTier })`), warm-cache peek(동일), `lastIdentifiedUidRef`, `Session Started`. `AuthorityTier` import 경로 = `@/shared/api/http/types/@enums`.
@@ -168,7 +168,7 @@
   - 캐시에 **멤버 me**(`AuthorityTier.FM`) 세팅 → `identifyAuthenticatedUser` 1회 호출(uid·tier 전달).
   - **게스트→멤버 전이**: 게스트 me 로 시작(식별 없음) → 같은 캐시키에 멤버 me 로 갱신 → 멤버로 1회 식별.
   - `Session Started` 는 게스트 캐시여도 발사됨(귀속은 무관 — 식별과 분리; `track('Session Started', ...)` 호출 자체는 유지)。
-    (기존 `handle-bubbled-error.test.tsx` 의 provider 렌더/mock 패턴을 미러. 새 컨벤션 발명 금지.)
+    (미러 대상 = `hydrate-announcements-from-status.test.tsx` 등 실제 컴포넌트-렌더 테스트의 RTL `render`+수동 `QueryClientProvider` 패턴. `handle-bubbled-error.test.tsx`/`renderWithClient` 아님 — 위 Files 정정 참조. 새 컨벤션 발명 금지.)
 
 - [ ] **Step 3: 실패 확인**
       Run: `yarn vitest run src/app/_providers/analytics.provider.test.tsx` → FAIL (현재 게스트도 식별)

--- a/docs/superpowers/plans/2026-05-20-amplitude-guest-anonymous-identity-bprime.md
+++ b/docs/superpowers/plans/2026-05-20-amplitude-guest-anonymous-identity-bprime.md
@@ -1,0 +1,229 @@
+# amplitude 게스트-익명 정체성 (B′) Implementation Plan
+
+> **For agentic workers:** REQUIRED: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** 게스트를 amplitude 에서 식별하지 않고(익명·device_id only) 멤버 인증 시에만 `setUserId` 하여, 익명→식별 device_id 병합으로 콘솔 단일 user=멤버를 만든다. `canonical_user_id` 패치 제거 + `auth_type:guest` 잔여버그 fix.
+
+**Architecture:** pfplay-web 프론트 한정. (C1) `AnalyticsProvider` 가 게스트(authorityTier=GT) me 에는 식별 스킵, 멤버만 식별. (C2) 소셜 콜백은 `trackSignedIn` 에 명시적 `'member'` authType 오버라이드를 넘겨 stale `me` 의존 제거. (C3) `canonical_user_id`/`getCurrentUserId` dead-code 제거(`events.ts` 타입 포함). DB/백엔드/스키마 무변경.
+
+**Tech Stack:** Next.js App Router, TypeScript, react-query, vitest + RTL, `@amplitude/analytics-browser`.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-amplitude-guest-anonymous-identity-bprime-design.md`
+**Branch:** `feature/amplitude-guest-anonymous-bprime` (이미 체크아웃됨, spec 2커밋 존재)
+
+**전역 규약:**
+
+- 각 Task 착수 시 대상 파일을 먼저 `Read`/grep 으로 **현재 라인 확인**(아래 라인번호는 근사치 — 절대 신뢰 말고 grep 으로 앵커 확인 후 편집).
+- i18n 무관(이 작업엔 사전 변경 없음). eslint 게이트 `--quiet`(repo 규약). 커밋 메시지 한글. 시크릿 금지.
+- 각 Task 끝에서 `yarn tsc --noEmit` 0 + 해당 스코프 `yarn vitest run <경로>` GREEN 후 커밋.
+
+---
+
+## Chunk 1: B′ (C3 → C2 → C1 → 회귀)
+
+> 순서 근거: C3(dead-code 제거·`identifyAuthenticatedUser` 단순화)를 먼저 해야 C2/콜백테스트가 단순화된 함수 위에서 깨끗이 작성됨. 각 Task 는 독립 커밋·전 스위트 GREEN 유지.
+
+### Task 1: C3 — `canonical_user_id`/`getCurrentUserId` dead-code 제거 + `identifyAuthenticatedUser` 단순화
+
+**Files:**
+
+- Modify: `src/shared/lib/analytics/auth-tracking.ts` (`identifyAuthenticatedUser` 본문, `getCurrentUserId` import 제거)
+- Modify: `src/shared/lib/analytics/index.ts` (`getCurrentUserId` export + JSDoc 삭제)
+- Modify: `src/shared/lib/analytics/events.ts` (`UserPropertySet` 의 `canonical_user_id` 멤버 + JSDoc 삭제)
+- Test: `src/shared/lib/analytics/auth-tracking.test.ts` (canonical describe 삭제 + identify 단순화 assert), `src/shared/lib/analytics/index.test.ts` (`getCurrentUserId` describe 삭제)
+
+- [ ] **Step 1: 현행 확인 (편집 전 앵커)**
+      Read `auth-tracking.ts`, `index.ts`, `events.ts`. grep 확인:
+      `grep -n "getCurrentUserId\|canonical_user_id\|previousUserId\|setOnce" src/shared/lib/analytics/*.ts` (테스트 제외)
+      기대: `auth-tracking.ts` 의 `identifyAuthenticatedUser` 가 `getCurrentUserId()` 캡처 + `canonical_user_id` setOnce(게스트측 if-블록 + 멤버측 set/setOnce)를 포함. `index.ts` 에 `getCurrentUserId` export. `events.ts` `UserPropertySet`(또는 해당 타입)에 `canonical_user_id?: string` 멤버 + JSDoc.
+
+- [ ] **Step 2: 실패 테스트 — `identifyAuthenticatedUser` 단순화 계약**
+      `auth-tracking.test.ts` 에서: 기존 `canonical_user_id pinning` describe 블록 **전체 삭제**. `identifyAuthenticatedUser` describe 를 아래 계약으로 교체/수정 (analytics index 는 기존 테스트 mock 패턴 그대로):
+
+  - `identifyAuthenticatedUser({ uid: 'u123', authorityTier: AuthorityTier.FM, oauthProvider: 'GOOGLE' })` →
+    - `setUserId` 가 `'u123'` 로 1회 호출
+    - `identify` 가 `{ set: { auth_type: 'member', authority_tier: AuthorityTier.FM, oauth_provider: 'GOOGLE' } }` 로 1회 호출
+    - **`setOnce` 키 없음**, `canonical_user_id` 미등장, `getCurrentUserId` 미호출
+  - `oauthProvider` 미전달 시 `set` 에 `oauth_provider` 키 없음
+  - GT tier 전달 시 `auth_type:'guest'`(함수는 tier-agnostic 유지 — GT 가드는 본 함수가 아니라 provider 책임[Task 3])
+
+- [ ] **Step 3: 실패 확인**
+      Run: `yarn vitest run src/shared/lib/analytics/auth-tracking.test.ts`
+      Expected: FAIL (현 구현이 setOnce/canonical 포함)
+
+- [ ] **Step 4: 구현 — `auth-tracking.ts` `identifyAuthenticatedUser` 교체**
+      `getCurrentUserId` import 제거(`./index` import 에서 빼기). 함수 본문을 아래로 교체:
+
+  ```ts
+  export function identifyAuthenticatedUser({
+    uid,
+    authorityTier,
+    oauthProvider,
+  }: IdentifyAuthArgs): void {
+    setUserId(uid);
+    identify({
+      set: {
+        auth_type: authTypeOf(authorityTier),
+        authority_tier: authorityTier,
+        ...(oauthProvider ? { oauth_provider: oauthProvider } : {}),
+      },
+    });
+  }
+  ```
+
+  (`previousUserId`/`canonicalUserId`/게스트측 setOnce 블록/멤버측 setOnce 전부 삭제. JSDoc 의 ADR-012 B 언급 주석도 제거 — 현 동작과 불일치 방지.)
+
+- [ ] **Step 5: 구현 — `index.ts` `getCurrentUserId` 제거**
+      `getCurrentUserId` export 함수 + 그 위 JSDoc(`현재 amplitude user_id ...`) 삭제. `__resetForTests`/`__preloadSdkForTests` 는 유지.
+
+- [ ] **Step 6: 구현 — `events.ts` `canonical_user_id` 타입 제거**
+      `UserPropertySet`(setOnce/set 에 쓰이는 타입) 에서 `canonical_user_id?: string;` 멤버 + 그 JSDoc 삭제. `identify`(index.ts)는 키를 제네릭 순회하므로 런타임 영향 없음 — 타입만 정리.
+
+- [ ] **Step 7: `index.test.ts` 의 `getCurrentUserId` describe 삭제**
+      해당 describe/it 블록 전체 삭제(의도된 삭제 — coverage 회귀 아님, spec §테스트 명시).
+
+- [ ] **Step 8: 통과 확인**
+      Run: `yarn vitest run src/shared/lib/analytics` → GREEN
+      Run: `yarn tsc --noEmit` → 0 (canonical 타입 제거로 깨지는 다른 소비자 없어야 함; 있으면 그 소비자도 dead 이므로 정리)
+
+- [ ] **Step 9: 커밋**
+  ```bash
+  git add src/shared/lib/analytics/auth-tracking.ts src/shared/lib/analytics/index.ts src/shared/lib/analytics/events.ts src/shared/lib/analytics/auth-tracking.test.ts src/shared/lib/analytics/index.test.ts
+  git commit -m "refactor(amplitude): canonical_user_id·getCurrentUserId dead-code 제거 (B′ — 게스트 미식별로 불필요)"
+  ```
+
+---
+
+### Task 2: C2 — `trackSignedIn` authType 오버라이드 + 소셜 콜백 member 고정
+
+**Files:**
+
+- Modify: `src/shared/lib/analytics/auth-tracking.ts` (`trackSignedIn` 시그니처)
+- Modify: `src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx` (`trackSignedIn` 호출)
+- Test: `src/shared/lib/analytics/auth-tracking.test.ts`, `src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx`
+
+- [ ] **Step 1: 현행 확인**
+      grep: `grep -n "trackSignedIn" src/**/*.ts src/**/*.tsx` (테스트 제외) — 호출지: `use-social-sign-in-callback.hook.tsx`(멤버), `use-auto-sign-in.hook.ts`/`by-guest/.../use-sign-in.hook.tsx`(GT). 후자는 **무변경**(오버라이드 미전달 → 기존 동작).
+
+- [ ] **Step 2: 실패 테스트 — `auth-tracking.test.ts` `trackSignedIn` 오버라이드**
+      추가:
+
+  - `trackSignedIn(AuthorityTier.GT)` → `track('User Signed In', { auth_type: 'guest' })` (기존 동작 유지 회귀)
+  - `trackSignedIn(AuthorityTier.GT, 'member')` → `track('User Signed In', { auth_type: 'member' })` (오버라이드 우선)
+  - `trackSignedIn(AuthorityTier.FM)` → `auth_type: 'member'`
+
+- [ ] **Step 3: 실패 확인**
+      Run: `yarn vitest run src/shared/lib/analytics/auth-tracking.test.ts` → FAIL (2-arg 미지원)
+
+- [ ] **Step 4: 구현 — `trackSignedIn`**
+
+  ```ts
+  export function trackSignedIn(authorityTier: AuthorityTier, authTypeOverride?: AuthType): void {
+    track('User Signed In', { auth_type: authTypeOverride ?? authTypeOf(authorityTier) });
+  }
+  ```
+
+  (`AuthType` 는 이미 `./events` 에서 import 중 — 확인.)
+
+- [ ] **Step 5: 통과 확인** Run: `yarn vitest run src/shared/lib/analytics/auth-tracking.test.ts` → GREEN
+
+- [ ] **Step 6: 실패 테스트 — 콜백 SIGNED_IN auth_type=member 고정**
+      `use-social-sign-in-callback.hook.test.tsx`: 기존 :83 부근 "canonical" 관련 테스트는 Task 1 으로 canonical 이 사라졌으니 **개명·정리**(canonical assert 제거). 핵심 신규/수정 계약:
+
+  - `fetchMeAsync` 가 **GT(게스트) me 로 resolve 되는 zombie 시나리오 mock** 에서도, `trackSignedIn` 이 `'member'` 오버라이드로 호출되어 `User Signed In` 의 `auth_type==='member'`.
+  - 정상(member me) 시나리오에서도 `auth_type==='member'`.
+  - `identifyAuthenticatedUser` 가 member uid 로 호출되는 기존 검증 + #310 zombie-me 방어(`cancelQueries`/`removeQueries`/`fetchMeAsync` 순서) 회귀 유지.
+
+- [ ] **Step 7: 실패 확인** Run: `yarn vitest run src/features/sign-in/by-social` → FAIL
+
+- [ ] **Step 8: 구현 — 콜백 호출 수정**
+      `use-social-sign-in-callback.hook.tsx` 에서 `trackSignedIn(me.authorityTier);` → `trackSignedIn(me.authorityTier, 'member');`
+      (identify→trackSignedUp→trackSignedIn 순서·zombie-me 방어 라인 무변경.)
+
+- [ ] **Step 9: 통과 확인**
+      Run: `yarn vitest run src/features/sign-in/by-social src/shared/lib/analytics` → GREEN. `yarn tsc --noEmit` → 0.
+
+- [ ] **Step 10: 커밋**
+  ```bash
+  git add src/shared/lib/analytics/auth-tracking.ts src/shared/lib/analytics/auth-tracking.test.ts src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+  git commit -m "fix(amplitude): SIGNED_IN auth_type 을 콜백 member 권위로 고정 (stale me 의존 제거)"
+  ```
+
+---
+
+### Task 3: C1 — `AnalyticsProvider` 게스트(GT) 식별 가드
+
+**Files:**
+
+- Modify: `src/app/_providers/analytics.provider.tsx`
+- Test: `src/app/_providers/analytics.provider.test.tsx` (**신규** — `src/app/_providers/` 엔 `handle-bubbled-error.test.tsx` 만 존재; 그 파일/기존 RTL 컨벤션 미러)
+
+- [ ] **Step 1: 현행 확인**
+      Read `analytics.provider.tsx`. 앵커: QueryCache `subscribe` 콜백(게스트/멤버 공통 `identifyAuthenticatedUser({ uid: me.uid, authorityTier: me.authorityTier })`), warm-cache peek(동일), `lastIdentifiedUidRef`, `Session Started`. `AuthorityTier` import 경로 = `@/shared/api/http/types/@enums`.
+
+- [ ] **Step 2: 실패 테스트 — `analytics.provider.test.tsx` 신규**
+      RTL + analytics mock(`vi.mock('@/shared/lib/analytics')` 및 `@/shared/lib/analytics/auth-tracking`), react-query `QueryClient`/`QueryClientProvider` 로 `[QueryKeys.Me]` 캐시 주입. 계약:
+
+  - 캐시에 **게스트 me**(`authorityTier: AuthorityTier.GT`) 세팅 → 마운트 후 `identifyAuthenticatedUser` **미호출**(`setUserId` 미호출).
+  - 캐시에 **멤버 me**(`AuthorityTier.FM`) 세팅 → `identifyAuthenticatedUser` 1회 호출(uid·tier 전달).
+  - **게스트→멤버 전이**: 게스트 me 로 시작(식별 없음) → 같은 캐시키에 멤버 me 로 갱신 → 멤버로 1회 식별.
+  - `Session Started` 는 게스트 캐시여도 발사됨(귀속은 무관 — 식별과 분리; `track('Session Started', ...)` 호출 자체는 유지)。
+    (기존 `handle-bubbled-error.test.tsx` 의 provider 렌더/mock 패턴을 미러. 새 컨벤션 발명 금지.)
+
+- [ ] **Step 3: 실패 확인**
+      Run: `yarn vitest run src/app/_providers/analytics.provider.test.tsx` → FAIL (현재 게스트도 식별)
+
+- [ ] **Step 4: 구현 — GT 가드 (구독 콜백 + warm peek 양쪽)**
+      `AuthorityTier` import 추가. 구독 콜백 내부, `if (!me?.uid) return;` 다음에:
+
+  ```ts
+  // B′: 게스트는 amplitude 에서 식별하지 않는다(익명·device_id only).
+  // 멤버 인증 시 device_id 익명→식별 병합으로 콘솔 단일 user=멤버.
+  if (me.authorityTier === AuthorityTier.GT) return;
+  ```
+
+  warm-cache peek 분기도 동일 가드 추가(게스트면 `lastIdentifiedUidRef` 갱신·식별 모두 스킵). 예:
+
+  ```ts
+  const cached = queryClient.getQueryData<Me.Model>([QueryKeys.Me]);
+  if (
+    cached?.uid &&
+    cached.authorityTier !== AuthorityTier.GT &&
+    lastIdentifiedUidRef.current !== cached.uid
+  ) {
+    lastIdentifiedUidRef.current = cached.uid;
+    identifyAuthenticatedUser({ uid: cached.uid, authorityTier: cached.authorityTier });
+  }
+  ```
+
+  `Session Started`(:28-31 부근)의 `auth_type`/`authority_tier` 속성 부착은 **무변경**(이벤트 속성일 뿐 식별 아님 — spec).
+
+- [ ] **Step 5: 통과 확인**
+      Run: `yarn vitest run src/app/_providers/analytics.provider.test.tsx` → GREEN. `yarn tsc --noEmit` → 0.
+
+- [ ] **Step 6: 커밋**
+  ```bash
+  git add src/app/_providers/analytics.provider.tsx src/app/_providers/analytics.provider.test.tsx
+  git commit -m "feat(amplitude): 게스트(GT) amplitude 미식별 — B′ 익명·device_id 병합"
+  ```
+
+---
+
+### Task 4: 전 회귀 + scope 검증
+
+- [ ] **Step 1:** `yarn vitest run` 전체 GREEN · `yarn tsc --noEmit` 0 · `yarn eslint src/shared/lib/analytics src/app/_providers src/features/sign-in --quiet` 0 error.
+- [ ] **Step 2:** `git diff --stat origin/development..HEAD` — 변경 = analytics(auth-tracking/index/events + tests), analytics.provider(+test), use-social-sign-in-callback(+test), spec/plan 문서 **뿐**. **DB/백엔드/스키마/i18n/기타 도메인 코드 무변경** 확인. `use-auto-sign-in.hook.ts`/`by-guest use-sign-in.hook.tsx` **무변경**(C4) 확인.
+- [ ] **Step 3:** `git log --oneline origin/development..HEAD` 로 논리 단위(spec 2 + Task1~3 각 1) 확인.
+
+---
+
+## 완료 정의 (DoD)
+
+- 게스트 me → amplitude 식별 안 됨(setUserId 미호출). 멤버 인증 시에만 `setUserId(memberUid)`. 소셜 콜백 SIGNED_IN `auth_type=member`(zombie me 무관). `canonical_user_id`/`getCurrentUserId`/`events.ts` 타입 dead-code 제거. C4(게스트 trackSignedIn) 무변경.
+- 전 vitest GREEN · tsc 0 · scoped eslint 0. 스코프 = pfplay-web 프론트 only(DB/백엔드 0).
+- post-merge 실증 검증(stg/amplitude 콘솔: 게스트→가입 케이스 콘솔 단일 user=멤버·게스트활동 병합·멤버 SIGNED 에 auth_type:guest 부재)은 별도 추적(머지=stg 배포).
+- **본 PR 머지 후 1회**: ADR-012(상태=B′ 채택, B/E·canonical/Phase2 폐기 사유) · `bugs/2026-05-14-amplitude-user-id-discontinuity.md`(#9) · 로드맵 LIVE · 메모리 정정(thrash 금지 — 머지 후 한 번).
+
+## 범위 밖 (재확인)
+
+DB/스키마/백엔드 · 옵션 D · D/#9 P2 backend FK · crew/페널티/영구추방 연속성 · 크로스디바이스 게스트→멤버 · platform 작업 일체. (제품 결정 = 의도된 단절, 손대지 않음.)

--- a/docs/superpowers/specs/2026-05-20-amplitude-guest-anonymous-identity-bprime-design.md
+++ b/docs/superpowers/specs/2026-05-20-amplitude-guest-anonymous-identity-bprime-design.md
@@ -41,14 +41,14 @@ OAuth 가입 시 백엔드는 **새 `user_account`(새 TSID)** 를 발급한다(
 `src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx`, `src/shared/lib/analytics/auth-tracking.ts`
 
 - 멤버 식별 지점(:45)·#310 의 zombie-me 방어(`cancelQueries`+`removeQueries`+`fetchMeAsync`)·track 재배치(identify→trackSignedUp/In) **유지**.
-- **잔여 명시버그 fix**: `User Signed In`/`Signed Up` 의 `auth_type` 을 stale `me` 가 아니라 **권위 결과에서 도출**. 콜백은 가입/로그인 완료 = 정의상 member 컨텍스트 → SIGNED 이벤트 auth_type 은 member 로 확정(게스트 me 가 늦게 resolve 돼도 `auth_type:guest` 가 안 새도록). 구현: 콜백 경로의 SIGNED 발사를 me.authorityTier 의존이 아니라 "이 경로 = member 인증 완료" 사실에 결속.
+- **잔여 명시버그 fix (구체 메커니즘 명시)**: 현재 `trackSignedIn(me.authorityTier)` 는 `fetchMeAsync()` 결과에서 tier 를 읽는다 — zombie-me 레이스로 그 `me` 가 게스트로 resolve 되면 `User Signed In {auth_type:guest}` 가 샌다. **콜백 경로는 정의상 member 인증 완료이므로 `me` 의존을 끊는다.** 구체 변경: `trackSignedIn` 에 명시적 `authType` 오버라이드 인자를 추가(예: `trackSignedIn(authorityTier, authTypeOverride?: AuthType)`)하고, 소셜 콜백에서는 `trackSignedIn(me.authorityTier, 'member')` 로 호출(또는 콜백 전용 member-고정 상수로 `authTypeOf` 우회). 즉 SIGNED 이벤트의 `auth_type` 은 `fetchMeAsync` 결과와 **분리**되어 이 경로에서 항상 `member`. `trackSignedUp` 은 tier 미사용이라 무변경(단 setUserId 후 발사 순서 유지로 멤버 user 귀속). 다른 호출지(`use-auto-sign-in`/`use-sign-in` 의 `trackSignedIn(GT)`)는 오버라이드 미전달 → 기존대로 `authTypeOf(GT)='guest'`(게스트 익명 이벤트, 정상).
 
 ### C3. `identifyAuthenticatedUser` — canonical pin 제거 (B′ 로 불필요)
 
 `src/shared/lib/analytics/auth-tracking.ts`
 
 - B′ 에선 게스트가 식별되지 않으므로 `getCurrentUserId()`(이전 게스트 id 캡처)·`canonical_user_id` setOnce(게스트/멤버 양쪽 pin) 로직은 **무의미 → 제거**. 함수는 멤버 `setUserId(uid)` + user property(`auth_type`, `authority_tier`, `oauth_provider`) set 으로 단순화.
-- `getCurrentUserId` 가 다른 곳서 안 쓰이면 함께 정리(grep 확인 후). SDK-load race(`!sdk`→undefined) 관련 복잡성도 canonical 제거로 동반 소거.
+- **제거 surface (확정)**: `auth-tracking.ts` 의 `previousUserId`/`canonicalUserId` 캡처·게스트측 setOnce·멤버측 setOnce(:22-33,:42 영역) · `index.ts` 의 `getCurrentUserId` export(소비자 0 — 검증됨) + 그 단위테스트(`index.test.ts` `getCurrentUserId` describe) · **`events.ts` 의 `UserPropertySet.canonical_user_id?: string` 멤버 + 그 JSDoc(:100-104 영역)** — dead 가 되므로 동반 제거(스펙 일관 — 잔여 dead-code 금지). SDK-load race(`!sdk`→undefined) 복잡성도 canonical 제거로 동반 소거.
 
 ### C4. 게스트 측 이벤트 (`trackSignedIn(GT)`)
 
@@ -81,7 +81,9 @@ OAuth 가입 시 백엔드는 **새 `user_account`(새 TSID)** 를 발급한다(
 
 - `AnalyticsProvider`: 게스트 me(GT) → `setUserId`/`identify` **미호출**(스킵) / 멤버 me → 1회 식별 / 게스트→멤버 전이 시 멤버 식별 발생. (RTL + analytics mock, 기존 컴포넌트 테스트 컨벤션.)
 - `auth-tracking`: 단순화된 `identifyAuthenticatedUser` = 멤버 setUserId + property only, canonical/getCurrentUserId 미사용. `authTypeOf` 회귀.
-- 소셜 콜백: SIGNED 이벤트 `auth_type=member`(게스트 me 늦게 resolve 시나리오 mock 으로도 member 고정) + #310 zombie-me 방어 회귀 유지.
+- 소셜 콜백: SIGNED 이벤트 `auth_type=member`(게스트 me 늦게 resolve 시나리오 mock 으로도 member 고정 — 새 `authType` 오버라이드 경로) + #310 zombie-me 방어 회귀 유지.
+- **삭제 항목 명시(회귀 오인 방지)**: `auth-tracking.test.ts` 의 `canonical_user_id pinning` describe(≈:108-145)·`index.test.ts` 의 `getCurrentUserId` describe(≈:187-195)·`use-social-sign-in-callback.hook.test.tsx:83` 의 "canonical" 테스트명 — B′ 로 **의도된 삭제/개명**(coverage 회귀 아님, 리뷰어 안내용). `auth-tracking.ts` 의 `identifyAuthenticatedUser` 는 tier-agnostic 유지(GT 가드는 provider 에만 — C1; 함수에 밀어넣지 않음).
+- **net-new**: `AnalyticsProvider` 테스트 파일 신규(`src/app/_providers/` 엔 현재 `handle-bubbled-error.test.tsx` 만 존재) — 기존 RTL 컨벤션 미러.
 - 전 vitest·tsc·scoped eslint green.
 
 ## 검증 (post-implementation, 실증)

--- a/docs/superpowers/specs/2026-05-20-amplitude-guest-anonymous-identity-bprime-design.md
+++ b/docs/superpowers/specs/2026-05-20-amplitude-guest-anonymous-identity-bprime-design.md
@@ -1,0 +1,99 @@
+# amplitude 게스트-익명 정체성 (옵션 B′) 설계
+
+- **상태**: 설계 확정 (사용자 결정 완료) — spec 리뷰 대기
+- **일자**: 2026-05-20
+- **관련**: ADR-012(전제 정정됨), `bugs/2026-05-14-amplitude-user-id-discontinuity.md`(#9), pfplay-web #320(정정·close), web #310(Phase1 B — 본 설계가 일부 대체)
+- **범위**: pfplay-web 프론트 한정. **DB·백엔드·스키마 무변경.**
+
+## 맥락 / 문제
+
+OAuth 가입 시 백엔드는 **새 `user_account`(새 TSID)** 를 발급한다(합성 게스트 email ≠ OAuth email → 재사용 경로 없음 — 이는 **의도된 설계**, 정정 확인됨). 현재 프론트(`AnalyticsProvider`)는 게스트 me(authorityTier=GT)에도 `setUserId(guestUid)` 를 호출해 **게스트를 별도 amplitude user 로 식별**한다. 가입 후엔 멤버 user_id 로 또 식별 → amplitude 콘솔에 **한 사람이 2개 user 아이템**(게스트 user_id / 멤버 user_id)으로 분리. 두 개의 서로 다른 non-null user_id 는 amplitude 가 자동 병합하지 않는다(ADR-012 인용 SDK 사실).
+
+옵션 B(web #310: 게스트·멤버 모두 식별 + `canonical_user_id` setOnce pin)는 Cohort/SQL **조인 키**만 제공할 뿐 **콘솔 UI 는 여전히 2 아이템**(ADR-012 자인한 한계). 제품 요구 = "한 사람 = 한 아이템, **콘솔 User ID = 최신(멤버)**".
+
+## 결정 (사용자 확정)
+
+**옵션 B′ — 게스트는 amplitude 에서 식별하지 않는다.**
+
+- 게스트 단계: `setUserId` **미호출**. 게스트 활동 = `device_id` only = 익명 이벤트.
+- 멤버 인증(소셜 로그인) 시점에만 `setUserId(memberUid)`.
+- amplitude 의 **익명→식별 자동 병합**(동일 `device_id` 의 직전 익명 이벤트를 새 user_id 로 흡수 — 두 non-null user_id 병합과 반대, SDK 가 지원하는 단일 자동 병합)이 게스트 활동을 멤버 user 에 접합.
+- 결과: 콘솔 단일 user = 멤버 id, 게스트 활동 포함. **DB/스키마 무변경, canonical property 불필요.**
+
+### 명시적으로 범위 밖 (제품 결정 — 의도된 동작, 고치지 않음)
+
+- 가입 시 새 `user_account_id` 생성 = 의도. **crew_id 단절·페널티/영구추방 미승계 = 정상 동작**(사용자 명시 수용). 옵션 D(DB 정체성 보존) 폐기.
+- 크로스-디바이스 게스트→멤버 연결 = 비시나리오(수용). 영구 게스트(가입 안 함) = 익명 device user 로 잔존(수용 — "익명은 추적 불요").
+- 백엔드 `member.previous_guest_user_account_id`(구 D/#9 P2) = 불필요·폐기.
+
+## 아키텍처 / 컴포넌트
+
+### C1. `AnalyticsProvider` — 게스트 식별 가드 (핵심 변경)
+
+`src/app/_providers/analytics.provider.tsx`
+
+- `/me` 캐시 구독 콜백(:48 근처)과 warm-cache peek(:55 근처) 양쪽에서, `identifyAuthenticatedUser(...)` 호출 **전에 `authorityTier === AuthorityTier.GT` 이면 식별 스킵**(setUserId/identify 미수행). 멤버(FM/AM 등 비-GT)만 식별.
+- `lastIdentifiedUidRef` 가드 의미 유지(멤버 uid 변경 시 1회 식별). 게스트는 ref 갱신도 하지 않음(이후 멤버 전이 시 정상 식별되도록).
+- `Session Started`(:28-34): 변경 없음. 게스트/콜드 시 익명 device 이벤트로 발사(수용 — 세션 신호; identity 는 device_id 병합으로 사후 정합). 멤버 warm 캐시 시 기존대로 auth_type 부착.
+
+### C2. 소셜 콜백 — 멤버 식별 유지 + `auth_type` 권위출처 도출
+
+`src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx`, `src/shared/lib/analytics/auth-tracking.ts`
+
+- 멤버 식별 지점(:45)·#310 의 zombie-me 방어(`cancelQueries`+`removeQueries`+`fetchMeAsync`)·track 재배치(identify→trackSignedUp/In) **유지**.
+- **잔여 명시버그 fix**: `User Signed In`/`Signed Up` 의 `auth_type` 을 stale `me` 가 아니라 **권위 결과에서 도출**. 콜백은 가입/로그인 완료 = 정의상 member 컨텍스트 → SIGNED 이벤트 auth_type 은 member 로 확정(게스트 me 가 늦게 resolve 돼도 `auth_type:guest` 가 안 새도록). 구현: 콜백 경로의 SIGNED 발사를 me.authorityTier 의존이 아니라 "이 경로 = member 인증 완료" 사실에 결속.
+
+### C3. `identifyAuthenticatedUser` — canonical pin 제거 (B′ 로 불필요)
+
+`src/shared/lib/analytics/auth-tracking.ts`
+
+- B′ 에선 게스트가 식별되지 않으므로 `getCurrentUserId()`(이전 게스트 id 캡처)·`canonical_user_id` setOnce(게스트/멤버 양쪽 pin) 로직은 **무의미 → 제거**. 함수는 멤버 `setUserId(uid)` + user property(`auth_type`, `authority_tier`, `oauth_provider`) set 으로 단순화.
+- `getCurrentUserId` 가 다른 곳서 안 쓰이면 함께 정리(grep 확인 후). SDK-load race(`!sdk`→undefined) 관련 복잡성도 canonical 제거로 동반 소거.
+
+### C4. 게스트 측 이벤트 (`trackSignedIn(GT)`)
+
+`use-auto-sign-in.hook.ts`, `by-guest/lib/use-sign-in.hook.tsx`
+
+- 게스트 `trackSignedIn(AuthorityTier.GT)` 는 **이벤트일 뿐 setUserId 아님** → B′ 에서 익명 device 이벤트로 발사됨(수용). 변경 없음(유지). `auth_type:guest` 는 이벤트 속성으로 정상(게스트 세션의 사실 기록).
+- (대안 — spec 리뷰서 판단: 게스트 SignedIn 을 아예 발사하지 않음. 기본안 = **유지**(익명 세션 신호 가치 > 노이즈). 변경 최소 원칙.)
+
+## 데이터 흐름 (B′ 정상 경로)
+
+```
+[게스트 진입] device_id=D, user_id=∅
+  → 게스트 활동 이벤트들: (D, user_id 없음) = 익명
+[소셜 로그인 콜백] member 쿠키 → fetchMeAsync(member)
+  → setUserId(memberUid)   (C2, reset() 없음 → device_id=D 유지)
+  → amplitude: D 의 직전 익명 이벤트 ⟶ memberUid 로 귀속(병합)
+  → trackSignedUp/In (auth_type=member, C2)
+[결과] 콘솔: user 1개 = memberUid, 게스트활동 포함. 최신 User ID=member.
+```
+
+## 에러 / 엣지
+
+- **device_id 안정성**: sign-out=`sdk.setUserId(undefined)`(reset 아님, device_id 보존). `resetAnalyticsUser()` app 호출 0. `!isValidAmplitudeUserId`→reset 은 게스트 미식별이라 정상 흐름 미진입(멤버=유효 TSID; super-admin id=1 는 기존 별도 처리). → 병합 깨는 reset 경로 없음(검증 완료).
+- **멤버 재로그인/신규 디바이스**: 매 세션 `setUserId(member)` — 정상(병합 무관, 동일 user_id).
+- **로그아웃 후 같은 디바이스 새 게스트**: 익명 복귀. 이후 다른 멤버로 가입 시 그 멤버로 device 병합 — 제품상 수용(비시나리오/허용).
+- **영구 게스트**: 익명 device user 잔존 — 수용. 게스트-한정 분석은 user_id 아닌 device/`auth_type` 이벤트속성 기반.
+- **SDK 미로드 중 track**: 기존 `pendingActions` 큐로 순서 보존. B′ 는 canonical 캡처 제거로 `!sdk`→undefined race 노출면 축소.
+
+## 테스트
+
+- `AnalyticsProvider`: 게스트 me(GT) → `setUserId`/`identify` **미호출**(스킵) / 멤버 me → 1회 식별 / 게스트→멤버 전이 시 멤버 식별 발생. (RTL + analytics mock, 기존 컴포넌트 테스트 컨벤션.)
+- `auth-tracking`: 단순화된 `identifyAuthenticatedUser` = 멤버 setUserId + property only, canonical/getCurrentUserId 미사용. `authTypeOf` 회귀.
+- 소셜 콜백: SIGNED 이벤트 `auth_type=member`(게스트 me 늦게 resolve 시나리오 mock 으로도 member 고정) + #310 zombie-me 방어 회귀 유지.
+- 전 vitest·tsc·scoped eslint green.
+
+## 검증 (post-implementation, 실증)
+
+stg(머지 후) 또는 amplitude 콘솔: ① 게스트로 활동 후 소셜 가입한 케이스가 **콘솔 단일 user=멤버**, 게스트 활동 그 안에 병합 ② 멤버 SIGNED 이벤트에 `auth_type:guest` 부재 ③ 게스트 전용 세션은 익명 device user(정상). 콘솔 미정합 시 device_id 안정성/병합 거동 재조사(추측 fix 금지).
+
+## DoD
+
+- C1~C3 구현 + 테스트 green, 스코프=프론트 only(DB/백엔드 0).
+- 본 PR 머지 후 **1회**: ADR-012(상태=옵션 B′ 채택, B/E·canonical/Phase2 폐기 사유 명기) · #9 노트 · 로드맵 LIVE · 메모리 정정(thrash 금지 — 머지 후 한 번).
+- post-impl 검증 항목은 별도 추적(머지=stg 배포라 모니터링).
+
+## 범위 밖 (재확인)
+
+DB/스키마/백엔드 변경 · 옵션 D · D/#9 P2 backend FK · crew/페널티/영구추방 연속성 · 크로스-디바이스 게스트→멤버 · platform 측 작업 일체.

--- a/src/app/_providers/analytics.provider.test.tsx
+++ b/src/app/_providers/analytics.provider.test.tsx
@@ -1,0 +1,76 @@
+vi.mock('@/shared/lib/analytics', () => ({
+  initAnalytics: vi.fn(),
+  track: vi.fn(),
+}));
+vi.mock('@/shared/lib/analytics/auth-tracking', () => ({
+  authTypeOf: vi.fn(() => 'GUEST'),
+  identifyAuthenticatedUser: vi.fn(),
+}));
+
+import { act, ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import * as Me from '@/entities/me/model/me.model';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import { track } from '@/shared/lib/analytics';
+import { identifyAuthenticatedUser } from '@/shared/lib/analytics/auth-tracking';
+import AnalyticsProvider from './analytics.provider';
+
+const guestMe = { uid: 'g123', authorityTier: AuthorityTier.GT } as unknown as Me.Model;
+const memberMe = { uid: 'm456', authorityTier: AuthorityTier.FM } as unknown as Me.Model;
+
+const renderWithCache = (seed?: Me.Model) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (seed) queryClient.setQueryData([QueryKeys.Me], seed);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const utils = render(<AnalyticsProvider>child</AnalyticsProvider>, { wrapper });
+  return { queryClient, ...utils };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AnalyticsProvider — B′ 게스트(GT) 미식별 가드', () => {
+  test('게스트 me 가 캐시에 있으면 identifyAuthenticatedUser 를 호출하지 않는다', () => {
+    renderWithCache(guestMe);
+    expect(identifyAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
+  test('멤버 me 가 캐시에 있으면 identifyAuthenticatedUser 를 멤버로 1회 호출한다', () => {
+    renderWithCache(memberMe);
+    expect(identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
+    expect(identifyAuthenticatedUser).toHaveBeenCalledWith({
+      uid: 'm456',
+      authorityTier: AuthorityTier.FM,
+    });
+  });
+
+  test('게스트→멤버 전이: 게스트는 미식별, 멤버 전이 시 멤버로 1회만 식별', () => {
+    const { queryClient } = renderWithCache(guestMe);
+    expect(identifyAuthenticatedUser).not.toHaveBeenCalled();
+
+    act(() => {
+      queryClient.setQueryData([QueryKeys.Me], memberMe);
+    });
+
+    expect(identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
+    expect(identifyAuthenticatedUser).toHaveBeenCalledWith({
+      uid: 'm456',
+      authorityTier: AuthorityTier.FM,
+    });
+  });
+
+  test('게스트 캐시 마운트에서도 Session Started 는 계속 발화한다', () => {
+    renderWithCache(guestMe);
+    expect(track).toHaveBeenCalledWith(
+      'Session Started',
+      expect.objectContaining({ authority_tier: AuthorityTier.GT })
+    );
+  });
+});

--- a/src/app/_providers/analytics.provider.test.tsx
+++ b/src/app/_providers/analytics.provider.test.tsx
@@ -73,4 +73,23 @@ describe('AnalyticsProvider — B′ 게스트(GT) 미식별 가드', () => {
       expect.objectContaining({ authority_tier: AuthorityTier.GT })
     );
   });
+
+  test('동일 uid 멤버 me 가 재설정돼도 identifyAuthenticatedUser 는 1회만 호출된다 (ref dedup)', () => {
+    const { queryClient } = renderWithCache(memberMe);
+    expect(identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      queryClient.setQueryData([QueryKeys.Me], {
+        uid: 'm456',
+        authorityTier: AuthorityTier.FM,
+      } as unknown as Me.Model);
+    });
+
+    expect(identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
+  });
+
+  test('uid 없는 게스트성 me 는 조기 반환되어 identifyAuthenticatedUser 를 호출하지 않는다', () => {
+    renderWithCache({ authorityTier: AuthorityTier.GT } as unknown as Me.Model);
+    expect(identifyAuthenticatedUser).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/_providers/analytics.provider.tsx
+++ b/src/app/_providers/analytics.provider.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import * as Me from '@/entities/me/model/me.model';
 import { QueryKeys } from '@/shared/api/http/query-keys';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import { initAnalytics, track } from '@/shared/lib/analytics';
 import { authTypeOf, identifyAuthenticatedUser } from '@/shared/lib/analytics/auth-tracking';
 import type { AuthorityTierLabel } from '@/shared/lib/analytics/events';
@@ -43,6 +44,9 @@ export default function AnalyticsProvider({ children }: { children: ReactNode })
       if (event.query.queryKey[0] !== QueryKeys.Me) return;
       const me = event.query.state.data as Me.Model | undefined;
       if (!me?.uid) return;
+      // B′: 게스트는 amplitude 에서 식별하지 않는다(익명·device_id only).
+      // 멤버 인증 시 device_id 익명→식별 병합으로 콘솔 단일 user=멤버.
+      if (me.authorityTier === AuthorityTier.GT) return;
       if (lastIdentifiedUidRef.current === me.uid) return;
       lastIdentifiedUidRef.current = me.uid;
       identifyAuthenticatedUser({ uid: me.uid, authorityTier: me.authorityTier });
@@ -50,7 +54,11 @@ export default function AnalyticsProvider({ children }: { children: ReactNode })
 
     // Apply identity for cache that was already warm at mount.
     const cached = queryClient.getQueryData<Me.Model>([QueryKeys.Me]);
-    if (cached?.uid && lastIdentifiedUidRef.current !== cached.uid) {
+    if (
+      cached?.uid &&
+      cached.authorityTier !== AuthorityTier.GT &&
+      lastIdentifiedUidRef.current !== cached.uid
+    ) {
       lastIdentifiedUidRef.current = cached.uid;
       identifyAuthenticatedUser({ uid: cached.uid, authorityTier: cached.authorityTier });
     }

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
@@ -80,7 +80,7 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
     );
   });
 
-  test('#9: identify(setUserId+canonical) 가 trackSignedUp/In 보다 먼저 발사', async () => {
+  test('#9: identify(setUserId) 가 trackSignedUp/In 보다 먼저 발사', async () => {
     callbackLogin.mockResolvedValue({ isNewUser: true });
     fetchMeAsync.mockResolvedValue(meModel({ authorityTier: AuthorityTier.FM }));
 

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
@@ -128,8 +128,6 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
 
     // tier 가 GT(guest-ish 좀비) 여도 콜백은 member 권위로 SIGNED_IN 을 고정한다.
     expect(trackSignedIn).toHaveBeenCalledWith(AuthorityTier.GT, 'member');
-    const overrideArg = trackSignedIn.mock.calls[0][1];
-    expect(overrideArg).toBe('member');
   });
 
   test('callbackLogin 실패 시 /sign-in 으로', async () => {

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
@@ -109,6 +109,29 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
     expect(trackSignedIn).toHaveBeenCalledTimes(1);
   });
 
+  test("B′: 정상 member-me 면 trackSignedIn 이 'member' override 와 함께 발사", async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: false });
+    fetchMeAsync.mockResolvedValue(meModel({ authorityTier: AuthorityTier.FM }));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(trackSignedIn).toHaveBeenCalledWith(AuthorityTier.FM, 'member');
+  });
+
+  test("B′: 좀비(GUEST-ish) me(GT) 가 와도 SIGNED_IN auth_type 은 'member' 로 고정", async () => {
+    callbackLogin.mockResolvedValue({ isNewUser: false });
+    fetchMeAsync.mockResolvedValue(meModel({ authorityTier: AuthorityTier.GT }));
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    // tier 가 GT(guest-ish 좀비) 여도 콜백은 member 권위로 SIGNED_IN 을 고정한다.
+    expect(trackSignedIn).toHaveBeenCalledWith(AuthorityTier.GT, 'member');
+    const overrideArg = trackSignedIn.mock.calls[0][1];
+    expect(overrideArg).toBe('member');
+  });
+
   test('callbackLogin 실패 시 /sign-in 으로', async () => {
     callbackLogin.mockRejectedValue(new Error('exchange failed'));
 

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
@@ -40,8 +40,8 @@ export default function useOAuth2Callback() {
         }
 
         if (me) {
-          // #9 (ADR-012 B): identify(→setUserId + canonical pin) 를 먼저 수행한
-          // 뒤 track 발사 — 이전엔 track 이 setUserId 전이라 GUEST id 로 귀속됐다.
+          // identify(→setUserId)를 먼저 수행한 뒤 track 발사 — track 이 setUserId 전이면
+          // 직전 식별자(게스트/익명)로 귀속되므로 순서 보장 필요.
           identifyAuthenticatedUser({
             uid: me.uid,
             authorityTier: me.authorityTier,

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
@@ -50,7 +50,7 @@ export default function useOAuth2Callback() {
           if (tokenResponse.isNewUser) {
             trackSignedUp(oauth2Provider);
           }
-          trackSignedIn(me.authorityTier);
+          trackSignedIn(me.authorityTier, 'member');
         }
 
         // 옵션2(#7): 신규 가입자는 좀비 me 와 무관하게 프로필 설정 강제.

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
@@ -50,6 +50,7 @@ export default function useOAuth2Callback() {
           if (tokenResponse.isNewUser) {
             trackSignedUp(oauth2Provider);
           }
+          // 콜백 도달 = OAuth 인증 완료. me 가 좀비 GUEST 로 늦게 풀려도 SIGNED_IN auth_type 은 member 로 고정.
           trackSignedIn(me.authorityTier, 'member');
         }
 

--- a/src/shared/lib/analytics/auth-tracking.test.ts
+++ b/src/shared/lib/analytics/auth-tracking.test.ts
@@ -58,6 +58,21 @@ describe('auth-tracking', () => {
       expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'guest' });
     });
 
+    test('override 미전달 시 tier 기준 유지 (회귀: GT → guest)', () => {
+      trackSignedIn(AuthorityTier.GT);
+      expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'guest' });
+    });
+
+    test('authTypeOverride 가 tier 보다 우선 (GT 라도 member)', () => {
+      trackSignedIn(AuthorityTier.GT, 'member');
+      expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'member' });
+    });
+
+    test('emits member auth_type for AuthorityTier.FM (override 없음)', () => {
+      trackSignedIn(AuthorityTier.FM);
+      expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'member' });
+    });
+
     test('emits member auth_type for AuthorityTier.AM', () => {
       trackSignedIn(AuthorityTier.AM);
       expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'member' });

--- a/src/shared/lib/analytics/auth-tracking.test.ts
+++ b/src/shared/lib/analytics/auth-tracking.test.ts
@@ -82,66 +82,36 @@ describe('auth-tracking', () => {
   });
 
   describe('identifyAuthenticatedUser', () => {
-    test('sets userId and applies auth_type / authority_tier user properties', () => {
-      identifyAuthenticatedUser({ uid: 'uid-1', authorityTier: AuthorityTier.FM });
-      expect(amplitude.setUserId).toHaveBeenCalledWith('uid-1');
-      expect(identifyProto.set).toHaveBeenCalledWith('auth_type', 'member');
-      expect(identifyProto.set).toHaveBeenCalledWith('authority_tier', 'FM');
-    });
-
-    test('includes oauth_provider when provided', () => {
+    test('setUserId(uid) 1회 + member 속성 identify 1회, setOnce 없음, getCurrentUserId 미호출', () => {
       identifyAuthenticatedUser({
-        uid: 'uid-1',
+        uid: 'u12345',
         authorityTier: AuthorityTier.FM,
-        oauthProvider: 'google',
+        oauthProvider: 'GOOGLE',
       });
-      expect(identifyProto.set).toHaveBeenCalledWith('oauth_provider', 'google');
-    });
 
-    test('omits oauth_provider when not provided', () => {
-      identifyAuthenticatedUser({ uid: 'uid-1', authorityTier: AuthorityTier.GT });
-      const setCalls = identifyProto.set.mock.calls.map((call) => call[0]);
-      expect(setCalls).not.toContain('oauth_provider');
-    });
-  });
+      expect(amplitude.setUserId).toHaveBeenCalledTimes(1);
+      expect(amplitude.setUserId).toHaveBeenCalledWith('u12345');
 
-  describe('canonical_user_id pinning (ADR-012 Phase 1 = B)', () => {
-    test('GUEST id 존재 & uid 와 다르면 GUEST·MEMBER 양쪽에 canonical pin + 순서(GUEST identify → setUserId → MEMBER identify)', () => {
-      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('guest-account-id');
-
-      identifyAuthenticatedUser({ uid: 'member-uid-1', authorityTier: AuthorityTier.FM });
-
-      expect(amplitude.setUserId).toHaveBeenCalledWith('member-uid-1');
-      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'guest-account-id');
-      // GUEST 측 + MEMBER 측 = identify 2회 호출, setUserId 가 그 사이.
-      expect(amplitude.identify).toHaveBeenCalledTimes(2);
-      const firstIdentifyOrder = (amplitude.identify as ReturnType<typeof vi.fn>).mock
-        .invocationCallOrder[0];
-      const setUserIdOrder = (amplitude.setUserId as ReturnType<typeof vi.fn>).mock
-        .invocationCallOrder[0];
-      const secondIdentifyOrder = (amplitude.identify as ReturnType<typeof vi.fn>).mock
-        .invocationCallOrder[1];
-      expect(firstIdentifyOrder).toBeLessThan(setUserIdOrder);
-      expect(setUserIdOrder).toBeLessThan(secondIdentifyOrder);
-    });
-
-    test('GUEST id 미상(SDK 미로드) 면 canonical=uid, GUEST 측 pre-pin 생략', () => {
-      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
-
-      identifyAuthenticatedUser({ uid: 'member-uid-2', authorityTier: AuthorityTier.FM });
-
-      expect(amplitude.setUserId).toHaveBeenCalledWith('member-uid-2');
-      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'member-uid-2');
-      expect(amplitude.identify).toHaveBeenCalledTimes(1); // MEMBER 측 1회만
-    });
-
-    test('현재 id 가 이미 uid (재로그인) 면 GUEST 측 pre-pin 생략, canonical=uid', () => {
-      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('member-uid-3');
-
-      identifyAuthenticatedUser({ uid: 'member-uid-3', authorityTier: AuthorityTier.AM });
-
-      expect(identifyProto.setOnce).toHaveBeenCalledWith('canonical_user_id', 'member-uid-3');
       expect(amplitude.identify).toHaveBeenCalledTimes(1);
+      expect(identifyProto.set).toHaveBeenCalledWith('auth_type', 'member');
+      expect(identifyProto.set).toHaveBeenCalledWith('authority_tier', AuthorityTier.FM);
+      expect(identifyProto.set).toHaveBeenCalledWith('oauth_provider', 'GOOGLE');
+
+      expect(identifyProto.setOnce).not.toHaveBeenCalled();
+      expect(amplitude.getUserId).not.toHaveBeenCalled();
+      const setKeys = identifyProto.set.mock.calls.map((call) => call[0]);
+      expect(setKeys).not.toContain('canonical_user_id');
+    });
+
+    test('oauthProvider 생략 시 set 에 oauth_provider 키 없음', () => {
+      identifyAuthenticatedUser({ uid: 'u12345', authorityTier: AuthorityTier.FM });
+      const setKeys = identifyProto.set.mock.calls.map((call) => call[0]);
+      expect(setKeys).not.toContain('oauth_provider');
+    });
+
+    test('AuthorityTier.GT 면 auth_type=guest (함수는 tier-agnostic, GT 가드는 별도)', () => {
+      identifyAuthenticatedUser({ uid: 'u12345', authorityTier: AuthorityTier.GT });
+      expect(identifyProto.set).toHaveBeenCalledWith('auth_type', 'guest');
     });
   });
 });

--- a/src/shared/lib/analytics/auth-tracking.test.ts
+++ b/src/shared/lib/analytics/auth-tracking.test.ts
@@ -77,11 +77,6 @@ describe('auth-tracking', () => {
       trackSignedIn(AuthorityTier.AM);
       expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'member' });
     });
-
-    test('emits member auth_type for AuthorityTier.FM', () => {
-      trackSignedIn(AuthorityTier.FM);
-      expect(amplitude.track).toHaveBeenCalledWith('User Signed In', { auth_type: 'member' });
-    });
   });
 
   describe('trackSignedUp', () => {

--- a/src/shared/lib/analytics/auth-tracking.test.ts
+++ b/src/shared/lib/analytics/auth-tracking.test.ts
@@ -82,7 +82,7 @@ describe('auth-tracking', () => {
   });
 
   describe('identifyAuthenticatedUser', () => {
-    test('setUserId(uid) 1회 + member 속성 identify 1회, setOnce 없음, getCurrentUserId 미호출', () => {
+    test('setUserId(uid) 1회 + member 속성 identify 1회, setOnce 없음, amplitude.getUserId 를 호출하지 않는다 (canonical 캡처 제거됨)', () => {
       identifyAuthenticatedUser({
         uid: 'u12345',
         authorityTier: AuthorityTier.FM,

--- a/src/shared/lib/analytics/auth-tracking.ts
+++ b/src/shared/lib/analytics/auth-tracking.ts
@@ -29,8 +29,8 @@ export function identifyAuthenticatedUser({
   });
 }
 
-export function trackSignedIn(authorityTier: AuthorityTier): void {
-  track('User Signed In', { auth_type: authTypeOf(authorityTier) });
+export function trackSignedIn(authorityTier: AuthorityTier, authTypeOverride?: AuthType): void {
+  track('User Signed In', { auth_type: authTypeOverride ?? authTypeOf(authorityTier) });
 }
 
 export function trackSignedUp(oauthProvider: OAuth2Provider): void {

--- a/src/shared/lib/analytics/auth-tracking.ts
+++ b/src/shared/lib/analytics/auth-tracking.ts
@@ -2,7 +2,7 @@ import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import type { OAuth2Provider } from '@/shared/api/http/types/users';
 
 import type { AuthType } from './events';
-import { getCurrentUserId, identify, setUserId, track } from './index';
+import { identify, setUserId, track } from './index';
 
 export function authTypeOf(authorityTier: AuthorityTier): AuthType {
   return authorityTier === AuthorityTier.GT ? 'guest' : 'member';
@@ -19,19 +19,6 @@ export function identifyAuthenticatedUser({
   authorityTier,
   oauthProvider,
 }: IdentifyAuthArgs): void {
-  // ADR-012 (Phase 1 = B): setUserId 직전 현재(GUEST) amplitude id 를 캡처.
-  // canonical_user_id 는 한 사람의 최초 id — GUEST·MEMBER 양쪽 user 에 동일 값을
-  // setOnce pin 하여 가입 전후 행동을 Cohort/SQL join 으로 잇는다.
-  const previousUserId = getCurrentUserId();
-  const canonicalUserId = previousUserId ?? uid;
-
-  // GUEST user 측에도 같은 anchor 를 박는다 (setUserId 로 전환되기 전이라
-  // 이 identify 는 GUEST id 에 귀속). previousUserId 가 이미 uid 면(재로그인 등)
-  // setUserId 후 한 번만 박아도 충분하므로 생략.
-  if (previousUserId && previousUserId !== uid) {
-    identify({ setOnce: { canonical_user_id: canonicalUserId } });
-  }
-
   setUserId(uid);
   identify({
     set: {
@@ -39,7 +26,6 @@ export function identifyAuthenticatedUser({
       authority_tier: authorityTier,
       ...(oauthProvider ? { oauth_provider: oauthProvider } : {}),
     },
-    setOnce: { canonical_user_id: canonicalUserId },
   });
 }
 

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -96,12 +96,6 @@ export type UserPropertySetOnce = {
   has_created_partyroom?: boolean;
   /** ISO 8601 timestamp recorded the first time the user enters any partyroom. */
   first_partyroom_entered_at?: string;
-  /**
-   * GUEST→MEMBER 가입 경계에서 한 사람의 amplitude identity 를 잇는 anchor.
-   * GUEST·MEMBER 양쪽 user 에 동일한 (최초 GUEST) id 를 setOnce 로 pin 하여
-   * Cohort/SQL join 으로 가입 전후 행동을 연결한다. ADR-012 (Phase 1 = B).
-   */
-  canonical_user_id?: string;
 };
 
 export type UserPropertyAdd = {

--- a/src/shared/lib/analytics/index.test.ts
+++ b/src/shared/lib/analytics/index.test.ts
@@ -3,7 +3,6 @@ import * as amplitude from '@amplitude/analytics-browser';
 import {
   __preloadSdkForTests,
   __resetForTests,
-  getCurrentUserId,
   identify,
   initAnalytics,
   resetAnalyticsUser,
@@ -181,18 +180,6 @@ describe('analytics module', () => {
     test('calls amplitude.reset', () => {
       resetAnalyticsUser();
       expect(amplitude.reset).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('getCurrentUserId', () => {
-    test('SDK 로드 상태면 amplitude.getUserId 결과 반환', () => {
-      (amplitude.getUserId as ReturnType<typeof vi.fn>).mockReturnValue('current-id');
-      expect(getCurrentUserId()).toBe('current-id');
-    });
-
-    test('SDK 미로드면 undefined (GUEST id 미상 — caller fallback)', () => {
-      __resetForTests(); // sdk = null
-      expect(getCurrentUserId()).toBeUndefined();
     });
   });
 });

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -131,16 +131,6 @@ export function resetAnalyticsUser(): void {
   });
 }
 
-/**
- * 현재 amplitude user_id (SDK 미로드 시 undefined).
- * GUEST→MEMBER 경계에서 setUserId 직전 GUEST id 를 캡처하는 데 쓴다 (ADR-012).
- * SDK 가 아직 로드 전이면 GUEST id 미상이라 undefined — caller 가 fallback 처리.
- */
-export function getCurrentUserId(): string | undefined {
-  if (!isEnabled() || !sdk) return undefined;
-  return sdk.getUserId();
-}
-
 export function __resetForTests(): void {
   initialized = false;
   sdk = null;


### PR DESCRIPTION
## 요약
amplitude 정체성 전략을 **B′** 로 전환 (프론트 한정, DB/백엔드 무변경). ADR-012 의 옵션 B(web #310 `canonical_user_id` pin)를 대체.

- **게스트는 amplitude 에서 식별하지 않음**: `AnalyticsProvider` 가 `authorityTier===GT` me 에는 `setUserId`/identify 스킵(구독 콜백 + warm-peek 양쪽). 게스트 활동 = 익명·device_id only.
- **멤버 인증 시에만 `setUserId(memberUid)`** → amplitude 익명→식별 device_id 병합이 직전 게스트 활동을 멤버 user 로 흡수 → **콘솔 단일 user = 멤버(최신 user_id)**, 가입 전후 연속.
- **canonical_user_id / getCurrentUserId dead-code 제거**(B′ 로 불필요): `auth-tracking.identifyAuthenticatedUser` 단순화(`setUserId`+member props), `index.getCurrentUserId`·`events.UserPropertySetOnce.canonical_user_id` 삭제.
- **잔여버그 fix**: `User Signed In` 의 `auth_type` 을 stale `me` 가 아니라 콜백 member 권위로 고정(`trackSignedIn(tier, 'member')`) — zombie GUEST me 여도 `auth_type:member`.

## 스코프 (의도된 경계)
프론트 analytics/sign-in 한정. **DB·백엔드·스키마·i18n 무변경.** 가입 시 새 user_account 발급(=의도된 설계)으로 인한 **crew/페널티/영구추방 단절은 제품 결정상 정상 동작 — 본 PR 범위 밖**(옵션 D/D#9 P2 backend FK 폐기). 게스트 측 `trackSignedIn(GT)` 익명 이벤트는 의도대로 유지.

## 검증
- 전 vitest **1279/1279** · `tsc --noEmit` 0 · scoped eslint 0.
- 신규 `analytics.provider.test.tsx`(게스트 미식별/멤버 1회/게스트→멤버 전이/Session Started 생존/ref dedup/uid-less) + auth-tracking·콜백 회귀.
- spec→리뷰→plan→리뷰→subagent-driven TDD(각 task spec+코드품질 2단 + 최종 holistic 리뷰) 통과.

## 후속 (머지 후)
ADR-012(상태=B′ 채택, B/E·canonical/Phase2 폐기 사유) · `bugs/2026-05-14-amplitude-user-id-discontinuity.md`(#9) · 로드맵 LIVE · 메모리 **1회 정정**. post-impl 실증: stg/amplitude 콘솔에서 게스트→가입 케이스 단일 user=멤버·게스트활동 병합·멤버 SIGNED 에 auth_type:guest 부재 모니터링.

🤖 Generated with [Claude Code](https://claude.com/claude-code)