### PR TITLE
fix(ui): 모달(Dialog) 열림/닫힘 시 scrollbar 깜빡임 제거

### DIFF
--- a/src/shared/ui/components/dialog/dialog.component.tsx
+++ b/src/shared/ui/components/dialog/dialog.component.tsx
@@ -99,85 +99,84 @@ const Dialog: FC<DialogProps> & DialogComposition = ({
   };
 
   return (
-    <Transition appear show={open} as={Fragment}>
-      <HUDialog
-        as='div'
-        className='relative'
-        style={{ zIndex }}
-        onClick={closeWhenOverlayClicked ? handleClose : undefined}
-        onClose={
-          () => {} /* 여기 close function 을 넣으면 중첩 모달 띄울 때 중첩 모달 내 인터랙션에 의해 직전 모달이 닫혀 버리는 문제가 있음. 해서 onClick 에서 컨트롤 */
-        }
-        id={id}
-      >
-        {!hideDim && (
+    <HUDialog
+      as='div'
+      open={open}
+      className='relative'
+      style={{ zIndex }}
+      onClick={closeWhenOverlayClicked ? handleClose : undefined}
+      onClose={
+        () => {} /* 여기 close function 을 넣으면 중첩 모달 띄울 때 중첩 모달 내 인터랙션에 의해 직전 모달이 닫혀 버리는 문제가 있음. 해서 onClick 에서 컨트롤 */
+      }
+      id={id}
+    >
+      {!hideDim && (
+        <Transition.Child
+          as={Fragment}
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
+        >
+          <div data-testid='dialog-backdrop' className='fixed inset-0 bg-dim' />
+        </Transition.Child>
+      )}
+
+      <div data-testid='dialog-overlay-container' className='fixed inset-0 overflow-y-auto'>
+        <div className='flex min-h-full items-center justify-center p-4 text-center'>
           <Transition.Child
             as={Fragment}
             enter='ease-out duration-300'
-            enterFrom='opacity-0'
-            enterTo='opacity-100'
+            enterFrom='opacity-0 scale-95'
+            enterTo='opacity-100 scale-100'
             leave='ease-in duration-200'
-            leaveFrom='opacity-100'
-            leaveTo='opacity-0'
+            leaveFrom='opacity-100 scale-100'
+            leaveTo='opacity-0 scale-95'
           >
-            <div data-testid='dialog-backdrop' className='fixed inset-0 bg-dim' />
-          </Transition.Child>
-        )}
-
-        <div data-testid='dialog-overlay-container' className='fixed inset-0 overflow-y-auto'>
-          <div className='flex min-h-full items-center justify-center p-4 text-center'>
-            <Transition.Child
-              as={Fragment}
-              enter='ease-out duration-300'
-              enterFrom='opacity-0 scale-95'
-              enterTo='opacity-100 scale-100'
-              leave='ease-in duration-200'
-              leaveFrom='opacity-100 scale-100'
-              leaveTo='opacity-0 scale-95'
+            <HUDialog.Panel
+              data-testid='dialog-panel'
+              className={cn(
+                'relative pt-[52px] px-[32px] pb-[32px] w-[440px] max-w-full transform rounded-[6px] bg-gray-800 border border-gray-700 transition-all',
+                classNames?.container
+              )}
+              style={{
+                overflowWrap: 'anywhere',
+              }}
             >
-              <HUDialog.Panel
-                data-testid='dialog-panel'
-                className={cn(
-                  'relative pt-[52px] px-[32px] pb-[32px] w-[440px] max-w-full transform rounded-[6px] bg-gray-800 border border-gray-700 transition-all',
-                  classNames?.container
-                )}
-                style={{
-                  overflowWrap: 'anywhere',
-                }}
-              >
-                {showCloseIcon && (
-                  <TextButton
-                    data-testid='dialog-close-button'
-                    onClick={handleClose}
-                    Icon={<PFClose width={24} height={24} />}
-                    className='absolute top-[16px] right-[16px] z-10'
-                  />
-                )}
+              {showCloseIcon && (
+                <TextButton
+                  data-testid='dialog-close-button'
+                  onClick={handleClose}
+                  Icon={<PFClose width={24} height={24} />}
+                  className='absolute top-[16px] right-[16px] z-10'
+                />
+              )}
 
-                {title && (
-                  <HUDialog.Title
-                    as='div'
-                    className={cn([
-                      'flexCol gap-[12px] mb-[24px]',
-                      {
-                        'items-start': titleAlign === 'left',
-                        'items-center': titleAlign === 'center',
-                      },
-                    ])}
-                  >
-                    {Title}
+              {title && (
+                <HUDialog.Title
+                  as='div'
+                  className={cn([
+                    'flexCol gap-[12px] mb-[24px]',
+                    {
+                      'items-start': titleAlign === 'left',
+                      'items-center': titleAlign === 'center',
+                    },
+                  ])}
+                >
+                  {Title}
 
-                    {Sub}
-                  </HUDialog.Title>
-                )}
+                  {Sub}
+                </HUDialog.Title>
+              )}
 
-                {typeof Body === 'function' ? <Body /> : Body}
-              </HUDialog.Panel>
-            </Transition.Child>
-          </div>
+              {typeof Body === 'function' ? <Body /> : Body}
+            </HUDialog.Panel>
+          </Transition.Child>
         </div>
-      </HUDialog>
-    </Transition>
+      </div>
+    </HUDialog>
   );
 };
 


### PR DESCRIPTION
## 증상
버그리포트·My profile·소셜로그인 등 **모달을 열거나 닫을 때 우측 scrollbar 가 순간 사라졌다 나타나며** 헤더/콘텐츠가 흔들림 (stg 확인 2/3/4).

## 원인 (MutationObserver 측정 + headlessui v2 소스)
`dialog.component` 가 `<Transition show={open}><HUDialog onClose>` 구조인데 **HUDialog 에 `open` prop 이 없어**, headlessui Dialog 가 외부 Transition 의 mount/unmount 에 따라 open 을 불안정하게 잡아 **scroll-lock(overflow:hidden+padding)을 전이 중 켰다 끄는 깜빡임** 발생. headlessui Dialog 의 scroll-lock 은 focus trap 과 묶여 있어 끌 수 없음.

## 수정
- 외부 `<Transition>` 제거 + `<HUDialog open={open}>` (controlled)
- headlessui v2 가 open prop 으로 내부 Transition 구성 → scroll-lock 이 open 동안 안정 유지, focus trap 유지
- `transition` prop 은 leave 중 scroll-lock 재계산 토글이 있어 미사용

## 검증
- MutationObserver: OPEN 1회 적용 / CLOSE 1회 해제 (전이 토글 없음)
- dialog 단위테스트 16/16 GREEN
- (드롭다운 ⑨/logout 은 #331 의 Menu modal={false} 로 이미 해결)