### PR TITLE
chore(analytics): 자동화 브라우저(E2E)에서 amplitude 비활성 (MTU 낭비 방지)

### DIFF
--- a/src/shared/lib/analytics/index.test.ts
+++ b/src/shared/lib/analytics/index.test.ts
@@ -182,4 +182,24 @@ describe('analytics module', () => {
       expect(amplitude.reset).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('automated browser (E2E webdriver) opt-out', () => {
+    afterEach(() => {
+      Object.defineProperty(navigator, 'webdriver', { configurable: true, value: false });
+    });
+
+    test('navigator.webdriver=true 면 initAnalytics 가 SDK init 을 호출하지 않는다', () => {
+      Object.defineProperty(navigator, 'webdriver', { configurable: true, value: true });
+      initAnalytics();
+      expect(amplitude.init).not.toHaveBeenCalled();
+    });
+
+    test('navigator.webdriver=true 면 track / identify 가 no-op 이다 (E2E MTU 낭비 방지)', () => {
+      Object.defineProperty(navigator, 'webdriver', { configurable: true, value: true });
+      track('User Signed In', { auth_type: 'guest' });
+      identify({ set: { authority_tier: 'FM' } });
+      expect(amplitude.track).not.toHaveBeenCalled();
+      expect(amplitude.identify).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -26,8 +26,15 @@ function isClient(): boolean {
   return typeof window !== 'undefined';
 }
 
+// E2E(Playwright 등 자동화 브라우저)는 navigator.webdriver=true 다. prod/stg 와
+// MTU 를 공유하므로 자동화 트래픽이 amplitude 를 호출하면 MTU 가 낭비된다.
+// 실제 사용자(webdriver=false/undefined)는 영향 없음.
+function isAutomated(): boolean {
+  return typeof navigator !== 'undefined' && navigator.webdriver === true;
+}
+
 function isEnabled(): boolean {
-  return isClient() && Boolean(getApiKey());
+  return isClient() && Boolean(getApiKey()) && !isAutomated();
 }
 
 function loadSdk(): Promise<AmplitudeModule> {
@@ -53,7 +60,7 @@ function callSdk(action: (sdk: AmplitudeModule) => void): void {
 
 export function initAnalytics(): void {
   const apiKey = getApiKey();
-  if (!isClient() || !apiKey || initialized) return;
+  if (!isClient() || !apiKey || initialized || isAutomated()) return;
   initialized = true;
   callSdk((sdk) => {
     sdk.init(apiKey, undefined, {


### PR DESCRIPTION
## 요약
E2E(Playwright 등 자동화 브라우저)에서 amplitude 이벤트 발화를 막아 MTU 낭비를 방지.

## 배경
amplitude MTU 는 **prod/stg 가 공유**한다. E2E 가 stg(또는 preview)를 대상으로 돌 때 `track`/`identify` 가 그대로 발화하면 자동화 트래픽이 MTU 를 잠식한다.

## 구현
`isEnabled()` / `initAnalytics()` 에 `navigator.webdriver`(자동화 브라우저=true) 게이트 추가:
- 자동화 브라우저: amplitude no-op (init/track/identify/setUserId)
- **실제 사용자(webdriver=false/undefined): 무영향** — dev/stg/prod 모든 환경 공통

## 검증
- `analytics/index.test.ts` 에 webdriver opt-out 케이스 추가 (TDD)
- analytics 전체 **59 tests GREEN**