### PR TITLE
fix(partyroom): 재연결·백그라운드 복귀 시 재생상태 resync (#335)

### DIFF
--- a/src/app/parties/(room)/[id]/layout.test.tsx
+++ b/src/app/parties/(room)/[id]/layout.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockEnter = vi.fn();
 const mockTeardown = vi.fn();
+const mockResync = vi.fn();
 const mockReplace = vi.fn();
 let searchParamsValue: string | null = null;
 
@@ -18,6 +19,10 @@ vi.mock('@/features/partyroom/enter', () => ({
 
 vi.mock('@/features/partyroom/exit', () => ({
   useTeardownPartyroom: () => mockTeardown,
+}));
+
+vi.mock('@/features/partyroom/resync', () => ({
+  usePlaybackResync: (id: number) => mockResync(id),
 }));
 
 vi.mock('@/shared/lib/analytics/room-tracking', () => ({
@@ -40,6 +45,16 @@ describe('PartyroomLayout (Cluster A PR-4 L2: unmount=teardown, no unload backen
     );
 
     expect(mockEnter).toHaveBeenCalledTimes(1);
+  });
+
+  test('마운트 시 usePlaybackResync(partyroomId) 를 호출한다 (재연결/복귀 시 재생상태 self-heal)', () => {
+    render(
+      <PartyroomLayout>
+        <div>child</div>
+      </PartyroomLayout>
+    );
+
+    expect(mockResync).toHaveBeenCalledWith(7);
   });
 
   test('?source= 가 있으면 router.replace 로 즉시 제거한다', () => {

--- a/src/app/parties/(room)/[id]/layout.tsx
+++ b/src/app/parties/(room)/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 import { useEnterPartyroom } from '@/features/partyroom/enter';
 import { useTeardownPartyroom } from '@/features/partyroom/exit';
+import { usePlaybackResync } from '@/features/partyroom/resync';
 import { parseEntrySource } from '@/shared/lib/analytics/room-tracking';
 import useDidMountEffect from '@/shared/lib/hooks/use-did-mount-effect';
 
@@ -15,6 +16,9 @@ export default function PartyroomLayout({ children }: PropsWithChildren) {
   const entrySource = parseEntrySource(searchParams.get('source'));
   const enter = useEnterPartyroom(partyroomId, { entrySource });
   const teardown = useTeardownPartyroom(partyroomId);
+
+  // 재연결 / 백그라운드 탭 복귀 시 놓친 재생상태를 서버에서 재조회해 self-heal 한다(#335).
+  usePlaybackResync(partyroomId);
 
   useDidMountEffect(() => {
     enter();

--- a/src/entities/partyroom-client/lib/partyroom-client.test.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.test.ts
@@ -44,6 +44,17 @@ describe('PartyroomClient', () => {
     expect(mockSocketInstance.onConnect).toHaveBeenCalledWith(callback, options);
   });
 
+  test('onReconnect → socketClient.onReconnect 에 위임하고 해제 함수를 그대로 반환한다', () => {
+    const callback = vi.fn();
+    const unregister = vi.fn();
+    mockSocketInstance.onReconnect.mockReturnValue(unregister);
+
+    const result = client.onReconnect(callback);
+
+    expect(mockSocketInstance.onReconnect).toHaveBeenCalledWith(callback);
+    expect(result).toBe(unregister);
+  });
+
   describe('subscribe', () => {
     test('구독이 없으면 올바른 경로로 subscribe를 호출한다', () => {
       const handler = vi.fn();

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -29,6 +29,14 @@ export default class PartyroomClient {
   }
 
   /**
+   * 재연결(최초 connect 이후) 시마다 콜백을 실행합니다. 최초 connect 에선 실행되지 않습니다.
+   * @returns 등록 해제 함수
+   */
+  public onReconnect(callback: () => void): () => void {
+    return this.socketClient.onReconnect(callback);
+  }
+
+  /**
    * partyroom 을 구독합니다. **replace 정책**:
    * 이미 다른 방을 구독 중이면 기존 방을 먼저 해지한 뒤 새 방을 구독합니다 (throw 없음).
    *

--- a/src/features/partyroom/resync/index.ts
+++ b/src/features/partyroom/resync/index.ts
@@ -1,0 +1,1 @@
+export { usePlaybackResync } from './lib/use-playback-resync.hook';

--- a/src/features/partyroom/resync/lib/use-playback-resync.hook.test.ts
+++ b/src/features/partyroom/resync/lib/use-playback-resync.hook.test.ts
@@ -1,0 +1,94 @@
+vi.mock('@/entities/partyroom-client');
+vi.mock('@/shared/lib/store/stores.context');
+vi.mock('@/shared/api/http/services', () => ({
+  partyroomsService: {
+    getSetupInfo: vi.fn(),
+  },
+}));
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePartyroomClient } from '@/entities/partyroom-client';
+import { partyroomsService } from '@/shared/api/http/services';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { usePlaybackResync } from './use-playback-resync.hook';
+
+const PARTYROOM_ID = 42;
+
+const updatePlaybackActivated = vi.fn();
+const updatePlayback = vi.fn();
+const updateCurrentDj = vi.fn();
+
+let reconnectCallback: () => void;
+const unregisterReconnect = vi.fn();
+const onReconnect = vi.fn((cb: () => void) => {
+  reconnectCallback = cb;
+  return unregisterReconnect;
+});
+
+const setupInfo = {
+  stageType: 'GENERAL',
+  crews: [],
+  display: {
+    playbackActivated: true,
+    playback: { linkId: 'dQw4w9WgXcQ' },
+    currentDj: { crewId: 7 },
+  },
+} as any;
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setVisibility('visible');
+  (partyroomsService.getSetupInfo as Mock).mockResolvedValue(setupInfo);
+  (usePartyroomClient as Mock).mockReturnValue({ onReconnect });
+  const useCurrentPartyroom = ((selector: (state: unknown) => unknown) =>
+    selector({ updatePlaybackActivated, updatePlayback, updateCurrentDj })) as unknown;
+  (useStores as Mock).mockReturnValue({ useCurrentPartyroom });
+});
+
+describe('usePlaybackResync', () => {
+  test('visibilitychange(visible) → getSetupInfo 의 재생상태(playback/playbackActivated/currentDj)를 스토어에 주입한다', async () => {
+    renderHook(() => usePlaybackResync(PARTYROOM_ID));
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await waitFor(() => expect(updatePlayback).toHaveBeenCalledWith(setupInfo.display.playback));
+    expect(partyroomsService.getSetupInfo).toHaveBeenCalledWith({ partyroomId: PARTYROOM_ID });
+    expect(updatePlaybackActivated).toHaveBeenCalledWith(true);
+    expect(updateCurrentDj).toHaveBeenCalledWith(setupInfo.display.currentDj);
+  });
+
+  test('재연결(onReconnect 콜백 실행) → 동일하게 재생상태를 재조회·주입한다', async () => {
+    renderHook(() => usePlaybackResync(PARTYROOM_ID));
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    reconnectCallback();
+
+    await waitFor(() => expect(updatePlayback).toHaveBeenCalledWith(setupInfo.display.playback));
+    expect(partyroomsService.getSetupInfo).toHaveBeenCalledWith({ partyroomId: PARTYROOM_ID });
+  });
+
+  test('탭이 숨겨질 때(visibilitychange + hidden)는 재조회하지 않는다', async () => {
+    renderHook(() => usePlaybackResync(PARTYROOM_ID));
+
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await Promise.resolve();
+    expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
+  });
+
+  test('언마운트 → onReconnect 해제 함수를 호출하고 visibilitychange 리스너를 제거한다', async () => {
+    const { unmount } = renderHook(() => usePlaybackResync(PARTYROOM_ID));
+
+    unmount();
+    expect(unregisterReconnect).toHaveBeenCalledTimes(1);
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/partyroom/resync/lib/use-playback-resync.hook.ts
+++ b/src/features/partyroom/resync/lib/use-playback-resync.hook.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+import { usePartyroomClient } from '@/entities/partyroom-client';
+import { partyroomsService } from '@/shared/api/http/services';
+import silent from '@/shared/lib/functions/silent';
+import { useStores } from '@/shared/lib/store/stores.context';
+
+/**
+ * 재연결 / 백그라운드 탭 복귀 시 서버의 현재 재생상태를 다시 조회해 스토어에 주입한다(이슈 #335).
+ *
+ * `PLAYBACK_STARTED` 등 fire-and-forget broadcast 는 연결이 끊겼거나 백그라운드 throttling 으로
+ * 놓친 구간에 발행되면 ack/replay 가 없어 영구 유실된다. 백그라운드 실시간 100% 수신은 cross-browser
+ * 로 보장 불가하므로, "복귀 시점에 self-heal" 하는 안전망으로 해결한다.
+ *
+ * - **reconnect**: `client.onReconnect`(최초 connect 제외)마다 재조회. 끊겼다 다시 붙은 경우.
+ * - **visibilitychange(hidden→visible)**: 연결이 유지된 채(예: half-open) 이벤트만 놓친 경우도 보정.
+ *
+ * 재생상태(playback / playbackActivated / currentDj)만 갱신한다 — 입장(enter)은 재호출하지 않으며,
+ * 구독 자체는 SocketClient 가 reconnect 시 `subscriptions[]` 기준으로 자체 reconcile 한다.
+ */
+export function usePlaybackResync(partyroomId: number) {
+  const client = usePartyroomClient();
+  const { useCurrentPartyroom } = useStores();
+  const [updatePlaybackActivated, updatePlayback, updateCurrentDj] = useCurrentPartyroom(
+    (state) => [state.updatePlaybackActivated, state.updatePlayback, state.updateCurrentDj]
+  );
+
+  const resync = useCallback(async () => {
+    const { display } = await partyroomsService.getSetupInfo({ partyroomId });
+    updatePlaybackActivated(display.playbackActivated);
+    updatePlayback(display.playback);
+    updateCurrentDj(display.currentDj);
+  }, [partyroomId, updatePlaybackActivated, updatePlayback, updateCurrentDj]);
+
+  useEffect(() => {
+    const run = () => void silent(resync());
+
+    const unregisterReconnect = client.onReconnect(run);
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') run();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      unregisterReconnect();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [client, resync]);
+}

--- a/src/shared/api/websocket/client.test.ts
+++ b/src/shared/api/websocket/client.test.ts
@@ -135,6 +135,45 @@ describe('SocketClient', () => {
     });
   });
 
+  describe('onReconnect', () => {
+    test('최초 connect 에서는 실행되지 않는다', () => {
+      const sc = new SocketClient();
+      const cb = vi.fn();
+      sc.onReconnect(cb);
+
+      triggerConnect(sc);
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    test('최초 이후의 connect(재연결)부터 매번 실행된다', () => {
+      const sc = new SocketClient();
+      const cb = vi.fn();
+      sc.onReconnect(cb);
+
+      triggerConnect(sc); // 최초
+      expect(cb).not.toHaveBeenCalled();
+
+      triggerConnect(sc); // 재연결 1
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      triggerConnect(sc); // 재연결 2
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    test('반환된 해제 함수를 호출하면 이후 재연결에서 실행되지 않는다', () => {
+      const sc = new SocketClient();
+      const cb = vi.fn();
+      const unregister = sc.onReconnect(cb);
+
+      triggerConnect(sc); // 최초
+      unregister();
+      triggerConnect(sc); // 재연결
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
   describe('subscribe', () => {
     test('onConnect를 경유하여 client.subscribe를 호출하고 subscriptions에 추가한다', () => {
       const sc = new SocketClient();

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -42,6 +42,9 @@ type OnConnect = {
 export default class SocketClient {
   private client: Client;
   private onConnectQueue: OnConnect[] = [];
+  private onReconnectQueue: Array<() => void> = [];
+  // 최초 connect 와 재연결을 구분하기 위한 플래그. onReconnect 콜백은 최초 connect 에선 건너뛴다.
+  private hasConnectedBefore = false;
   public subscriptions: Subscription[] = [];
   private heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
   private heartbeatSubscription: StompSubscription | undefined;
@@ -63,6 +66,13 @@ export default class SocketClient {
 
       this.onConnectQueue.forEach(({ callback }) => callback());
       this.onConnectQueue = this.onConnectQueue.filter(({ options }) => !options?.once);
+
+      // 재연결(최초 connect 이후)에서만 resync 등 복구 콜백을 실행한다.
+      // 최초 connect 의 초기 셋업(getSetupInfo)은 onConnect once 경로가 담당하므로 중복 방지.
+      if (this.hasConnectedBefore) {
+        this.onReconnectQueue.forEach((callback) => callback());
+      }
+      this.hasConnectedBefore = true;
     };
 
     const handleDisconnect = () => {
@@ -135,6 +145,23 @@ export default class SocketClient {
     }
 
     this.onConnectQueue.push({ callback, options });
+  }
+
+  /**
+   * 재연결(최초 connect 이후의 모든 connect) 시마다 콜백을 실행합니다.
+   * **최초 connect 에서는 실행되지 않습니다** — 초기 셋업은 `onConnect`(once) 가 담당하므로,
+   * 본 콜백은 끊겼다 다시 붙었을 때의 상태 복구(resync) 전용입니다.
+   *
+   * fire-and-forget broadcast(예: PLAYBACK_STARTED)는 끊긴 구간에 발행되면 영구 유실되므로,
+   * 재연결 시 서버 상태를 다시 조회해 self-heal 하는 용도로 사용합니다.
+   *
+   * @returns 등록 해제 함수 (컴포넌트 언마운트 시 호출하여 누수 방지)
+   */
+  public onReconnect(callback: () => void): () => void {
+    this.onReconnectQueue.push(callback);
+    return () => {
+      this.onReconnectQueue = this.onReconnectQueue.filter((registered) => registered !== callback);
+    };
   }
 
   /**


### PR DESCRIPTION
## 개요
백그라운드 탭에서 타이머 throttling / 연결 끊김으로 `PLAYBACK_STARTED`(fire-and-forget broadcast)를 놓치면, 재연결 후에도 ack/replay 가 없어 **영구 유실**돼 곡이 갱신되지 않던 문제. 이슈 #335 의 **resync-only(Phase 1)** 구현.

closes #335

## 접근 (피지빌리티)
백그라운드 탭에서 "실시간 이벤트 100% 수신"은 cross-browser 로 보장 불가(플랫폼 정책). 대신 **복귀 시점에 놓친 상태를 재조회해 self-heal** 하는 것이 확실한 해법 — 우리 코드에 빠져 있던 복구 경로(결함 ②: `once:true` 라 reconnect 시 resync 부재)를 메운다.

## 변경
- **`SocketClient.onReconnect(cb): () => void`** 신설 — 최초 connect 를 제외한 재연결마다 실행되는 복구 콜백 등록(+해제 함수 반환). 초기 셋업을 담당하는 기존 `onConnect(once)` 와 책임 분리(중복 `getSetupInfo` 방지).
- **`PartyroomClient.onReconnect`** 위임.
- **`usePlaybackResync(partyroomId)`** 훅 신설 — 두 트리거에서 `getSetupInfo` 재조회 후 `playback / playbackActivated / currentDj` 재주입:
  - `reconnect`: 끊겼다 다시 붙은 경우.
  - `visibilitychange(hidden→visible)`: 연결이 half-open 으로 유지된 채 이벤트만 놓친 경우도 보정.
- **`PartyroomLayout`** 에서 마운트(세션 경계).

## 설계 메모
- `enter` mutation 은 재호출하지 않는다(crew 재등록 / analytics 중복 방지). resync 는 재생상태만 갱신하는 가벼운 경로.
- 구독은 `SocketClient` 가 reconnect 시 `subscriptions[]`(단일 진실원천) 기준으로 자체 reconcile 하므로 별도 재구독 불필요.
- `playbackActivated=false` 면 `playback/currentDj` 가 `undefined` 로 정리됨 → 백그라운드 중 트랙 종료/큐 비움도 올바르게 self-heal.
- reconnect + visibilitychange 가 복귀 시 둘 다 발화해 resync 가 2회 일어날 수 있으나 동일 상태 주입이라 idempotent(무해).

## 검증
- ✅ `SocketClient.onReconnect` 3건(최초 제외 / 재연결마다 실행 / 해제), `PartyroomClient` 위임 1건, `usePlaybackResync` 4건(visible 주입 / reconnect 주입 / hidden no-op / 언마운트 정리), `PartyroomLayout` 마운트 1건.
- ✅ `yarn test` 전체 239 파일 / 1304 통과, `yarn test:type` 통과, eslint 클린.

## 후속 (별도 백로그)
- Phase 2: WS 연결을 SharedWorker 로 이전해 백그라운드 실시간 수신 구간 확대(Phase 1 이 안전망이므로 worker 가 죽어도 self-heal). 이번 PR 범위 외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)