### PR TITLE
feat(guest): 게스트 플레이리스트/검색/파티룸생성 가드 + AM 파티룸 생성 허용

### DIFF
--- a/src/features/partyroom/create/ui/card.component.test.tsx
+++ b/src/features/partyroom/create/ui/card.component.test.tsx
@@ -1,0 +1,53 @@
+vi.mock('@/entities/me', () => ({
+  useIsGuest: vi.fn(),
+}));
+vi.mock('@/features/sign-in/by-social', () => ({
+  useInformSocialType: vi.fn(() => vi.fn()),
+}));
+vi.mock('@/shared/lib/localization/i18n.context');
+vi.mock('@/shared/lib/localization/lang.context', () => ({
+  useLang: vi.fn(() => 'ko'),
+}));
+vi.mock('@/shared/ui/components/dialog');
+vi.mock('./form.component', () => ({
+  __esModule: true,
+  default: () => <div data-testid='create-form' />,
+}));
+vi.mock('next/image', () => ({ __esModule: true, default: () => <img alt='' /> }));
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import PartyroomCreateCard from './card.component';
+
+const mockOpenDialog = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(false));
+  (useI18n as Mock).mockReturnValue({
+    lobby: { title: { be_a_host: 'Be a Host' }, para: { freely_host: 'Freely host' } },
+    createparty: { title: { create_party: 'Create' }, para: { cancel_confirm: 'a\nb' } },
+  });
+  (useDialog as Mock).mockReturnValue({ openDialog: mockOpenDialog, openConfirmDialog: vi.fn() });
+});
+
+describe('PartyroomCreateCard', () => {
+  test('멤버(AM/FM)가 클릭하면 파티룸 생성 다이얼로그를 연다 (지갑 게이트 없음)', async () => {
+    render(<PartyroomCreateCard />);
+    fireEvent.click(screen.getByTestId('create-partyroom-button'));
+    await waitFor(() => expect(mockOpenDialog).toHaveBeenCalled());
+  });
+
+  test('게스트가 클릭하면 소셜 모달 유도 + 다이얼로그 미오픈', async () => {
+    const mockInform = vi.fn();
+    (useInformSocialType as Mock).mockReturnValue(mockInform);
+    (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(true));
+    render(<PartyroomCreateCard />);
+    fireEvent.click(screen.getByTestId('create-partyroom-button'));
+    await waitFor(() => expect(mockInform).toHaveBeenCalled());
+    expect(mockOpenDialog).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/partyroom/create/ui/card.component.tsx
+++ b/src/features/partyroom/create/ui/card.component.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Image from 'next/image';
-import { useInformWalletLinkage, useIsWalletLinked } from '@/entities/wallet';
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import { Language } from '@/shared/lib/localization/constants';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useLang } from '@/shared/lib/localization/lang.context';
@@ -12,12 +13,14 @@ export default function PartyroomCreateCard() {
   const t = useI18n();
   const lang = useLang();
   const { openDialog, openConfirmDialog } = useDialog();
-  const isWalletLinked = useIsWalletLinked();
-  const informWalletLinkage = useInformWalletLinkage();
+  const isGuest = useIsGuest();
+  const informSocialType = useInformSocialType();
 
+  // 게스트(GT)만 차단. AM/FM 모두 파티룸 생성 가능 (backend PartyroomCreationPolicy = FM|AM).
+  // 지갑 연결 게이트는 제거 — 지갑 미연결 AM 도 생성 가능해야 하므로(지갑=FM 승급 경로는 별개).
   const handleClickBeAHostBtn = async () => {
-    if (!(await isWalletLinked())) {
-      informWalletLinkage();
+    if (await isGuest()) {
+      informSocialType();
       return;
     }
 

--- a/src/features/playlist/add/ui/entry-button.component.test.tsx
+++ b/src/features/playlist/add/ui/entry-button.component.test.tsx
@@ -1,0 +1,45 @@
+vi.mock('@/entities/me', () => ({
+  useIsGuest: vi.fn(),
+}));
+vi.mock('@/features/sign-in/by-social', () => ({
+  useInformSocialType: vi.fn(() => vi.fn()),
+}));
+vi.mock('@/shared/lib/localization/i18n.context');
+vi.mock('./form.component', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import EntryButton from './entry-button.component';
+import useAddPlaylistDialog from './form.component';
+
+const mockOpenAddDialog = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useAddPlaylistDialog as Mock).mockReturnValue(mockOpenAddDialog);
+  (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(false));
+  (useI18n as Mock).mockReturnValue({ playlist: { btn: { add_list: 'Add List' } } });
+});
+
+describe('EntryButton', () => {
+  test('멤버가 클릭하면 플레이리스트 생성 다이얼로그를 연다', async () => {
+    render(<EntryButton />);
+    fireEvent.click(screen.getByTestId('add-playlist-button'));
+    await waitFor(() => expect(mockOpenAddDialog).toHaveBeenCalled());
+  });
+
+  test('게스트가 클릭하면 소셜 모달 유도 + 다이얼로그 미오픈', async () => {
+    const mockInform = vi.fn();
+    (useInformSocialType as Mock).mockReturnValue(mockInform);
+    (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(true));
+    render(<EntryButton />);
+    fireEvent.click(screen.getByTestId('add-playlist-button'));
+    await waitFor(() => expect(mockInform).toHaveBeenCalled());
+    expect(mockOpenAddDialog).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/playlist/add/ui/entry-button.component.tsx
+++ b/src/features/playlist/add/ui/entry-button.component.tsx
@@ -1,3 +1,5 @@
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import { PFAdd } from '@/shared/ui/icons';
@@ -6,6 +8,16 @@ import useAddPlaylistDialog from './form.component';
 const EntryButton = () => {
   const t = useI18n();
   const openAddDialog = useAddPlaylistDialog();
+  const isGuest = useIsGuest();
+  const informSocialType = useInformSocialType();
+
+  const handleClick = async () => {
+    if (await isGuest()) {
+      informSocialType();
+      return;
+    }
+    openAddDialog();
+  };
 
   return (
     <Button
@@ -13,7 +25,7 @@ const EntryButton = () => {
       variant='outline'
       color='secondary'
       Icon={<PFAdd />}
-      onClick={openAddDialog}
+      onClick={handleClick}
       data-testid='add-playlist-button'
     >
       {t.playlist.btn.add_list}

--- a/src/widgets/partyroom-display-board/ui/parts/add-tracks-button.component.test.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/add-tracks-button.component.test.tsx
@@ -1,14 +1,29 @@
+const mockExecute = vi.fn();
+
+vi.mock('@/entities/me', () => ({
+  useIsGuest: vi.fn(),
+}));
+vi.mock('@/features/sign-in/by-social', () => ({
+  useInformSocialType: vi.fn(() => vi.fn()),
+}));
 vi.mock('@/features/playlist/add-tracks', () => ({
   AddTracksToPlaylist: ({ children }: { children: (props: any) => React.ReactNode }) =>
-    children({ text: 'Add Tracks', execute: vi.fn() }),
+    children({ text: 'Add Tracks', execute: mockExecute }),
 }));
 vi.mock('@/shared/ui/icons', () => ({
   PFAddPlaylist: () => <svg data-testid='add-icon' />,
 }));
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import AddTracksButton from './add-tracks-button.component';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(false));
+});
 
 describe('AddTracksButton', () => {
   test('Add Tracks 텍스트를 렌더링한다', () => {
@@ -19,5 +34,21 @@ describe('AddTracksButton', () => {
   test('아이콘을 렌더링한다', () => {
     render(<AddTracksButton />);
     expect(screen.getByTestId('add-icon')).toBeTruthy();
+  });
+
+  test('멤버가 클릭하면 트랙 추가(execute)를 실행한다', async () => {
+    render(<AddTracksButton />);
+    fireEvent.click(screen.getByText('Add Tracks'));
+    await waitFor(() => expect(mockExecute).toHaveBeenCalled());
+  });
+
+  test('게스트가 클릭하면 소셜 모달 유도 + execute 미실행', async () => {
+    const mockInform = vi.fn();
+    (useInformSocialType as Mock).mockReturnValue(mockInform);
+    (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(true));
+    render(<AddTracksButton />);
+    fireEvent.click(screen.getByText('Add Tracks'));
+    await waitFor(() => expect(mockInform).toHaveBeenCalled());
+    expect(mockExecute).not.toHaveBeenCalled();
   });
 });

--- a/src/widgets/partyroom-display-board/ui/parts/add-tracks-button.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/add-tracks-button.component.tsx
@@ -1,12 +1,29 @@
+import { useIsGuest } from '@/entities/me';
 import { AddTracksToPlaylist } from '@/features/playlist/add-tracks';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import { Button } from '@/shared/ui/components/button';
 import { PFAddPlaylist } from '@/shared/ui/icons';
 
 export default function AddTracksButton() {
+  const isGuest = useIsGuest();
+  const informSocialType = useInformSocialType();
+
   return (
     <AddTracksToPlaylist>
       {({ text, execute }) => (
-        <Button size='md' variant='fill' color='primary' Icon={<PFAddPlaylist />} onClick={execute}>
+        <Button
+          size='md'
+          variant='fill'
+          color='primary'
+          Icon={<PFAddPlaylist />}
+          onClick={async () => {
+            if (await isGuest()) {
+              informSocialType();
+              return;
+            }
+            execute();
+          }}
+        >
           {text}
         </Button>
       )}

--- a/src/widgets/sidebar/ui/sidebar.component.test.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.test.tsx
@@ -19,8 +19,9 @@ vi.mock('@/shared/ui/icons', () => ({
   PFHeadset: (props: any) => <svg data-testid='headset-icon' {...props} />,
 }));
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useIsGuest, useSuspenseFetchMe } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { useDialog } from '@/shared/ui/components/dialog';
@@ -58,10 +59,20 @@ describe('Sidebar', () => {
     expect(screen.getByTestId('headset-icon')).toBeTruthy();
   });
 
-  test('플레이리스트 버튼 클릭 시 setPlaylistDrawer를 호출한다', () => {
+  test('멤버가 플레이리스트 버튼 클릭 시 setPlaylistDrawer를 호출한다', async () => {
     render(<Sidebar className='test' onClickAvatarSetting={vi.fn()} />);
     fireEvent.click(screen.getByText('Playlist'));
-    expect(mockSetPlaylistDrawer).toHaveBeenCalled();
+    await waitFor(() => expect(mockSetPlaylistDrawer).toHaveBeenCalled());
+  });
+
+  test('게스트가 플레이리스트 버튼 클릭 시 소셜 모달 유도 + drawer 미오픈', async () => {
+    const mockInform = vi.fn();
+    (useInformSocialType as Mock).mockReturnValue(mockInform);
+    (useIsGuest as Mock).mockReturnValue(vi.fn().mockResolvedValue(true));
+    render(<Sidebar className='test' onClickAvatarSetting={vi.fn()} />);
+    fireEvent.click(screen.getByText('Playlist'));
+    await waitFor(() => expect(mockInform).toHaveBeenCalled());
+    expect(mockSetPlaylistDrawer).not.toHaveBeenCalled();
   });
 
   test('extraButtons를 렌더링한다', () => {

--- a/src/widgets/sidebar/ui/sidebar.component.tsx
+++ b/src/widgets/sidebar/ui/sidebar.component.tsx
@@ -34,7 +34,11 @@ export default function Sidebar({ className, onClickAvatarSetting, extraButtons 
   const setPlaylistDrawer = useUIState((state) => state.setPlaylistDrawer);
   const informSocialType = useInformSocialType();
 
-  const togglePlaylist = () => {
+  const togglePlaylist = async () => {
+    if (await isGuest()) {
+      informSocialType();
+      return;
+    }
     setPlaylistDrawer((prev) => mergeDeep(prev, { open: !prev.open }));
   };
 


### PR DESCRIPTION
## 요약
게스트(GT)가 플레이리스트 관련 기능과 파티룸 생성에 진입할 때 소셜 로그인 유도 모달로 보내고, 멤버(AM/FM)는 정상 진행하도록 클라이언트 가드를 추가. 프로필/DJ큐 버튼의 기존 `isGuest()` + `informSocialType()` 패턴 재사용.

## ① 게스트 가드 (3곳)
| 진입점 | 파일 | 동작 |
|---|---|---|
| 사이드바 플레이리스트 버튼 | `widgets/sidebar` | 게스트 → 소셜 모달, drawer 미오픈 |
| 플레이리스트 생성 | `features/playlist/add/entry-button` | 게스트 → 소셜 모달, 생성 다이얼로그 미오픈 |
| 트랙추가·음악검색 진입 | `partyroom-display-board/add-tracks-button` | 게스트 → 소셜 모달, execute 미실행 (render-prop 래핑) |

> add-tracks-button 은 사이드바 drawer 외에도 파티룸 디스플레이보드/시네마 패널에 노출되므로 진입점 자체에 가드. 사이드바 가드는 drawer 진입을 막아 일반 경로를 차단.

## ② AM 파티룸 생성 허용
- `card.component`: `isWalletLinked()` 게이트 제거 → `isGuest()` 가드로 교체
- **이유**: AuthorityTier 정의상 AM=지갑 미연결 / FM=지갑 연결이라, 기존 `isWalletLinked()` 게이트가 사실상 **FM-only** 와 동치였음. backend 는 PR #249 로 파티룸 생성을 FM+AM 허용했는데 프론트 wallet 게이트가 AM 을 막고 있었음. 게이트 제거로 정합 (게스트만 차단 유지).
- `useIsWalletLinked`/`useInformWalletLinkage` hook 은 향후 지갑 연결 유도(아바타/승급)용으로 `entities/wallet` 에 보존, card 의 호출만 제거.

## 검증
- 각 컴포넌트 게스트/멤버 케이스 테스트 추가 (sidebar 5, entry-button 2, add-tracks-button 4, card 2)
- 전체 vitest **1290 passed**, tsc 0

## Test plan
- [x] 게스트: 4곳 모두 소셜 모달 유도 + 원동작 미실행
- [x] 멤버(AM/FM): 4곳 모두 정상 진행 (파티룸 생성은 지갑 게이트 없이)
- [x] 전체 vitest 회귀
- [ ] stg 배포 후 게스트/AM 실제 흐름 확인 (사후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)