### PR TITLE
fix(avatar): 아바타 설정 Face 버그 (문구섹션 비침 / 까맣게 / 가로 스크롤)

### DIFF
--- a/src/entities/avatar/lib/calculate-dimensions.test.ts
+++ b/src/entities/avatar/lib/calculate-dimensions.test.ts
@@ -68,6 +68,14 @@ describe('calculateDimensions', () => {
     expect(result.zoom).toBe(2.5);
   });
 
+  test('scale 가 0 이하(비정상 데이터)면 zoom 을 1 로 방어한다', () => {
+    // scale 은 배율 단위(1=원본)다. AvatarSetting.scale 기본값(0.0) 이나 잘못된
+    // 음수/0 이 들어오면 transform: scale(0) 으로 face 가 사라져 까맣게 보이므로,
+    // 0 이하일 때는 1(원본)로 보정한다.
+    expect(calculateDimensions(BODY_BASE_HEIGHT, 0, 0, 0, 0, 0).zoom).toBe(1);
+    expect(calculateDimensions(BODY_BASE_HEIGHT, 0, 0, 0, 0, -1).zoom).toBe(1);
+  });
+
   test('x, y offset 계산', () => {
     const result = calculateDimensions(BODY_BASE_HEIGHT, 0, 0, 0.5, 0.3, 1);
     const expectedFaceWidth = BODY_BASE_WIDTH * FACE_BASE_WIDTH_RATIO;

--- a/src/entities/avatar/lib/calculate-dimensions.ts
+++ b/src/entities/avatar/lib/calculate-dimensions.ts
@@ -34,7 +34,9 @@ export default function calculateDimensions(
   const faceHeight = targetHeight * FACE_BASE_HEIGHT_RATIO;
   const offsetX = x * faceWidth;
   const offsetY = y * faceHeight;
-  const zoom = scale;
+  // scale 은 배율(1=원본). 0 이하의 비정상 값(미설정 기본 0.0 등)은 face 가
+  // transform: scale(0) 으로 사라져 까맣게 보이므로 1 로 보정한다.
+  const zoom = scale > 0 ? scale : 1;
 
   return {
     width,

--- a/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list-item.component.tsx
@@ -7,10 +7,9 @@ import { useSelectedAvatarState } from '../lib/selected-avatar-state.context';
 
 interface Props {
   meta: AvatarFace | Nft.Model;
-  hideSelected: boolean;
 }
 
-const AvatarFaceListItem: FC<Props> = ({ meta, hideSelected }) => {
+const AvatarFaceListItem: FC<Props> = ({ meta }) => {
   const selectedAvatar = useSelectedAvatarState();
 
   const handleAvatarImgClick = () => {
@@ -22,7 +21,7 @@ const AvatarFaceListItem: FC<Props> = ({ meta, hideSelected }) => {
       handleClick={handleAvatarImgClick}
       imageSrc={meta.resourceUri}
       name={meta.name}
-      selected={!hideSelected && selectedAvatar.faceUri === meta.resourceUri}
+      selected={selectedAvatar.faceUri === meta.resourceUri}
       testId='avatar-face-list-item'
     />
   );

--- a/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
+++ b/src/features/edit-profile-avatar/ui/avatar-face-list.component.tsx
@@ -36,13 +36,13 @@ const AvatarFaceList = () => {
         )}
         data-testid='avatar-face-list'
       >
-        {faces.map((face) => (
-          <AvatarFaceListItem key={face.resourceUri} meta={face} hideSelected={!combinable} />
-        ))}
+        {/* combinable=false(전신 아이템)이면 face 선택 자체가 불가하므로 리스트를
+            렌더하지 않는다. 과거엔 렌더한 채 반투명 overlay 로만 덮어 face 이미지가
+            비쳐 보였다(ⓐ). */}
+        {combinable &&
+          faces.map((face) => <AvatarFaceListItem key={face.resourceUri} meta={face} />)}
 
-        {nfts.map((nft) => (
-          <AvatarFaceListItem key={nft.resourceUri} meta={nft} hideSelected={!combinable} />
-        ))}
+        {combinable && nfts.map((nft) => <AvatarFaceListItem key={nft.resourceUri} meta={nft} />)}
 
         {!combinable && (
           <div className='absolute inset-0 flexColCenter gap-[16px] px-2 text-center bg-dim text-white cursor-not-allowed select-none'>


### PR DESCRIPTION
## 증상
아바타 설정 페이지에서:
- **ⓐ** combinable 몸통을 선택하지 않고 Face 탭으로 가면, "Face selection unavailable" 문구 섹션 좌상단에 기본 Face 이미지가 비쳐 보임
- **ⓑ** combinable 몸통 선택 + 기본 Face 선택 시 '페이스 위치 조절 공간'에 face 가 까맣게만 보이고, 저장 시 파티룸에 까만 아바타로 입장
- **ⓒ** Face 선택 순간 가로 스크롤바가 길게 생김

## 원인 (Playwright 측정으로 규명)
- **ⓐ**: `combinable=false` 일 때도 face 리스트(`faces.map`/`nfts.map`)를 렌더한 채 반투명 `bg-dim` overlay 로만 덮어, 좌상단 face 가 비쳐 보임
- **ⓑⓒ**: `/me/profile/summary` 의 `scale: 100`. scale 은 배율 단위(1=원본)인데 dev seed(`upgradeMember`)가 100(=100배)로 설정 → `transform: scale(100)` → face 100배 확대 → 중앙 1/100만 노출(까맣게) + react-moveable 거대 bounding box → 가로 스크롤

## 수정 (web)
- **ⓐ**: `!combinable` 이면 face 리스트를 렌더하지 않음(overlay 만 표시). dead 가 된 `hideSelected` prop 제거
- **ⓑⓒ frontend 방어**: `calculate-dimensions` 에서 `scale<=0 → 1` 보정 (미설정 0.0 등 비정상 scale robustness, TDD)

## 연계 (별도 처리 완료)
- 근본 원인(dev seed scale=100): backend [pfplay-platform #256](https://github.com/pfplay/pfplay-platform/pull/256) 에서 `1.0` 으로 수정
- 기존 dev/stg DB 의 scale=100 레코드: SQL(`UPDATE user_profile SET scale=1 WHERE scale=100`)로 정정 완료 (prod 무관 — temporary user 경로 `@Profile("!prod")`)

## 검증
- `calculate-dimensions` 단위테스트 GREEN (scale<=0 방어 케이스 추가)
- dev 브라우저 확인: ⓐ face 숨김 / ⓑ face 정상 표시 / ⓒ 스크롤 없음 (사용자 확인)