### PR TITLE
feat(dj): 디제잉 대기 중 플레이리스트 변경 (Change Playlist)

### DIFF
--- a/src/shared/api/http/services/djs.ts
+++ b/src/shared/api/http/services/djs.ts
@@ -1,5 +1,6 @@
 import {
   RegisterMeToQueuePayload,
+  ChangeMyPlaylistPayload,
   UnregisterMeFromQueuePayload,
   UnregisterDjFromQueuePayload,
   GetPlaybackHistoryPayload,
@@ -16,6 +17,10 @@ export default class DjsService extends HTTPClient implements DjsClient {
 
   public registerMeToQueue({ partyroomId, ...body }: RegisterMeToQueuePayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue`, body);
+  }
+
+  public changeMyPlaylist({ partyroomId, ...body }: ChangeMyPlaylistPayload) {
+    return this.patch<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue/me`, body);
   }
 
   public unregisterMeFromQueue({ partyroomId }: UnregisterMeFromQueuePayload) {

--- a/src/shared/api/http/types/djs.ts
+++ b/src/shared/api/http/types/djs.ts
@@ -5,6 +5,11 @@ export type RegisterMeToQueuePayload = {
   playlistId: Playlist['id'];
 };
 
+export type ChangeMyPlaylistPayload = {
+  partyroomId: number;
+  playlistId: Playlist['id'];
+};
+
 export type UnregisterMeFromQueuePayload = {
   partyroomId: number;
 };
@@ -30,6 +35,7 @@ export type SkipPlaybackPayload = {
 
 export interface DjsClient {
   registerMeToQueue: (payload: RegisterMeToQueuePayload) => Promise<void>;
+  changeMyPlaylist: (payload: ChangeMyPlaylistPayload) => Promise<void>;
   unregisterMeFromQueue: (payload: UnregisterMeFromQueuePayload) => Promise<void>;
   unregisterDjFromQueue: (payload: UnregisterDjFromQueuePayload) => Promise<void>;
   getPlaybackHistories: (payload: GetPlaybackHistoryPayload) => Promise<PlaybackHistoryItem[]>;

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -65,6 +65,10 @@ export type EventPropertyMap = {
     partyroom_id: number;
     playlist_id: number;
   };
+  'DJ Playlist Changed': {
+    partyroom_id: number;
+    playlist_id: number;
+  };
   'DJ Deregistered': {
     partyroom_id: number;
     reason: DjDeregisterReason;

--- a/src/widgets/partyroom-djing-dialog/api/use-change-my-playlist.mutation.ts
+++ b/src/widgets/partyroom-djing-dialog/api/use-change-my-playlist.mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { djsService } from '@/shared/api/http/services';
+import { APIError } from '@/shared/api/http/types/@shared';
+import { ChangeMyPlaylistPayload } from '@/shared/api/http/types/djs';
+import { track } from '@/shared/lib/analytics';
+
+export const useChangeMyPlaylist = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, AxiosError<APIError>, ChangeMyPlaylistPayload>({
+    mutationFn: (request) => djsService.changeMyPlaylist(request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.DjingQueue, variables.partyroomId],
+      });
+      track('DJ Playlist Changed', {
+        partyroom_id: variables.partyroomId,
+        playlist_id: variables.playlistId,
+      });
+    },
+  });
+};

--- a/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/body.component.tsx
@@ -17,6 +17,7 @@ import { DjListItem } from '@/shared/ui/components/dj-list-item';
 import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFClose } from '@/shared/ui/icons';
+import ChangePlaylistButton from './change-playlist-button.component';
 import RegisterButton from './register-button.component';
 import UnregisterButton from './unregister-button.component';
 import { useDjingQueue } from '../lib/djing-queue.context';
