### PR TITLE
fix(player): 외부 인터럽트 자동 일시정지 시 무인터랙션 재개 (#334)

### DIFF
--- a/src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.test.ts
+++ b/src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.test.ts
@@ -1,0 +1,133 @@
+import type TReactPlayer from 'react-player';
+import { renderHook, act } from '@testing-library/react';
+import { RESUME_RECHECK_MS, useAutoResumeOnPause } from './use-auto-resume-on-pause.hook';
+
+const YT_STATE_PLAYING = 1;
+const YT_STATE_PAUSED = 2;
+
+function createPlayerRef(internal: unknown) {
+  return {
+    current: { getInternalPlayer: () => internal } as unknown as TReactPlayer,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('useAutoResumeOnPause', () => {
+  test('enabled=false 면 pause 가 와도 playVideo 와 onFallback 둘 다 호출하지 않는다', () => {
+    const playVideo = vi.fn();
+    const getPlayerState = vi.fn(() => YT_STATE_PAUSED);
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef({ playVideo, getPlayerState });
+
+    const { result } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: false, onFallback })
+    );
+
+    act(() => {
+      result.current();
+      vi.advanceTimersByTime(RESUME_RECHECK_MS + 100);
+    });
+
+    expect(playVideo).not.toHaveBeenCalled();
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  test('enabled=true 면 pause 즉시 무인터랙션 playVideo 를 1회 호출한다', () => {
+    const playVideo = vi.fn();
+    const getPlayerState = vi.fn(() => YT_STATE_PLAYING);
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef({ playVideo, getPlayerState });
+
+    const { result } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: true, onFallback })
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    expect(playVideo).toHaveBeenCalledTimes(1);
+  });
+
+  test('재확인 시점에 여전히 PAUSED 면(정책 차단) onFallback 으로 폴백한다', () => {
+    const playVideo = vi.fn();
+    const getPlayerState = vi.fn(() => YT_STATE_PAUSED);
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef({ playVideo, getPlayerState });
+
+    const { result } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: true, onFallback })
+    );
+
+    act(() => {
+      result.current();
+      vi.advanceTimersByTime(RESUME_RECHECK_MS);
+    });
+
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+
+  test('재확인 시점에 재생 중이면(자동 재개 성공) onFallback 을 호출하지 않는다', () => {
+    const playVideo = vi.fn();
+    const getPlayerState = vi.fn(() => YT_STATE_PLAYING);
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef({ playVideo, getPlayerState });
+
+    const { result } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: true, onFallback })
+    );
+
+    act(() => {
+      result.current();
+      vi.advanceTimersByTime(RESUME_RECHECK_MS);
+    });
+
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  test('언마운트되면 대기 중이던 재확인 타이머가 취소되어 onFallback 을 호출하지 않는다', () => {
+    const playVideo = vi.fn();
+    const getPlayerState = vi.fn(() => YT_STATE_PAUSED);
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef({ playVideo, getPlayerState });
+
+    const { result, unmount } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: true, onFallback })
+    );
+
+    act(() => {
+      result.current();
+    });
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(RESUME_RECHECK_MS + 100);
+    });
+
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  test('internal player 가 없어도 throw 하지 않고 onFallback 도 호출하지 않는다', () => {
+    const onFallback = vi.fn();
+    const playerRef = createPlayerRef(null);
+
+    const { result } = renderHook(() =>
+      useAutoResumeOnPause(playerRef, { enabled: true, onFallback })
+    );
+
+    expect(() =>
+      act(() => {
+        result.current();
+        vi.advanceTimersByTime(RESUME_RECHECK_MS + 100);
+      })
+    ).not.toThrow();
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.ts
+++ b/src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.ts
@@ -1,0 +1,62 @@
+import { RefObject, useEffect, useRef } from 'react';
+import type TReactPlayer from 'react-player';
+
+// YouTube IFrame API 의 PlayerState. 자동 재개 후에도 이 값이면 정책상 차단된 것으로 본다.
+// @see https://developers.google.com/youtube/iframe_api_reference#getPlayerState
+const YT_PLAYER_STATE_PAUSED = 2;
+
+// playVideo() 자동 시도 후 이 시간 뒤 상태를 재확인한다. buffering→playing 전이를 기다릴 만큼은
+// 길고, 차단 시 폴백이 너무 늦지 않을 만큼은 짧게.
+export const RESUME_RECHECK_MS = 1200;
+
+type InternalYouTubePlayer = {
+  playVideo?: () => void;
+  getPlayerState?: () => number;
+};
+
+/**
+ * 블루투스 이어폰 제거 등 외부 인터럽트로 비디오가 자동 일시정지되면 사용자 인터랙션 없이
+ * 재생을 자동 재개한다(이슈 #334, A안). 전광판엔 의도적 일시정지 UI 가 없으므로 모든 pause 를
+ * 비자발적 인터럽트로 간주한다.
+ *
+ * - 데스크톱(Chrome/Edge/FF): 입장 시 sticky activation 이 유지돼 `playVideo()` 가 곧바로 성공.
+ * - Safari/iOS: 프로그래매틱 재생이 정책상 거부될 수 있어, 재확인 시점에도 PAUSED 면 `onFallback`
+ *   (기존 "탭하여 재생" gesture gate)으로 위임한다.
+ * - mute 는 절대 건드리지 않는다. naive mute 는 sticky 라 이어폰 재연결 시 무음이 잔존한다.
+ *
+ * @param playerRef react-player 인스턴스 ref
+ * @param enabled   재생이 활성이어야 하는 상태(`videoId && playerReady`)일 때만 동작
+ * @param onFallback 자동 재개 실패 시 호출(주로 gesture gate 노출)
+ * @returns react-player 의 `onPause` 에 연결할 핸들러
+ */
+export function useAutoResumeOnPause(
+  playerRef: RefObject<TReactPlayer | null>,
+  { enabled, onFallback }: { enabled: boolean; onFallback: () => void }
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  return () => {
+    if (!enabled) return;
+
+    const internal = playerRef.current?.getInternalPlayer() as
+      | InternalYouTubePlayer
+      | null
+      | undefined;
+    internal?.playVideo?.();
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      if (internal?.getPlayerState?.() === YT_PLAYER_STATE_PAUSED) {
+        onFallback();
+      }
+    }, RESUME_RECHECK_MS);
+  };
+}

