### PR TITLE
fix(player): 트랙 변경 시 player 재사용으로 백그라운드 연속 재생 (#335)

### DIFF
--- a/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
@@ -97,13 +97,25 @@ export default function Video({
     }
   }, [cinemaView, pendingFullscreen, setPendingFullscreen]);
 
+  // 현재 트랙의 라이브 위치로 seek 한다. player 준비(onReady)·트랙 변경 후 새 영상 시작(onStart) 시 호출.
+  const seekToLive = () => {
+    if (!playback) return;
+    playerRef.current?.seekTo(Playback.getInitialSeek(playback as PartyroomPlayback), 'seconds');
+  };
+
   const onPlayerReady = (player: TReactPlayer) => {
     // NOTE: onReady는 미디어가 재생 준비되었을 때 호출되므로, 이 콜백이 실행되었다는건 playback.linkId가 존재한다는 것을 의미함
     playerRef.current = player;
-    const initialSeek = Playback.getInitialSeek(playback as PartyroomPlayback);
-    player.seekTo(initialSeek, 'seconds');
+    seekToLive();
     player.forceUpdate();
     setPlayerReady(true);
+  };
+
+  // 트랙이 바뀌어도 player 를 remount 하지 않고(key 에 videoId/endTime 미포함) react-player 가 같은
+  // 인스턴스에 다음 영상을 load 한다. remount 가 없어야 백그라운드 탭에서도 새 트랙 autoplay 가 차단되지
+  // 않고 재생이 이어진다. 새 영상이 시작되면(onStart) 라이브 위치로 맞춘다.
+  const onStart = () => {
+    seekToLive();
   };
 
   const onPlay = () => {
@@ -178,7 +190,7 @@ export default function Video({
     <div className='relative w-full h-full'>
       {!playable && <div className='w-full h-full bg-black'>{!!playback && <LoadingPanel />}</div>}
       <YoutubePlayer
-        key={`video-${videoId}-${playerReady}-${played}-${playback?.endTime}`}
+        key={`video-${playerReady}-${played}`}
         playing={playerReady}
         volume={muted ? 0 : volume}
         muted={muted}
@@ -187,6 +199,7 @@ export default function Video({
         url={`https://www.youtube.com/watch?v=${videoId}`}
         className={playerClass}
         onReady={onPlayerReady}
+        onStart={onStart}
         onPlay={onPlay}
         config={config}
         pip={false}
@@ -296,7 +309,7 @@ export default function Video({
       )}
 
       <YoutubePlayer
-        key={`video-${videoId}-${playerReady}-${played}-${playback?.endTime}`}
+        key={`video-${playerReady}-${played}`}
         playing={playerReady}
         volume={muted ? 0 : volume}
         muted={muted}
@@ -305,6 +318,7 @@ export default function Video({
         url={`https://www.youtube.com/watch?v=${videoId}`}
         className={playerClass}
         onReady={onPlayerReady}
+        onStart={onStart}
         onPlay={onPlay}
         config={config}
         pip={false}


### PR DESCRIPTION
## 개요
백그라운드 탭에서 곡이 바뀔 때 재생이 멈추던 문제(#335)를 해결합니다.

closes #335

## 진단 (원래 가설 폐기)
원 이슈는 "백그라운드 중 `PLAYBACK_STARTED` 이벤트 유실"로 추정했으나, 로컬 실측 결과 **그렇지 않았습니다**:
- 백그라운드 탭에서도 WS는 살아있고 `PLAYBACK_STARTED`를 **정상 수신**(콘솔 확인). 새 곡 처리·seek 계산까지 정상 수행.
- 진짜 원인: 트랙 변경 시 전광판 player가 **remount**되면서, 백그라운드 탭에서는 **새로 mount된 video의 autoplay가 브라우저 정책상 차단** → 트랙 경계마다 재생이 멈추고, 복귀 시 멈춰있던 지점부터 재생.

→ resync-on-recover(별도 검토 PR #339)로는 해결 불가하여 close하고, player 재사용으로 직접 해결.

## 변경 (`video.component.tsx`)
- **`YoutubePlayer` key 에서 `videoId`/`endTime` 제거** → 트랙이 바뀌어도 remount하지 않고 react-player가 같은 인스턴스에 다음 영상을 load. 이미 재생 권한을 가진 player라 백그라운드에서도 재생이 끊기지 않고 이어진다.
- **`playerReady`는 key에 유지** → 최초 진입 시 player를 보이는 상태에서 (재)생성하는 기존 워크어라운드 보존. (제거 시 `display:none`으로 초기화돼 화면 검정·소리만 나오는 회귀 발생 — 검증 중 실제 확인.)
- **`seekToLive` 추출** → `onReady`(최초) + `onStart`(트랙 변경 후 새 영상 시작) 양쪽에서 라이브 위치로 seek. remount가 없어 onReady가 트랙마다 안 불리므로 onStart 보강.

## 검증
- ✅ Chrome·Edge 로컬 in-browser 검증: **검정화면 없음 / 포그라운드 트랙 전환 정상 / 백그라운드 곡 전환 시 소리 연속 재생** 확인.
- ✅ `yarn test:type` 통과, eslint 클린, `partyroom-display-board` 테스트 44건 통과.
- ⚠️ react-player 렌더링/remount 동작이라 단위 테스트 비대상 — 실브라우저 검증으로 확인(repo에 video.component 단위테스트 없음).

## 참고
- 같은 파일(`video.component.tsx`)을 #338(이슈 #334, BT 자동재개)도 수정합니다. 영역이 달라(이쪽은 key/onStart/seekToLive, #338은 onPause) 머지 충돌 위험은 낮습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)