@@ -137,16 +138,7 @@ export default function Body({ onCancel }: Props) {
                     suffixTagValue={isMe ? 'Me' : undefined}
                   />
                   <div className='flex items-center gap-2'>
-                    {isMe && (
-                      <Button
-                        color='primary'
-                        variant='outline'
-                        size='sm'
-                        onClick={() => alert('Not Impl')}
-                      >
-                        {t.playlist.btn.change_playlist}
-                      </Button>
-                    )}
+                    {isMe && <ChangePlaylistButton />}
                     {canDeleteDjFromQueue && (
                       <Button
                         size='sm'

--- a/src/widgets/partyroom-djing-dialog/ui/change-playlist-button.component.test.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/change-playlist-button.component.test.tsx
@@ -1,0 +1,46 @@
+vi.mock('@/features/partyroom/select-playlist-for-djing', () => ({
+  useSelectPlaylistForDjing: vi.fn(),
+}));
+vi.mock('@/features/playlist/list', () => ({
+  useFetchPlaylists: vi.fn(() => ({ data: [] })),
+}));
+vi.mock('../lib/partyroom-id.context', () => ({
+  usePartyroomId: vi.fn(() => 1),
+}));
+vi.mock('../api/use-change-my-playlist.mutation', () => ({
+  useChangeMyPlaylist: vi.fn(),
+}));
+vi.mock('@/shared/lib/localization/i18n.context');
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useSelectPlaylistForDjing } from '@/features/partyroom/select-playlist-for-djing';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import ChangePlaylistButton from './change-playlist-button.component';
+import { useChangeMyPlaylist } from '../api/use-change-my-playlist.mutation';
+
+const mockMutate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useChangeMyPlaylist as Mock).mockReturnValue({ mutate: mockMutate });
+  (useI18n as Mock).mockReturnValue({ playlist: { btn: { change_playlist: 'Change Playlist' } } });
+});
+
+describe('ChangePlaylistButton', () => {
+  test('플레이리스트 선택 시 changeMyPlaylist(partyroomId, playlistId) 호출', async () => {
+    (useSelectPlaylistForDjing as Mock).mockReturnValue(vi.fn().mockResolvedValue({ id: 42 }));
+    render(<ChangePlaylistButton />);
+    fireEvent.click(screen.getByTestId('change-playlist-button'));
+    await waitFor(() =>
+      expect(mockMutate).toHaveBeenCalledWith({ partyroomId: 1, playlistId: 42 })
+    );
+  });
+
+  test('선택 취소(null) 시 mutation 미호출', async () => {
+    (useSelectPlaylistForDjing as Mock).mockReturnValue(vi.fn().mockResolvedValue(null));
+    render(<ChangePlaylistButton />);
+    fireEvent.click(screen.getByTestId('change-playlist-button'));
+    await waitFor(() => expect(useSelectPlaylistForDjing).toHaveBeenCalled());
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/partyroom-djing-dialog/ui/change-playlist-button.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/change-playlist-button.component.tsx
@@ -1,0 +1,33 @@
+import { useSelectPlaylistForDjing } from '@/features/partyroom/select-playlist-for-djing';
+import { useFetchPlaylists } from '@/features/playlist/list';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import { useChangeMyPlaylist } from '../api/use-change-my-playlist.mutation';
+import { usePartyroomId } from '../lib/partyroom-id.context';
+
+export default function ChangePlaylistButton() {
+  const t = useI18n();
+  const { data: playlists = [] } = useFetchPlaylists();
+  const selectPlaylist = useSelectPlaylistForDjing({ playlists });
+  const partyroomId = usePartyroomId();
+  const { mutate: changeMyPlaylist } = useChangeMyPlaylist();
+
+  const handleChangePlaylist = async () => {
+    const selected = await selectPlaylist();
+    if (!selected) return; // canceled
+
+    changeMyPlaylist({ partyroomId, playlistId: selected.id });
+  };
+
+  return (
+    <Button
+      color='primary'
+      variant='outline'
+      size='sm'
+      onClick={handleChangePlaylist}
+      data-testid='change-playlist-button'
+    >
+      {t.playlist.btn.change_playlist}
+    </Button>
+  );
+}


### PR DESCRIPTION
## 요약
백엔드 `PATCH /dj-queue/me` (E/#223, platform #244) 를 프론트에서 연결. 기존 placeholder `alert('Not Impl')` 를 실제 구현으로 교체.

## 변경
- `djs` service: `changeMyPlaylist` — `PATCH /v1/partyrooms/{id}/dj-queue/me`, body `{playlistId}`
- `useChangeMyPlaylist` mutation: DjingQueue invalidate + `'DJ Playlist Changed'` track
- `ChangePlaylistButton`: `useSelectPlaylistForDjing` 으로 playlist 선택 후 PATCH (RegisterButton 의 DJ 등록 playlist 선택 패턴 재사용)
- `body.component`: 대기열 본인(isMe) row 의 alert placeholder → `<ChangePlaylistButton/>`
- analytics events: `'DJ Playlist Changed'` (DJ Registered 와 대칭)

## 검증
- `change-playlist-button` 테스트 2건 (선택 시 PATCH / 취소 시 미호출)
- djing-dialog 9 GREEN, tsc 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)