### PR TITLE
fix(ui): 소셜모달 X버튼 + layout shift + 버그아이콘 배치 + 버튼 정렬 (UI polish)

### DIFF
--- a/src/features/bug-report/ui/bug-report-form.component.tsx
+++ b/src/features/bug-report/ui/bug-report-form.component.tsx
@@ -67,7 +67,7 @@ export function BugReportForm({ onSubmitted }: Props) {
           {t.bug_report.validation[errorMessageKey]}
         </Typography>
       )}
-      <div className='flex justify-end gap-3'>
+      <div className='flex items-center justify-end gap-3'>
         <TextButton onClick={onSubmitted} type='button'>
           {t.bug_report.btn.cancel}
         </TextButton>

--- a/src/shared/ui/components/dialog/dialog.component.tsx
+++ b/src/shared/ui/components/dialog/dialog.component.tsx
@@ -138,33 +138,33 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
               <HUDialog.Panel
                 data-testid='dialog-panel'
                 className={cn(
-                  'pt-[52px] px-[32px] pb-[32px] w-[440px] max-w-full transform rounded-[6px] bg-gray-800 border border-gray-700 transition-all',
+                  'relative pt-[52px] px-[32px] pb-[32px] w-[440px] max-w-full transform rounded-[6px] bg-gray-800 border border-gray-700 transition-all',
                   classNames?.container
                 )}
                 style={{
                   overflowWrap: 'anywhere',
                 }}
               >
+                {showCloseIcon && (
+                  <TextButton
+                    data-testid='dialog-close-button'
+                    onClick={handleClose}
+                    Icon={<PFClose width={24} height={24} />}
+                    className='absolute top-[16px] right-[16px] z-10'
+                  />
+                )}
+
                 {title && (
                   <HUDialog.Title
                     as='div'
                     className={cn([
-                      'relative flexCol gap-[12px] mb-[24px]',
+                      'flexCol gap-[12px] mb-[24px]',
                       {
                         'items-start': titleAlign === 'left',
                         'items-center': titleAlign === 'center',
                       },
                     ])}
                   >
-                    {showCloseIcon && (
-                      <TextButton
-                        data-testid='dialog-close-button'
-                        onClick={handleClose}
-                        Icon={<PFClose width={24} height={24} />}
-                        className='absolute top-[2.5px] right-0'
-                      />
-                    )}
-
                     {Title}
 
                     {Sub}

--- a/src/shared/ui/foundation/globals.css
+++ b/src/shared/ui/foundation/globals.css
@@ -9,6 +9,9 @@
   }
   body {
     @apply text-white bg-black min-h-screen;
+    /* scrollbar 가 사라져도(모달/드로어 overflow-hidden) gutter 공간을 유지해
+       콘텐츠가 우측으로 밀리는 layout shift 를 방지한다. */
+    scrollbar-gutter: stable;
   }
   body.scroll-hidden {
     @apply overflow-hidden;

--- a/src/widgets/layouts/ui/header.component.tsx
+++ b/src/widgets/layouts/ui/header.component.tsx
@@ -72,8 +72,8 @@ const Header: FC<Props> = ({ withLogo }) => {
             </Menu>
           )}
 
-          {me && <BugReportButton />}
           <LanguageChangeMenu />
+          {me && <BugReportButton />}
         </div>
       </header>
     </>


### PR DESCRIPTION
## 요약
staging UI 미흡 4건 일괄 수정 (① 소셜모달 X버튼 + ⑤a/b/d Bug Report UI).

| # | 항목 | 수정 |
|---|---|---|
| ① | 소셜 로그인 모달 X버튼이 title 과 겹침 | `dialog.component`: X버튼을 title 블록 → **panel 레벨**(relative + `absolute top-[16px] right-[16px]`)로 이동. pt-[52px] 상단 영역 고정, title 과 분리 |
| ⑤a | 모달/드롭다운 열 때 scrollbar 사라지며 우측 이동(layout shift) | `globals.css` body 에 `scrollbar-gutter: stable`. scrollbar 사라져도 gutter 유지 → shift 0 (전역 적용, Edge 지원) |
| ⑤b | 버그 아이콘 위치 | `header`: BugReportButton 을 LanguageChangeMenu **오른쪽**으로 순서 swap |
| ⑤d | Cancel/Submit 버튼 텍스트 높이 불일치 | `bug-report-form`: 버튼 컨테이너에 `items-center` → 높이 다른 TextButton/Button 세로 중앙 정렬 |

## 검증
- dialog(10)/header(5)/use-dialog(6) 테스트 회귀 GREEN
- 전체 vitest 1290 passed, tsc 0
- **시각 변경(X버튼 위치/layout shift/버튼 정렬)은 Vercel preview 에서 확인 권장**

## 비고
- ① 게스트 가드 로직은 PR #324(머지됨)에서 처리, 본 PR 은 그 소셜 모달의 X버튼 위치만 (공통 dialog)
- ⑤c(AuthContext)는 platform PR #254(머지됨)에서 별도 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)