### PR TITLE
feat(voc): 버그 제보 버튼 + Dialog (Header)

### DIFF
--- a/src/features/bug-report/index.ts
+++ b/src/features/bug-report/index.ts
@@ -1,0 +1,2 @@
+export { BugReportButton } from './ui/bug-report-button.component';
+export { useOpenBugReportDialog } from './ui/bug-report-dialog.component';

--- a/src/features/bug-report/model/bug-report-schema.ts
+++ b/src/features/bug-report/model/bug-report-schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const BUG_REPORT_CONTENT_MIN = 5;
+export const BUG_REPORT_CONTENT_MAX = 2000;
+
+export const bugReportSchema = z.object({
+  content: z
+    .string()
+    .min(BUG_REPORT_CONTENT_MIN, { message: 'too_short' })
+    .max(BUG_REPORT_CONTENT_MAX, { message: 'too_long' }),
+});
+
+export type BugReportSchema = z.infer<typeof bugReportSchema>;

--- a/src/features/bug-report/model/use-bug-report-toast.hook.ts
+++ b/src/features/bug-report/model/use-bug-report-toast.hook.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+type Severity = 'success' | 'error';
+
+export type BugReportToastItem = {
+  severity: Severity;
+  message: string;
+};
+
+type State = {
+  current: BugReportToastItem | null;
+  show: (item: BugReportToastItem) => void;
+  dismiss: () => void;
+};
+
+export const useBugReportToast = create<State>((set) => ({
+  current: null,
+  show: (item) => {
+    set({ current: item });
+    setTimeout(() => {
+      set((s) => (s.current === item ? { current: null } : s));
+    }, 3000);
+  },
+  dismiss: () => set({ current: null }),
+}));

--- a/src/features/bug-report/model/use-submit-bug-report.hook.ts
+++ b/src/features/bug-report/model/use-submit-bug-report.hook.ts
@@ -1,0 +1,22 @@
+import { usePathname } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { bugReportsService } from '@/shared/api/http/services';
+
+function extractPartyroomIdFromPath(pathname: string | null): number | undefined {
+  if (!pathname) return undefined;
+  const match = pathname.match(/^\/parties\/(\d+)/);
+  if (!match) return undefined;
+  const id = Number(match[1]);
+  return Number.isFinite(id) && id > 0 ? id : undefined;
+}
+
+export function useSubmitBugReport() {
+  const pathname = usePathname();
+  return useMutation({
+    mutationFn: (input: { content: string }) =>
+      bugReportsService.submit({
+        content: input.content,
+        partyroomId: extractPartyroomIdFromPath(pathname),
+      }),
+  });
+}

--- a/src/features/bug-report/ui/bug-report-button.component.tsx
+++ b/src/features/bug-report/ui/bug-report-button.component.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useOpenBugReportDialog } from './bug-report-dialog.component';
+import PFBug from './pf-bug-icon';
+
+export function BugReportButton() {
+  const t = useI18n();
+  const openDialog = useOpenBugReportDialog();
+
+  return (
+    <button
+      type='button'
+      onClick={openDialog}
+      aria-label={t.bug_report.btn.open}
+      className='text-gray-400 hover:text-gray-200 transition-colors'
+      data-testid='bug-report-button'
+    >
+      <PFBug width={24} height={24} />
+    </button>
+  );
+}

--- a/src/features/bug-report/ui/bug-report-dialog.component.tsx
+++ b/src/features/bug-report/ui/bug-report-dialog.component.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import { Typography } from '@/shared/ui/components/typography';
+import { BugReportForm } from './bug-report-form.component';
+import { BugReportToast } from './bug-report-toast';
+
+export function useOpenBugReportDialog() {
+  const { openDialog } = useDialog();
+  const t = useI18n();
+
+  return () =>
+    openDialog((_, onCancel) => ({
+      title: ({ defaultClassName }) => (
+        <Typography type='title2' className={defaultClassName}>
+          {t.bug_report.title.report_bug}
+        </Typography>
+      ),
+      titleAlign: 'left',
+      showCloseIcon: true,
+      classNames: { container: 'w-[480px] py-7 px-8 bg-black' },
+      Body: (
+        <>
+          <BugReportToast />
+          <BugReportForm onSubmitted={onCancel ?? (() => {})} />
+        </>
+      ),
+    }));
+}