--- a/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
@@ -13,6 +13,7 @@ import { useStores } from '@/shared/lib/store/stores.context';
 import { LoadingPanel } from '@/shared/ui/components/loading';
 import CinemaFooter from './cinema-footer.component';
 import CinemaHeader from './cinema-header.component';
+import { useAutoResumeOnPause } from './use-auto-resume-on-pause.hook';
 import VideoControls from './video-controls.component';
 
 const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
@@ -129,6 +130,16 @@ export default function Video({
     setAutoplayBlocked(false);
   };
 
+  // 블루투스 이어폰 제거 등 외부 인터럽트로 자동 일시정지되면 무인터랙션으로 재개를 시도하고(이슈 #334),
+  // 정책상 차단되면(주로 Safari) played 를 풀어 player 를 재마운트하면서 gesture gate 로 폴백한다.
+  const onPause = useAutoResumeOnPause(playerRef, {
+    enabled: playable,
+    onFallback: () => {
+      setPlayed(false);
+      setAutoplayBlocked(true);
+    },
+  });
+
   const handleTheater = () => setCinemaView(true);
 
   const handleFull = () => {
@@ -188,6 +199,7 @@ export default function Video({
         className={playerClass}
         onReady={onPlayerReady}
         onPlay={onPlay}
+        onPause={onPause}
         config={config}
         pip={false}
       />
@@ -306,6 +318,7 @@ export default function Video({
         className={playerClass}
         onReady={onPlayerReady}
         onPlay={onPlay}
+        onPause={onPause}
         config={config}
         pip={false}
       />


### PR DESCRIPTION
## 개요
블루투스 이어폰 제거 등으로 전광판(YouTube)이 OS 레벨에서 자동 일시정지되면, 사용자 인터랙션 없이 곧바로 재생을 재개한다. 이슈 #334 의 **A안(자동 재개 + unmute 유지)** 구현.

closes #334

## 동작
1. `onPause` 발생 → `getInternalPlayer().playVideo()` 무인터랙션 1회 자동 시도.
2. `RESUME_RECHECK_MS`(1200ms) 뒤 `getPlayerState()` 가 여전히 `PAUSED(2)` 면(정책 차단, 주로 Safari/iOS) → 기존 `autoplayBlocked` "탭하여 재생" gesture gate 로 폴백.
3. **mute 는 절대 건드리지 않음.** naive mute 는 sticky 라 이어폰 재연결 시 무음이 잔존(이슈 본문 dead-end 참고). 재연결 복구는 OS 라우팅이 무료로 처리.

## 변경
- `use-auto-resume-on-pause.hook.ts` 신설 — 재개 시도/재확인/폴백 오케스트레이션을 테스트 가능한 훅으로 분리. 언마운트 시 대기 타이머 정리.
- `video.component.tsx` — 두 `YoutubePlayer`(시네마/기본)에 `onPause` 연결.

## 설계 메모
- 전광판엔 의도적 일시정지 컨트롤이 없어(VideoControls = 볼륨/시네마/풀스크린만) **모든 pause 를 비자발적 인터럽트로 간주**(이슈 point 5).
- 별도의 서버 `playbackActivated` 조회 없이 `playable(videoId && playerReady)` 가드가 그 역할을 대신함 — playback 비활성 시 `videoId` 가 사라져 `enabled=false`.

## 검증
- ✅ `use-auto-resume-on-pause.hook` 단위 테스트 6건 (enabled 게이트 / 즉시 재개 / PAUSED 폴백 / 재생중 폴백 안함 / 언마운트 타이머 정리 / null player 안전).
- ✅ `yarn test` 전체 239 파일 / 1301 통과, `yarn test:type` 통과, eslint 클린.
- ⚠️ **수동 검증 필요(자동화 불가)**: 실제 디바이스에서 BT 이어폰 제거 → 데스크톱(Chrome) 무인터랙션 재개 / Safari 폴백 gate 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)