### PR TITLE
fix(ui): 플레이리스트 드로어+모달 동시 layout shift(흔들림) 제거

### DIFF
--- a/src/shared/ui/components/drawer/drawer.component.tsx
+++ b/src/shared/ui/components/drawer/drawer.component.tsx
@@ -31,14 +31,22 @@ const Drawer = ({
   const root = usePortalRoot(DomId.DrawerRoot);
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.classList.add('scroll-hidden');
-    } else {
-      document.body.classList.remove('scroll-hidden');
+    if (!isOpen) return;
+    // 배경 스크롤 잠금(body overflow:hidden, viewport 로 전파). 전파로 <html>
+    // scrollbar 가 사라지므로 그 폭만큼 padding-right 로 보상해 콘텐츠가 좌측으로
+    // 밀리는 layout shift 를 막는다. 보상은 <body> 에 건다 — headlessui Dialog 는
+    // <html> 의 padding-right 를 자기 계산값으로 덮어쓰므로(드로어 위에서 모달을
+    // 열면 r=0 으로 계산해 보상을 0 으로 만든다), 같은 <html> 에 걸면 충돌한다.
+    // <body> 는 headlessui 가 건드리지 않아 모달 토글과 무관하게 16px 가 유지된다.
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    const prevPaddingRight = document.body.style.paddingRight;
+    document.body.classList.add('scroll-hidden');
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
-
     return () => {
       document.body.classList.remove('scroll-hidden');
+      document.body.style.paddingRight = prevPaddingRight;
     };
   }, [isOpen]);
 

--- a/src/shared/ui/foundation/globals.css
+++ b/src/shared/ui/foundation/globals.css
@@ -9,10 +9,12 @@
   }
   body {
     @apply text-white bg-black min-h-screen;
-    /* scrollbar 가 사라져도(모달/드로어 overflow-hidden) gutter 공간을 유지해
-       콘텐츠가 우측으로 밀리는 layout shift 를 방지한다. */
-    scrollbar-gutter: stable;
   }
+  /* 드로어/모달이 열리면 배경 스크롤을 잠근다. body overflow:hidden 은 viewport
+     로 전파되어 <html> scrollbar 를 제거하는데, 그 16px 보상은 Drawer 가
+     <html> 의 padding-right 로 직접 넣는다(headlessui Dialog 와 동일 메커니즘·
+     동일 요소). scrollbar-gutter(body) 는 body 가 스크롤 컨테이너가 아니라
+     무효였고, headlessui 의 html padding 과 이중 보상이 되어 제거했다. */
   body.scroll-hidden {
     @apply overflow-hidden;
   }


### PR DESCRIPTION
## 증상
플레이리스트 드로어가 활성인 상태에서 모달(DJ 대기열/음악 검색/플레이리스트 이름 지정 등)이 **열리거나 닫히는 순간 화면이 좌우로 흔들리던** 버그. 로비·파티룸 양쪽에서 재현.

## 원인 (Playwright headed 측정으로 규명)
- 페이지 scrollbar 는 `<html>`(documentElement)에 있는데, PR #325 의 `scrollbar-gutter: stable` 은 `<body>` 에 걸려 **무효**였다 (body 는 스크롤 컨테이너가 아님). 드로어 열림 시 `htmlClientW` 1424→1440 으로 gutter 를 못 지킴.
- Drawer 가 배경을 잠글 때 `body overflow:hidden` 이 viewport 로 전파되어 `<html>` scrollbar 16px 가 **보상 없이** 사라짐.
- 보상을 `<html>` padding 으로 넣으면, 모달(headlessui v2 `Dialog`)이 열릴 때 `adjustScrollbarPadding` 이 `<html>` padding-right 를 **자기 계산값(드로어가 이미 scrollbar 를 없앤 뒤라 r=0)으로 덮어써** 보상이 무력화 → 같은 `<html>` 요소를 Drawer 와 headlessui 가 두고 다툼.

## 수정
- 무효 + 이중 보상이던 `scrollbar-gutter: stable`(body) 제거
- Drawer 의 scrollbar 보상을 **`<body>` padding-right** 로 이동. headlessui 는 `<html>` 만 건드리므로 모달 토글과 무관하게 16px 보상이 유지된다 (배경 잠금은 그대로).

## 검증
- Playwright **headed** 측정(localhost dev): 드로어/모달 전 구간 콘텐츠 폭(body) **1424px 일정** (수정 전 1424↔1440 토글 → shift). headless 는 scrollbar 0px 라 재현 불가 → headed 필수였음.
- drawer 단위테스트 **7/7 통과**
- 사용자 실브라우저 확인: 흔들림 사라짐

Refs #325