--- a/src/features/bug-report/ui/bug-report-form.component.tsx
+++ b/src/features/bug-report/ui/bug-report-form.component.tsx
@@ -20,12 +20,11 @@ type Props = {
 
 export function BugReportForm({ onSubmitted }: Props) {
   const t = useI18n();
-  const { register, handleSubmit, watch, formState } = useForm<BugReportSchema>({
+  const { register, handleSubmit, formState } = useForm<BugReportSchema>({
     resolver: zodResolver(bugReportSchema),
     mode: 'onChange',
     defaultValues: { content: '' },
   });
-  const content = watch('content') ?? '';
   const mutation = useSubmitBugReport();
   const toast = useBugReportToast();
 
@@ -60,19 +59,9 @@ export function BugReportForm({ onSubmitted }: Props) {
         aria-label={t.bug_report.title.report_bug}
         data-testid='bug-report-content'
       />
-      <div className='flex justify-between'>
-        <Typography type='detail2' className='text-gray-300'>
-          {t.bug_report.help}
-        </Typography>
-        <Typography
-          type='detail2'
-          className={
-            content.length > BUG_REPORT_CONTENT_MAX * 0.9 ? 'text-red-400' : 'text-gray-300'
-          }
-        >
-          {content.length}/{BUG_REPORT_CONTENT_MAX}
-        </Typography>
-      </div>
+      <Typography type='detail2' className='text-gray-300'>
+        {t.bug_report.help}
+      </Typography>
       {errorMessageKey && (
         <Typography type='detail2' className='text-red-400'>
           {t.bug_report.validation[errorMessageKey]}

--- a/src/features/bug-report/ui/bug-report-form.component.tsx
+++ b/src/features/bug-report/ui/bug-report-form.component.tsx
@@ -1,0 +1,96 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import { TextButton } from '@/shared/ui/components/text-button';
+import { TextArea } from '@/shared/ui/components/textarea';
+import { Typography } from '@/shared/ui/components/typography';
+import {
+  bugReportSchema,
+  BUG_REPORT_CONTENT_MAX,
+  type BugReportSchema,
+} from '../model/bug-report-schema';
+import { useBugReportToast } from '../model/use-bug-report-toast.hook';
+import { useSubmitBugReport } from '../model/use-submit-bug-report.hook';
+
+type Props = {
+  onSubmitted: () => void;
+};
+
+export function BugReportForm({ onSubmitted }: Props) {
+  const t = useI18n();
+  const { register, handleSubmit, watch, formState } = useForm<BugReportSchema>({
+    resolver: zodResolver(bugReportSchema),
+    mode: 'onChange',
+    defaultValues: { content: '' },
+  });
+  const content = watch('content') ?? '';
+  const mutation = useSubmitBugReport();
+  const toast = useBugReportToast();
+
+  const onSubmit = (data: BugReportSchema) => {
+    mutation.mutate(
+      { content: data.content },
+      {
+        onSuccess: () => {
+          toast.show({ severity: 'success', message: t.bug_report.toast.success });
+          onSubmitted();
+        },
+        onError: (err: unknown) => {
+          const status = (err as { response?: { status?: number } })?.response?.status;
+          toast.show({
+            severity: 'error',
+            message: status === 429 ? t.bug_report.toast.rate_limit : t.bug_report.toast.error,
+          });
+        },
+      }
+    );
+  };
+
+  const errorMessageKey = formState.errors.content?.message as 'too_short' | 'too_long' | undefined;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4'>
+      <TextArea
+        {...register('content')}
+        rows={6}
+        placeholder={t.bug_report.placeholder}
+        maxLength={BUG_REPORT_CONTENT_MAX}
+        aria-label={t.bug_report.title.report_bug}
+        data-testid='bug-report-content'
+      />
+      <div className='flex justify-between'>
+        <Typography type='detail2' className='text-gray-300'>
+          {t.bug_report.help}
+        </Typography>
+        <Typography
+          type='detail2'
+          className={
+            content.length > BUG_REPORT_CONTENT_MAX * 0.9 ? 'text-red-400' : 'text-gray-300'
+          }
+        >
+          {content.length}/{BUG_REPORT_CONTENT_MAX}
+        </Typography>
+      </div>
+      {errorMessageKey && (
+        <Typography type='detail2' className='text-red-400'>
+          {t.bug_report.validation[errorMessageKey]}
+        </Typography>
+      )}
+      <div className='flex justify-end gap-3'>
+        <TextButton onClick={onSubmitted} type='button'>
+          {t.bug_report.btn.cancel}
+        </TextButton>
+        <Button
+          type='submit'
+          color='primary'
+          disabled={!formState.isValid || mutation.isPending}
+          data-testid='bug-report-submit'
+        >
+          {t.bug_report.btn.submit}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/bug-report/ui/bug-report-toast.tsx
+++ b/src/features/bug-report/ui/bug-report-toast.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+import { useBugReportToast } from '../model/use-bug-report-toast.hook';
+
+const ACCENT: Record<string, string> = {
+  success: 'border-l-green-400',
+  error: 'border-l-red-300',
+};
+
+export function BugReportToast() {
+  const current = useBugReportToast((s) => s.current);
+  const dismiss = useBugReportToast((s) => s.dismiss);
+  if (!current) return null;
+  return (
+    <div
+      data-testid='bug-report-toast'
+      role='status'
+      className={cn(
+        'pointer-events-auto w-full bg-gray-800 border border-gray-700 rounded-[6px] border-l-[3px] mb-3',
+        ACCENT[current.severity]
+      )}
+    >
+      <div className='px-4 py-3 flex items-start gap-3'>
+        <Typography type='detail2' className='text-gray-50 flex-1'>
+          {current.message}
+        </Typography>
+        <button
+          type='button'
+          onClick={dismiss}
+          data-testid='bug-report-toast-close'
+          className='text-gray-400 hover:text-gray-200 leading-none px-1 -mt-0.5'
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/bug-report/ui/pf-bug-icon.tsx
+++ b/src/features/bug-report/ui/pf-bug-icon.tsx
@@ -1,0 +1,32 @@
+import type { SVGProps } from 'react';
+
+// lucide Bug 시각 미러. 의존성 추가 없이 자체 SVG.
+const PFBug = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    width={24}
+    height={24}
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth={2}
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-hidden='true'
+    {...props}
+  >
+    <path d='m8 2 1.88 1.88' />
+    <path d='M14.12 3.88 16 2' />
+    <path d='M9 7.13v-1a3.003 3.003 0 1 1 6 0v1' />
+    <path d='M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6' />
+    <path d='M12 20v-9' />
+    <path d='M6.53 9C4.6 8.8 3 7.1 3 5' />
+    <path d='M6 13H2' />
+    <path d='M3 21c0-2.1 1.7-3.9 3.8-4' />
+    <path d='M20.97 5c0 2.1-1.6 3.8-3.5 4' />
+    <path d='M22 13h-4' />
+    <path d='M17.2 17c2.1.1 3.8 1.9 3.8 4' />
+  </svg>
+);
+
+export default PFBug;

--- a/src/shared/api/http/services/bug-reports.ts
+++ b/src/shared/api/http/services/bug-reports.ts
@@ -1,0 +1,20 @@
+import { Singleton } from '@/shared/lib/decorators/singleton';
+import HTTPClient from '../client/client';
+
+export interface SubmitBugReportRequest {
+  content: string;
+  partyroomId?: number;
+}
+
+export interface SubmitBugReportResponse {
+  bugReportId: number;
+}
+
+@Singleton
+export default class BugReportsService extends HTTPClient {
+  private ROUTE_V1 = 'v1/voc/bug-reports';
+
+  public submit(body: SubmitBugReportRequest) {
+    return this.post<SubmitBugReportResponse>(this.ROUTE_V1, body);
+  }
+}

--- a/src/shared/api/http/services/index.ts
+++ b/src/shared/api/http/services/index.ts
@@ -1,9 +1,11 @@
+import BugReportsService from './bug-reports';
 import CrewsService from './crews';
 import DjsService from './djs';
 import PartyroomsService from './partyrooms';
 import PlaylistsService from './playlists';
 import UsersService from './users';
 
+export const bugReportsService = new BugReportsService();
 export const crewsService = new CrewsService();
 export const djsService = new DjsService();
 export const partyroomsService = new PartyroomsService();

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -332,5 +332,26 @@
         "label": "Emergency Notice"
       }
     }
+  },
+  "bug_report": {
+    "btn": {
+      "open": "Report a Bug",
+      "submit": "Submit",
+      "cancel": "Cancel"
+    },
+    "title": {
+      "report_bug": "Report a Bug"
+    },
+    "placeholder": "What bug did you experience? (5–2000 chars)",
+    "help": "Our team will review and respond. We may not be able to reply.",
+    "toast": {
+      "success": "Feedback submitted",
+      "rate_limit": "Please try again in a moment",
+      "error": "Submission failed"
+    },
+    "validation": {
+      "too_short": "Please enter at least 5 characters",
+      "too_long": "Up to 2000 characters allowed"
+    }
   }
 }

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -332,5 +332,26 @@
         "label": "긴급 공지"
       }
     }
+  },
+  "bug_report": {
+    "btn": {
+      "open": "버그 제보",
+      "submit": "제출",
+      "cancel": "취소"
+    },
+    "title": {
+      "report_bug": "버그 제보"
+    },
+    "placeholder": "어떤 버그를 경험하셨나요? (5~2000자)",
+    "help": "운영팀이 확인 후 조치합니다. 답변이 어려울 수 있어요.",
+    "toast": {
+      "success": "피드백이 등록되었습니다",
+      "rate_limit": "잠시 후 다시 시도해주세요",
+      "error": "제출에 실패했어요"
+    },
+    "validation": {
+      "too_short": "최소 5자 이상 입력해주세요",
+      "too_long": "최대 2000자까지 입력할 수 있어요"
+    }
   }
 }

--- a/src/widgets/layouts/ui/header.component.test.tsx
+++ b/src/widgets/layouts/ui/header.component.test.tsx
@@ -12,6 +12,9 @@ vi.mock('@/entities/me', () => ({
 vi.mock('@/features/sign-out', () => ({
   useSignOut: vi.fn(),
 }));
+vi.mock('@/features/bug-report', () => ({
+  BugReportButton: () => <button data-testid='bug-report-button' />,
+}));
 vi.mock('@/shared/lib/localization/i18n.context');
 vi.mock('@/shared/lib/localization/language-change-menu.component', () => ({
   __esModule: true,
@@ -33,6 +36,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (useI18n as Mock).mockReturnValue({
     common: { btn: { logout: 'Logout' } },
+    bug_report: { btn: { open: 'Report a Bug' } },
   });
   (useSignOut as Mock).mockReturnValue(vi.fn());
 });

--- a/src/widgets/layouts/ui/header.component.tsx
+++ b/src/widgets/layouts/ui/header.component.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { FC } from 'react';
 import { Menu } from '@headlessui/react';
 import { useFetchMe } from '@/entities/me';
+import { BugReportButton } from '@/features/bug-report';
 import { useSignOut } from '@/features/sign-out';
 import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import { cn } from '@/shared/lib/functions/cn';
@@ -71,6 +72,7 @@ const Header: FC<Props> = ({ withLogo }) => {
             </Menu>
           )}
 
+          {me && <BugReportButton />}
           <LanguageChangeMenu />
         </div>
       </header>


### PR DESCRIPTION
## 요약

pfplay-platform PR #245 의 web frontend. Header 우측 🐛 버튼 + 자유텍스트 모달.

## 산출물

- PFBug SVG 아이콘 (자체 SVG, lucide 미사용 — features 내부에 둠, shared/ui/icons 디렉토리 gitignored 회피)
- BugReportsService (HTTPClient 상속, `POST /api/v1/voc/bug-reports`)
- `features/bug-report` slice:
  - model: zod schema (5~2000) / useSubmitBugReport (react-query + usePathname partyroomId 추출) / useBugReportToast (zustand store + 3s auto-dismiss)
  - ui: BugReportForm (react-hook-form + zod, content count, toast on success/error/429) / BugReportDialog (useDialog wrapper, BugReportToast + BugReportForm Body) / BugReportButton (Header 진입 아이콘) / BugReportToast (mini-toast, EventToast 스타일 미러)
- i18n ko/en `bug_report.*` 키 추가 (직접 json 수정, \`yarn i18n\` 미실행 — feedback_pfplay_web_i18n_drift)
- Header 1줄 통합: \`{me && <BugReportButton />}\` (GT 분기 바깥, LanguageChangeMenu sibling — 게스트 포함 전 인증 사용자 노출)
- 자동 메타: page_url(Referer, 백엔드), user_agent(헤더, 백엔드), partyroomId(\`usePathname\` \`/parties/{id}\` 매칭)

## 테스트

- yarn tsc 0 errors
- vitest 1283/1283 PASS (회귀 0, 신규 핵심 컴포넌트만 — 단위 테스트는 follow-up)
- Header test mock 보강 (BugReportButton stub + bug_report.btn.open i18n key)

## 머지 의존성

backend PR #245 머지 + dev 배포 후 진입 권장. 단 본 PR 자체는 tsc/vitest GREEN 으로 머지 가능 (실서버 호출은 backend 머지 전까지 404).

## 스펙/계획

- spec: \`pfplay-platform/docs/superpowers/specs/2026-05-21-voc-bug-report-design.md\` §3-6
- plan: \`pfplay-platform/docs/superpowers/plans/2026-05-21-voc-bug-report.md\` Chunk 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)