### PR TITLE
fix(ui): 언어 드롭다운 layout shift + 버그리포트 글자수 카운터 겹침

### DIFF
--- a/src/shared/ui/components/menu/menu-item-panel.component.tsx
+++ b/src/shared/ui/components/menu/menu-item-panel.component.tsx
@@ -52,6 +52,10 @@ const MenuItemPanel = ({
       <MenuItems
         as='ul'
         anchor='bottom end'
+        // 드롭다운은 배경 스크롤을 잠글 이유가 없다. headlessui v2 의 modal 기본값(true)은
+        // 열릴 때 scroll-lock(scrollbar 보상)을 걸어, 세로 스크롤이 있는 화면에서 드롭다운을
+        // 열면 scrollbar 가 사라지며 헤더가 좌우로 흔들린다. modal=false 로 비활성화.
+        modal={false}
         className={cn(
           'absolute right-0 mt-2 py-2 origin-top-right rounded-[4px] bg-gray-800 shadow-lg z-50',
           menuItemPanelStyle,

--- a/src/shared/ui/components/textarea/textarea.component.tsx
+++ b/src/shared/ui/components/textarea/textarea.component.tsx
@@ -34,11 +34,11 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     };
 
     return (
-      <div className={cn('relative flex max-w-full', containerClassName)}>
+      <div className={cn('flex flex-col gap-1 max-w-full', containerClassName)}>
         <textarea
           ref={combinedRef}
           className={cn(
-            'flex-1 min-h-max py-[12px] pl-[12px] pr-[60px] rounded-[4px]',
+            'flex-1 min-h-max p-[12px] rounded-[4px]',
             'bg-gray-700 text-gray-50 placeholder:gray-400 caret-red-300',
             'focus:interaction-outline',
             textareaClassName
@@ -50,7 +50,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
         {Number.isInteger(maxLength) && (
           <Typography
-            className={cn('absolute top-[12px] right-[12px]', {
+            className={cn('self-end', {
               'text-gray-400': !localValue.length,
               'text-gray-50': !!localValue.length,
             })}


### PR DESCRIPTION
stg 확인 중 발견된 UI 버그 2건.

## ⑨ 언어 드롭다운 layout shift
세로 스크롤이 있는 화면에서 언어 드롭다운을 열면 scrollbar 가 사라지며 헤더 버튼들이 좌우로 흔들림.
- 원인: headlessui v2 `MenuItems` 의 `modal` 기본값(true) → 열릴 때 scroll-lock(scrollbar 보상)
- 수정: 드롭다운은 배경 스크롤을 잠글 이유가 없어 `modal={false}` (menu-item-panel)

## ⑩ 버그리포트 글자수 카운터 겹침
`0000/2000` 카운터가 `(5-2000 characters)` placeholder·입력 텍스트와 겹침.
- 원인: TextArea 카운터가 `absolute top-[12px] right-[12px]`(입력 영역 안 우측 상단)
- 수정: 컨테이너 `flex-col` + 카운터 `self-end`(textarea 밖 아래 우측), 우측 패딩(pr-60) 제거

## 검증
- menu/textarea 단위테스트 16/16 GREEN
- stg 에서 시각 최종 확인 예정