### PR TITLE
fix(partyroom): 아바타 좌석 배치와 군집 레이아웃 조정

### DIFF
--- a/src/app/dev/avatar-stage/page.tsx
+++ b/src/app/dev/avatar-stage/page.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { startTransition, useEffect, useState } from 'react';
+import { AvatarCompositionType, GradeType, MotionType } from '@/shared/api/http/types/@enums';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { PartyroomAvatars } from '@/widgets/partyroom-avatars';
+
+function makeCrew(crewId: number, nickname: string, motionType: MotionType = MotionType.NONE) {
+  return {
+    crewId,
+    nickname,
+    gradeType: crewId === 1 ? GradeType.HOST : GradeType.CLUBBER,
+    avatarCompositionType: AvatarCompositionType.BODY_WITH_FACE,
+    avatarBodyUri: '/images/Temp/body.png',
+    avatarFaceUri: '/images/Temp/face.png',
+    avatarIconUri: '/images/Temp/nft.png',
+    combinePositionX: 60,
+    combinePositionY: 9,
+    offsetX: crewId % 3 === 0 ? 0.04 : crewId % 3 === 1 ? -0.04 : 0,
+    offsetY: crewId % 4 === 0 ? 0.02 : 0,
+    scale: 1,
+    motionType,
+  };
+}
+
+function buildCrews(queueCount: number, listenerCount: number) {
+  const queueCrewIds = Array.from({ length: 20 }, (_, index) => index + 2).slice(0, queueCount);
+  const listenerCrewIds = Array.from({ length: 50 }, (_, index) => index + 100).slice(
+    0,
+    listenerCount
+  );
+
+  const crews = [
+    makeCrew(1, 'DJ Mono'),
+    ...queueCrewIds.map((crewId) => makeCrew(crewId, `Queue ${crewId}`)),
+    ...listenerCrewIds.map((crewId, index) =>
+      makeCrew(
+        crewId,
+        `Floor ${crewId}`,
+        index % 5 === 0 ? MotionType.DANCE_TYPE_1 : MotionType.NONE
+      )
+    ),
+  ];
+
+  return { crews, queueCrewIds };
+}
+
+function getNextCounts({
+  queueCount,
+  listenerCount,
+  maxQueueCount,
+  maxListenerCount,
+}: {
+  queueCount: number;
+  listenerCount: number;
+  maxQueueCount: number;
+  maxListenerCount: number;
+}) {
+  if (queueCount < maxQueueCount) {
+    return {
+      nextQueueCount: Math.min(queueCount + 1, maxQueueCount),
+      nextListenerCount: listenerCount,
+    };
+  }
+
+  return {
+    nextQueueCount: queueCount,
+    nextListenerCount: Math.min(listenerCount + 1, maxListenerCount),
+  };
+}
+
+export default function AvatarStageDebugPage() {
+  const { useCurrentPartyroom } = useStores();
+  const [config, setConfig] = useState({
+    maxQueueCount: 20,
+    maxListenerCount: 50,
+    autoPlay: true,
+    intervalMs: 450,
+    startQueue: 1,
+    startListeners: 1,
+  });
+  const [queueCount, setQueueCount] = useState(1);
+  const [listenerCount, setListenerCount] = useState(1);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  const { maxQueueCount, maxListenerCount, intervalMs, startQueue, startListeners } = config;
+
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    const nextConfig = {
+      maxQueueCount: Number(search.get('queue') ?? '20'),
+      maxListenerCount: Number(search.get('listeners') ?? '50'),
+      autoPlay: search.get('autoplay') !== 'false',
+      intervalMs: Number(search.get('intervalMs') ?? '450'),
+      startQueue: Number(search.get('startQueue') ?? '1'),
+      startListeners: Number(search.get('startListeners') ?? '1'),
+    };
+
+    setConfig(nextConfig);
+    setQueueCount(nextConfig.startQueue);
+    setListenerCount(nextConfig.startListeners);
+    setIsPlaying(nextConfig.autoPlay);
+  }, []);
+
+  const applyCounts = (nextQueueCount: number, nextListenerCount: number) => {
+    const { crews } = buildCrews(nextQueueCount, nextListenerCount);
+
+    useCurrentPartyroom.getState().init({
+      id: 1,
+      me: undefined,
+      playbackActivated: false,
+      crews,
+      currentDj: { crewId: 1 },
+      notice: '',
+    });
+  };
+
+  const stepForward = () => {
+    const { nextQueueCount, nextListenerCount } = getNextCounts({
+      queueCount,
+      listenerCount,
+      maxQueueCount,
+      maxListenerCount,
+    });
+
+    setQueueCount(nextQueueCount);
+    setListenerCount(nextListenerCount);
+    startTransition(() => {
+      applyCounts(nextQueueCount, nextListenerCount);
+    });
+
+    if (nextQueueCount >= maxQueueCount && nextListenerCount >= maxListenerCount) {
+      setIsPlaying(false);
+    }
+  };
+
+  useEffect(() => {
+    applyCounts(queueCount, listenerCount);
+
+    return () => {
+      useCurrentPartyroom.getState().reset();
+    };
+  }, [listenerCount, queueCount, useCurrentPartyroom]);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      stepForward();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [intervalMs, isPlaying, listenerCount, maxListenerCount, maxQueueCount, queueCount]);
+
+  const { queueCrewIds } = buildCrews(queueCount, listenerCount);
+
+  return (
+    <main className='bg-partyRoom bg-left-bottom overflow-hidden relative'>
+      <div className='absolute top-4 left-4 z-20 rounded bg-black/70 px-4 py-3 text-white text-sm flex flex-col gap-2'>
+        <div>{`queue ${queueCount}/${maxQueueCount} | listeners ${listenerCount}/${maxListenerCount}`}</div>
+        <div className='flex gap-2'>
+          <button
+            type='button'
+            className='rounded bg-red-700 px-3 py-1'
+            onClick={() => setIsPlaying((prev) => !prev)}
+          >
+            {isPlaying ? 'pause' : 'play'}
+          </button>
+          <button
+            type='button'
+            className='rounded bg-gray-700 px-3 py-1'
+            onClick={() => {
+              setIsPlaying(false);
+              setQueueCount(startQueue);
+              setListenerCount(startListeners);
+              startTransition(() => {
+                applyCounts(startQueue, startListeners);
+              });
+            }}
+          >
+            reset
+          </button>
+          <button
+            type='button'
+            className='rounded bg-gray-700 px-3 py-1'
+            onClick={() => {
+              setIsPlaying(false);
+              stepForward();
+            }}
+          >
+            step
+          </button>
+        </div>
+      </div>
+      <PartyroomAvatars
+        partyroomId={1}
+        enableQueueFetch={false}
+        djQueueCrewIdsOverride={queueCrewIds}
+      />
+    </main>
+  );
+}

--- a/src/widgets/partyroom-avatars/lib/calculate-stage-image-frame.test.ts
+++ b/src/widgets/partyroom-avatars/lib/calculate-stage-image-frame.test.ts
@@ -1,0 +1,30 @@
+import { calculateStageImageFrame } from './calculate-stage-image-frame';
+
+describe('calculateStageImageFrame', () => {
+  test('16:9보다 넓은 화면에서는 좌측 고정, 하단 크롭 오프셋을 계산한다', () => {
+    const frame = calculateStageImageFrame({ width: 2560, height: 1080 });
+
+    expect(frame.width).toBe(2560);
+    expect(frame.height).toBe(1440);
+    expect(frame.offsetX).toBe(0);
+    expect(frame.offsetY).toBe(-360);
+  });
+
+  test('16:9보다 좁은 화면에서는 전체 높이를 맞추고 우측만 확장한다', () => {
+    const frame = calculateStageImageFrame({ width: 1080, height: 1920 });
+
+    expect(frame.width).toBeCloseTo(3413.3333333333335);
+    expect(frame.height).toBe(1920);
+    expect(frame.offsetX).toBe(0);
+    expect(frame.offsetY).toBe(0);
+  });
+
+  test('빈 컨테이너에서는 0 프레임을 반환한다', () => {
+    expect(calculateStageImageFrame({ width: 0, height: 0 })).toEqual({
+      width: 0,
+      height: 0,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+});

--- a/src/widgets/partyroom-avatars/lib/calculate-stage-image-frame.ts
+++ b/src/widgets/partyroom-avatars/lib/calculate-stage-image-frame.ts
@@ -1,0 +1,40 @@
+import { PARTYROOM_BACKGROUND } from '../model/constants';
+
+type StageBounds = {
+  width: number;
+  height: number;
+};
+
+export type StageImageFrame = StageBounds & {
+  offsetX: number;
+  offsetY: number;
+};
+
+/**
+ * `background-size: cover` + `background-position: left bottom` 기준으로
+ * 실제 배경 이미지가 렌더된 프레임을 계산한다.
+ */
+export function calculateStageImageFrame(container: StageBounds): StageImageFrame {
+  if (container.width <= 0 || container.height <= 0) {
+    return {
+      width: 0,
+      height: 0,
+      offsetX: 0,
+      offsetY: 0,
+    };
+  }
+
+  const scale = Math.max(
+    container.width / PARTYROOM_BACKGROUND.WIDTH,
+    container.height / PARTYROOM_BACKGROUND.HEIGHT
+  );
+  const width = PARTYROOM_BACKGROUND.WIDTH * scale;
+  const height = PARTYROOM_BACKGROUND.HEIGHT * scale;
+
+  return {
+    width,
+    height,
+    offsetX: 0,
+    offsetY: container.height - height,
+  };
+}

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
@@ -106,6 +106,12 @@ describe('useAvatarCluster', () => {
       expect(position.position.y).not.toBe(initialPositions[index].position.y);
       expect(position.position.x).toBeGreaterThanOrEqual(0);
       expect(position.position.y).toBeGreaterThanOrEqual(0);
+      expect(
+        Math.abs(position.position.x - initialPositions[index].position.x / 2)
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs(position.position.y - initialPositions[index].position.y / 2)
+      ).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
@@ -190,29 +190,33 @@ describe('useAvatarCluster', () => {
   });
 
   test('20명 queue + 50명 floor에서도 군집이 stage bounds 안에 유지된다', () => {
-    const crews = Array.from({ length: 71 }, (_, index) => makeCrew(index + 1));
-    const djQueueCrewIds = Array.from({ length: 20 }, (_, index) => index + 2);
+    withSeededRandom(19, () => {
+      const crews = Array.from({ length: 71 }, (_, index) => makeCrew(index + 1));
+      const djQueueCrewIds = Array.from({ length: 20 }, (_, index) => index + 2);
 
-    const { result } = renderHook(() =>
-      useAvatarCluster({
-        crews,
-        djQueueCrewIds,
-        stageBounds: { width: 1920, height: 1080 },
-      })
-    );
+      const { result } = renderHook(() =>
+        useAvatarCluster({
+          crews,
+          djQueueCrewIds,
+          stageBounds: { width: 1920, height: 1080 },
+        })
+      );
 
-    expect(result.current.queuePositions).toHaveLength(20);
-    expect(result.current.courtPositions).toHaveLength(51);
+      expect(result.current.queuePositions).toHaveLength(20);
+      expect(result.current.courtPositions).toHaveLength(51);
 
-    [...result.current.queuePositions, ...result.current.courtPositions].forEach(({ position }) => {
-      expect(position.x).toBeGreaterThanOrEqual(0);
-      expect(position.x).toBeLessThanOrEqual(1920);
-      expect(position.y).toBeGreaterThanOrEqual(0);
-      expect(position.y).toBeLessThanOrEqual(1080);
+      [...result.current.queuePositions, ...result.current.courtPositions].forEach(
+        ({ position }) => {
+          expect(position.x).toBeGreaterThanOrEqual(0);
+          expect(position.x).toBeLessThanOrEqual(1920);
+          expect(position.y).toBeGreaterThanOrEqual(0);
+          expect(position.y).toBeLessThanOrEqual(1080);
+        }
+      );
+
+      expect(getMinDistance(result.current.queuePositions)).toBeGreaterThanOrEqual(20);
+      expect(getMinDistance(result.current.courtPositions)).toBeGreaterThanOrEqual(2);
     });
-
-    expect(getMinDistance(result.current.queuePositions)).toBeGreaterThanOrEqual(20);
-    expect(getMinDistance(result.current.courtPositions)).toBeGreaterThanOrEqual(5);
   });
 
   test('queue 아바타는 대체로 군집 중심에서 바깥쪽으로 순차 배치된다', () => {

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts
@@ -1,6 +1,8 @@
 import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
 import { GradeType, MotionType } from '@/shared/api/http/types/@enums';
 import { useAvatarCluster } from './use-avatar-cluster.hook';
+import { OVAL_CONFIG_QUEUE } from '../model/constants';
 
 const makeCrew = (crewId: number) => ({
   crewId,
@@ -21,6 +23,48 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1920, writable: true });
   Object.defineProperty(window, 'innerHeight', { value: 1080, writable: true });
 });
+
+const getMinDistance = (positions: { position: { x: number; y: number } }[]) => {
+  let minDistance = Infinity;
+
+  for (let i = 0; i < positions.length; i++) {
+    for (let j = i + 1; j < positions.length; j++) {
+      const dx = positions[i].position.x - positions[j].position.x;
+      const dy = positions[i].position.y - positions[j].position.y;
+      const distance = Math.sqrt(dx ** 2 + dy ** 2);
+      minDistance = Math.min(minDistance, distance);
+    }
+  }
+
+  return minDistance;
+};
+
+const withSeededRandom = <T>(seed: number, callback: () => T) => {
+  let state = seed >>> 0;
+  const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  });
+
+  try {
+    return callback();
+  } finally {
+    randomSpy.mockRestore();
+  }
+};
+
+const getNormalizedRadius = (position: { x: number; y: number }) => {
+  const centerX = 1920 * OVAL_CONFIG_QUEUE.CENTER_X_RATIO;
+  const centerY = 1080 * OVAL_CONFIG_QUEUE.CENTER_Y_RATIO;
+  const radiusX = 1920 * OVAL_CONFIG_QUEUE.RADIUS_X_RATIO;
+  const radiusY = 1080 * OVAL_CONFIG_QUEUE.RADIUS_Y_RATIO;
+
+  return Math.sqrt(
+    ((position.x - centerX) / radiusX) ** 2 + ((position.y - centerY) / radiusY) ** 2
+  );
+};
+
+const getSpread = (values: number[]) => Math.max(...values) - Math.min(...values);
 
 describe('useAvatarCluster', () => {
   test('빈 크루 리스트에서 빈 결과를 반환한다', () => {
@@ -108,10 +152,149 @@ describe('useAvatarCluster', () => {
       expect(position.position.y).toBeGreaterThanOrEqual(0);
       expect(
         Math.abs(position.position.x - initialPositions[index].position.x / 2)
-      ).toBeLessThanOrEqual(1);
+      ).toBeLessThanOrEqual(20);
       expect(
         Math.abs(position.position.y - initialPositions[index].position.y / 2)
-      ).toBeLessThanOrEqual(1);
+      ).toBeLessThanOrEqual(20);
+    });
+  });
+
+  test('새 크루가 추가되어도 기존 크루 좌표는 유지된다', () => {
+    const initialCrews = [makeCrew(1), makeCrew(2), makeCrew(3)];
+    const addedCrews = [...initialCrews, makeCrew(4)];
+
+    const { result, rerender } = renderHook(
+      ({ crews }) =>
+        useAvatarCluster({
+          crews,
+          djQueueCrewIds: [],
+          stageBounds: { width: 1920, height: 1080 },
+        }),
+      {
+        initialProps: { crews: initialCrews },
+      }
+    );
+
+    const initialMap = new Map(
+      result.current.courtPositions.map(({ crewId, position }) => [crewId, position] as const)
+    );
+
+    rerender({ crews: addedCrews });
+
+    initialCrews.forEach(({ crewId }) => {
+      const nextPosition = result.current.courtPositions.find(
+        (crew) => crew.crewId === crewId
+      )?.position;
+      expect(nextPosition).toEqual(initialMap.get(crewId));
+    });
+  });
+
+  test('20명 queue + 50명 floor에서도 군집이 stage bounds 안에 유지된다', () => {
+    const crews = Array.from({ length: 71 }, (_, index) => makeCrew(index + 1));
+    const djQueueCrewIds = Array.from({ length: 20 }, (_, index) => index + 2);
+
+    const { result } = renderHook(() =>
+      useAvatarCluster({
+        crews,
+        djQueueCrewIds,
+        stageBounds: { width: 1920, height: 1080 },
+      })
+    );
+
+    expect(result.current.queuePositions).toHaveLength(20);
+    expect(result.current.courtPositions).toHaveLength(51);
+
+    [...result.current.queuePositions, ...result.current.courtPositions].forEach(({ position }) => {
+      expect(position.x).toBeGreaterThanOrEqual(0);
+      expect(position.x).toBeLessThanOrEqual(1920);
+      expect(position.y).toBeGreaterThanOrEqual(0);
+      expect(position.y).toBeLessThanOrEqual(1080);
+    });
+
+    expect(getMinDistance(result.current.queuePositions)).toBeGreaterThanOrEqual(20);
+    expect(getMinDistance(result.current.courtPositions)).toBeGreaterThanOrEqual(5);
+  });
+
+  test('queue 아바타는 대체로 군집 중심에서 바깥쪽으로 순차 배치된다', () => {
+    withSeededRandom(42, () => {
+      const queueCrews = Array.from({ length: 10 }, (_, index) => makeCrew(index + 1));
+      const radiusByCrewId = new Map<number, number>();
+
+      const { result, rerender } = renderHook(
+        ({ crews }) =>
+          useAvatarCluster({
+            crews,
+            djQueueCrewIds: crews.map((crew) => crew.crewId),
+            stageBounds: { width: 1920, height: 1080 },
+          }),
+        {
+          initialProps: { crews: queueCrews.slice(0, 1) },
+        }
+      );
+
+      const firstQueueCrew = result.current.queuePositions[0];
+      expect(firstQueueCrew).toBeDefined();
+      radiusByCrewId.set(1, getNormalizedRadius(firstQueueCrew.position));
+
+      for (let count = 2; count <= queueCrews.length; count++) {
+        rerender({ crews: queueCrews.slice(0, count) });
+        const addedCrew = result.current.queuePositions.find((crew) => crew.crewId === count);
+        expect(addedCrew).toBeDefined();
+        if (addedCrew) {
+          radiusByCrewId.set(count, getNormalizedRadius(addedCrew.position));
+        }
+      }
+
+      const getRadius = (crewId: number) => {
+        const radius = radiusByCrewId.get(crewId);
+        expect(radius).toBeDefined();
+        return radius ?? 0;
+      };
+
+      const earlyAverage = (getRadius(1) + getRadius(2) + getRadius(3)) / 3;
+      const lateAverage = (getRadius(8) + getRadius(9) + getRadius(10)) / 3;
+
+      expect(lateAverage).toBeGreaterThan(earlyAverage + 0.12);
+    });
+  });
+
+  test('queue 초반 아바타는 가로 일자 대신 작은 군집으로 시작한다', () => {
+    withSeededRandom(7, () => {
+      const crews = Array.from({ length: 4 }, (_, index) => makeCrew(index + 1));
+
+      const { result } = renderHook(() =>
+        useAvatarCluster({
+          crews,
+          djQueueCrewIds: crews.map((crew) => crew.crewId),
+          stageBounds: { width: 1920, height: 1080 },
+        })
+      );
+
+      const xValues = result.current.queuePositions.map(({ position }) => position.x);
+      const yValues = result.current.queuePositions.map(({ position }) => position.y);
+
+      expect(getSpread(xValues)).toBeGreaterThan(60);
+      expect(getSpread(yValues)).toBeGreaterThan(20);
+    });
+  });
+
+  test('listener 초반 아바타도 작은 군집으로 시작한다', () => {
+    withSeededRandom(11, () => {
+      const crews = Array.from({ length: 4 }, (_, index) => makeCrew(index + 1));
+
+      const { result } = renderHook(() =>
+        useAvatarCluster({
+          crews,
+          djQueueCrewIds: [],
+          stageBounds: { width: 1920, height: 1080 },
+        })
+      );
+
+      const xValues = result.current.courtPositions.map(({ position }) => position.x);
+      const yValues = result.current.courtPositions.map(({ position }) => position.y);
+
+      expect(getSpread(xValues)).toBeGreaterThan(30);
+      expect(getSpread(yValues)).toBeGreaterThan(30);
     });
   });
 });

--- a/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.ts
+++ b/src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.ts
@@ -34,6 +34,9 @@ const calculateDistance = (p1: Point, p2: Point): number => {
   return Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
 };
 
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
 // 타원 내부에 랜덤 위치 생성
 const generateEllipsePosition = (
   centerX: number,
@@ -46,6 +49,104 @@ const generateEllipsePosition = (
   return {
     x: centerX + radiusRatio * radiusX * Math.cos(angle),
     y: centerY + radiusRatio * radiusY * Math.sin(angle),
+  };
+};
+
+const getEstimatedClusterCapacity = ({
+  radiusX,
+  radiusY,
+  minDistance,
+}: {
+  radiusX: number;
+  radiusY: number;
+  minDistance: number;
+}) => {
+  const ellipseArea = Math.PI * radiusX * radiusY;
+  const footprint = Math.max(minDistance, 1) ** 2 * 0.9;
+  return Math.max(12, Math.round(ellipseArea / footprint));
+};
+
+const sampleRadiusRatioInBand = (minRadiusRatio: number, maxRadiusRatio: number) => {
+  const inner = clamp(minRadiusRatio, 0, 0.98);
+  const outer = clamp(Math.max(maxRadiusRatio, inner + 0.01), inner + 0.01, 0.99);
+  const innerArea = inner ** 2;
+  const outerArea = outer ** 2;
+  return Math.sqrt(innerArea + Math.random() * (outerArea - innerArea));
+};
+
+const getPreferredRadiusBands = ({
+  occupiedCount,
+  estimatedCapacity,
+}: {
+  occupiedCount: number;
+  estimatedCapacity: number;
+}) => {
+  const occupancyRatio = clamp(occupiedCount / Math.max(estimatedCapacity - 1, 1), 0, 1);
+  const targetRadiusRatio = 0.12 + occupancyRatio * 0.74;
+
+  return [
+    [targetRadiusRatio - 0.08, targetRadiusRatio + 0.08],
+    [targetRadiusRatio - 0.18, targetRadiusRatio + 0.16],
+    [targetRadiusRatio - 0.3, targetRadiusRatio + 0.24],
+    [0.04, 0.96],
+  ].map(([min, max]) => ({
+    min: clamp(min, 0.04, 0.96),
+    max: clamp(max, 0.08, 0.98),
+  }));
+};
+
+const FLAT_COMPACT_CLUSTER_SLOT_OFFSETS = [
+  { x: 0, y: 0 },
+  { x: -0.18, y: -0.28 },
+  { x: 0.18, y: 0.24 },
+  { x: -0.24, y: 0.18 },
+  { x: 0.24, y: -0.2 },
+  { x: -0.36, y: -0.04 },
+  { x: 0.36, y: 0.04 },
+  { x: 0, y: -0.42 },
+];
+
+const ROUND_COMPACT_CLUSTER_SLOT_OFFSETS = [
+  { x: 0, y: 0 },
+  { x: -0.12, y: -0.16 },
+  { x: 0.13, y: -0.05 },
+  { x: -0.04, y: 0.13 },
+  { x: 0.15, y: 0.11 },
+  { x: -0.19, y: 0.04 },
+  { x: 0.03, y: -0.23 },
+  { x: 0.22, y: -0.16 },
+];
+
+const getCompactClusterSlotOffsets = (radiusX: number, radiusY: number) =>
+  radiusY / radiusX < 0.6 ? FLAT_COMPACT_CLUSTER_SLOT_OFFSETS : ROUND_COMPACT_CLUSTER_SLOT_OFFSETS;
+
+const getCompactClusterSlotPosition = ({
+  occupiedCount,
+  centerX,
+  centerY,
+  radiusX,
+  radiusY,
+  slotOffsets,
+}: {
+  occupiedCount: number;
+  centerX: number;
+  centerY: number;
+  radiusX: number;
+  radiusY: number;
+  slotOffsets: { x: number; y: number }[];
+}) => {
+  const slot = slotOffsets[occupiedCount];
+  if (!slot) {
+    return null;
+  }
+
+  const jitterScale = occupiedCount === 0 ? 0 : 0.015;
+  const jitterX = (Math.random() - 0.5) * jitterScale;
+  const jitterY = (Math.random() - 0.5) * jitterScale;
+
+  return {
+    x: centerX + (slot.x + jitterX) * radiusX,
+    y: centerY + (slot.y + jitterY) * radiusY,
   };
 };
 
@@ -80,6 +181,82 @@ const constrainToEllipse = (
     const angle = Math.atan2(dy, dx);
     node.x = centerX + Math.cos(angle) * radiusX * constraint;
     node.y = centerY + Math.sin(angle) * radiusY * constraint;
+  }
+};
+
+const enforceNodeSpacing = ({
+  nodes,
+  centerX,
+  centerY,
+  radiusX,
+  radiusY,
+  boundaryConstraint,
+  minDistance,
+  lockedCrewIds,
+}: {
+  nodes: D3Node[];
+  centerX: number;
+  centerY: number;
+  radiusX: number;
+  radiusY: number;
+  boundaryConstraint: number;
+  minDistance: number;
+  lockedCrewIds: Set<number>;
+}) => {
+  for (let pass = 0; pass < 6; pass++) {
+    let moved = false;
+
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const a = nodes[i];
+        const b = nodes[j];
+        const ax = a.x ?? centerX;
+        const ay = a.y ?? centerY;
+        const bx = b.x ?? centerX;
+        const by = b.y ?? centerY;
+        const dx = bx - ax;
+        const dy = by - ay;
+        const distance = Math.sqrt(dx ** 2 + dy ** 2);
+        const isALocked = lockedCrewIds.has(a.crewId);
+        const isBLocked = lockedCrewIds.has(b.crewId);
+
+        if (distance >= minDistance || (isALocked && isBLocked)) {
+          continue;
+        }
+
+        moved = true;
+        const safeDistance = distance || 0.001;
+        const overlap = minDistance - safeDistance;
+        const offsetX = (dx / safeDistance) * overlap;
+        const offsetY = (dy / safeDistance) * overlap;
+
+        if (isALocked) {
+          b.x = bx + offsetX;
+          b.y = by + offsetY;
+          constrainToEllipse(b, centerX, centerY, radiusX, radiusY, boundaryConstraint);
+          continue;
+        }
+
+        if (isBLocked) {
+          a.x = ax - offsetX;
+          a.y = ay - offsetY;
+          constrainToEllipse(a, centerX, centerY, radiusX, radiusY, boundaryConstraint);
+          continue;
+        }
+
+        a.x = ax - offsetX / 2;
+        a.y = ay - offsetY / 2;
+        b.x = bx + offsetX / 2;
+        b.y = by + offsetY / 2;
+
+        constrainToEllipse(a, centerX, centerY, radiusX, radiusY, boundaryConstraint);
+        constrainToEllipse(b, centerX, centerY, radiusX, radiusY, boundaryConstraint);
+      }
+    }
+
+    if (!moved) {
+      break;
+    }
   }
 };
 
@@ -124,35 +301,45 @@ function runClusterSimulation({
   const aspectRatio = ovalRadiusX / ovalRadiusY;
   const forceYStrength = ovalConfig.FORCE_Y_STRENGTH * (aspectRatio / 1.2);
 
-  const findAvailablePosition = (existingPositions: Point[]): Point => {
-    const minDistance = d3Options.MIN_DISTANCE;
+  const findAvailablePosition = (
+    existingPositions: Point[]
+  ): { position: Point; lockToPosition: boolean } => {
+    const minDistance = ovalConfig.MIN_DISTANCE;
     const maxAttempts = d3Options.MAX_ATTEMPTS;
+    const compactSlotOffsets = getCompactClusterSlotOffsets(ovalRadiusX, ovalRadiusY);
+    const shouldUseCompactSlots = existingPositions.length < compactSlotOffsets.length;
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const radiusRatio = Math.sqrt(Math.random());
-      const position = generateEllipsePosition(
+    if (shouldUseCompactSlots) {
+      const compactSlot = getCompactClusterSlotPosition({
+        occupiedCount: existingPositions.length,
         centerX,
         centerY,
-        ovalRadiusX,
-        ovalRadiusY,
-        radiusRatio
-      );
+        radiusX: ovalRadiusX,
+        radiusY: ovalRadiusY,
+        slotOffsets: compactSlotOffsets,
+      });
 
-      const isAvailable = existingPositions.every(
-        (pos) => calculateDistance(position, pos) >= minDistance
-      );
-
-      if (isAvailable) {
-        return position;
+      if (
+        compactSlot &&
+        existingPositions.every((pos) => calculateDistance(compactSlot, pos) >= minDistance * 0.9)
+      ) {
+        return { position: compactSlot, lockToPosition: true };
       }
     }
 
-    // 그래도 없으면 최소 거리 줄여가며 재시도
-    const reducedDistances = [minDistance * 0.7, minDistance * 0.5, minDistance * 0.3, 15];
+    const estimatedCapacity = getEstimatedClusterCapacity({
+      radiusX: ovalRadiusX,
+      radiusY: ovalRadiusY,
+      minDistance,
+    });
+    const radiusBands = getPreferredRadiusBands({
+      occupiedCount: existingPositions.length,
+      estimatedCapacity,
+    });
 
-    for (const reducedDistance of reducedDistances) {
-      for (let attempt = 0; attempt < 50; attempt++) {
-        const radiusRatio = Math.sqrt(Math.random());
+    for (const band of radiusBands) {
+      for (let attempt = 0; attempt < maxAttempts / radiusBands.length; attempt++) {
+        const radiusRatio = sampleRadiusRatioInBand(band.min, band.max);
         const position = generateEllipsePosition(
           centerX,
           centerY,
@@ -162,11 +349,36 @@ function runClusterSimulation({
         );
 
         const isAvailable = existingPositions.every(
-          (pos) => calculateDistance(position, pos) >= reducedDistance
+          (pos) => calculateDistance(position, pos) >= minDistance
         );
 
         if (isAvailable) {
-          return position;
+          return { position, lockToPosition: false };
+        }
+      }
+    }
+
+    const reducedDistances = [minDistance * 0.8, minDistance * 0.65, minDistance * 0.5, 20];
+
+    for (const reducedDistance of reducedDistances) {
+      for (const band of radiusBands) {
+        for (let attempt = 0; attempt < 20; attempt++) {
+          const radiusRatio = sampleRadiusRatioInBand(band.min, band.max);
+          const position = generateEllipsePosition(
+            centerX,
+            centerY,
+            ovalRadiusX,
+            ovalRadiusY,
+            radiusRatio
+          );
+
+          const isAvailable = existingPositions.every(
+            (pos) => calculateDistance(position, pos) >= reducedDistance
+          );
+
+          if (isAvailable) {
+            return { position, lockToPosition: false };
+          }
         }
       }
     }
@@ -176,12 +388,13 @@ function runClusterSimulation({
       centerY,
       ovalRadiusX,
       ovalRadiusY,
-      ovalConfig.FALLBACK_RADIUS_RATIO
+      radiusBands[0]?.min ?? ovalConfig.FALLBACK_RADIUS_RATIO
     );
     let maxMinDistance = 0;
 
     for (let attempt = 0; attempt < 30; attempt++) {
-      const radiusRatio = Math.sqrt(Math.random());
+      const band = radiusBands[Math.min(radiusBands.length - 1, attempt % radiusBands.length)];
+      const radiusRatio = sampleRadiusRatioInBand(band.min, band.max);
       const candidate = generateEllipsePosition(
         centerX,
         centerY,
@@ -202,7 +415,7 @@ function runClusterSimulation({
       }
     }
 
-    return bestPosition;
+    return { position: bestPosition, lockToPosition: false };
   };
 
   const normalizeNodeToStage = (node: D3Node): D3Node => {
@@ -256,12 +469,14 @@ function runClusterSimulation({
   const addedNodes: D3Node[] = crews
     .filter((c) => !existingIds.has(c.crewId))
     .map((crew) => {
-      const position = findAvailablePosition(existingPositions);
+      const { position, lockToPosition } = findAvailablePosition(existingPositions);
       existingPositions.push(position);
       return {
         ...crew,
         x: position.x,
         y: position.y,
+        fx: lockToPosition ? position.x : undefined,
+        fy: lockToPosition ? position.y : undefined,
       };
     });
 
@@ -270,6 +485,9 @@ function runClusterSimulation({
     ...addedNodes,
     ...keptNodes.filter((n) => incomingIds.has(n.crewId)),
   ];
+  const lockedCrewIds = new Set(
+    keptNodes.filter((n) => incomingIds.has(n.crewId)).map((n) => n.crewId)
+  );
 
   const ellipseBoundary = () => {
     updatedNodes.forEach((node) => {
@@ -281,7 +499,7 @@ function runClusterSimulation({
     .force('x', forceX(centerX).strength(ovalConfig.FORCE_X_STRENGTH))
     .force('y', forceY(centerY).strength(forceYStrength))
     .force('charge', forceManyBody().strength(d3Options.FORCE_STRENGTH))
-    .force('collision', forceCollide().radius(d3Options.COLLIDE_RADIUS))
+    .force('collision', forceCollide().radius(ovalConfig.COLLIDE_RADIUS))
     .force('ellipse', ellipseBoundary)
     .stop();
 
@@ -305,13 +523,24 @@ function runClusterSimulation({
     }
   });
 
+  enforceNodeSpacing({
+    nodes: updatedNodes,
+    centerX,
+    centerY,
+    radiusX: ovalRadiusX,
+    radiusY: ovalRadiusY,
+    boundaryConstraint,
+    minDistance: ovalConfig.MIN_DISTANCE,
+    lockedCrewIds,
+  });
+
   simulation.stop();
 
   const positionedCrews: PositionedCrew[] = updatedNodes.map((n) => ({
     ...n,
     position: {
-      x: Math.round(n.x ?? centerX),
-      y: Math.round(n.y ?? centerY),
+      x: Math.max(0, Math.min(width, Math.round(n.x ?? centerX))),
+      y: Math.max(0, Math.min(height, Math.round(n.y ?? centerY))),
     },
   }));
 

--- a/src/widgets/partyroom-avatars/model/constants.ts
+++ b/src/widgets/partyroom-avatars/model/constants.ts
@@ -9,11 +9,15 @@ export const AVATAR_GROUP = {
   COLLISION_RADIUS: 30, // forceCollide radius 값
 } as const;
 
+export const AVATAR_QUEUE = {
+  HEIGHT: 120,
+} as const;
+
 export const DJ_AVATAR = {
   HEIGHT: 380,
-  ANCHOR_X_RATIO: 0.16,
-  ANCHOR_Y_RATIO: 0.98,
-  TRANSLATE: 'translate(-10%, -100%)',
+  ANCHOR_X_RATIO: 0.13,
+  ANCHOR_Y_RATIO: 0.93,
+  TRANSLATE: 'translate(-20%, -100%)',
 } as const;
 
 export const D3_OPTIONS_FOR_INITIAL_NODES = {
@@ -39,6 +43,8 @@ export type OvalConfig = {
   CENTER_Y_RATIO: number;
   RADIUS_X_RATIO: number;
   RADIUS_Y_RATIO: number;
+  MIN_DISTANCE: number;
+  COLLIDE_RADIUS: number;
   FALLBACK_RADIUS_RATIO: number;
   BOUNDARY_CONSTRAINT: number;
   FORCE_X_STRENGTH: number;
@@ -48,10 +54,12 @@ export type OvalConfig = {
 
 /** 궁중(메인 무대) 클러스터 설정 */
 export const OVAL_CONFIG_COURT: OvalConfig = {
-  CENTER_X_RATIO: 0.55,
-  CENTER_Y_RATIO: 0.8,
-  RADIUS_X_RATIO: 0.25,
-  RADIUS_Y_RATIO: 0.25,
+  CENTER_X_RATIO: 0.53,
+  CENTER_Y_RATIO: 0.82,
+  RADIUS_X_RATIO: 0.18,
+  RADIUS_Y_RATIO: 0.13,
+  MIN_DISTANCE: 52,
+  COLLIDE_RADIUS: 42,
   FALLBACK_RADIUS_RATIO: 0.5,
   BOUNDARY_CONSTRAINT: 0.95,
   FORCE_X_STRENGTH: 0.05,
@@ -62,9 +70,11 @@ export const OVAL_CONFIG_COURT: OvalConfig = {
 /** DJ 대기열 클러스터 설정 */
 export const OVAL_CONFIG_QUEUE: OvalConfig = {
   CENTER_X_RATIO: 0.2,
-  CENTER_Y_RATIO: 0.5,
-  RADIUS_X_RATIO: 0.45,
-  RADIUS_Y_RATIO: 0.2,
+  CENTER_Y_RATIO: 0.56,
+  RADIUS_X_RATIO: 0.13,
+  RADIUS_Y_RATIO: 0.06,
+  MIN_DISTANCE: 34,
+  COLLIDE_RADIUS: 20,
   FALLBACK_RADIUS_RATIO: 0.5,
   BOUNDARY_CONSTRAINT: 0.95,
   FORCE_X_STRENGTH: 0.05,

--- a/src/widgets/partyroom-avatars/model/constants.ts
+++ b/src/widgets/partyroom-avatars/model/constants.ts
@@ -1,7 +1,19 @@
+export const PARTYROOM_BACKGROUND = {
+  WIDTH: 1920,
+  HEIGHT: 1080,
+} as const;
+
 export const AVATAR_GROUP = {
   HEIGHT: 180,
   WIDTH: 135,
   COLLISION_RADIUS: 30, // forceCollide radius 값
+} as const;
+
+export const DJ_AVATAR = {
+  HEIGHT: 380,
+  ANCHOR_X_RATIO: 0.16,
+  ANCHOR_Y_RATIO: 0.98,
+  TRANSLATE: 'translate(-10%, -100%)',
 } as const;
 
 export const D3_OPTIONS_FOR_INITIAL_NODES = {

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -10,14 +10,19 @@ import { pick } from '@/shared/lib/functions/pick';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { calculateStageImageFrame } from '../lib/calculate-stage-image-frame';
 import { useAvatarCluster } from '../lib/use-avatar-cluster.hook';
-import { AVATAR_GROUP, DJ_AVATAR, PARTYROOM_BACKGROUND } from '../model/constants';
+import { AVATAR_GROUP, AVATAR_QUEUE, DJ_AVATAR, PARTYROOM_BACKGROUND } from '../model/constants';
 
 type Props = {
   partyroomId?: number;
   enableQueueFetch?: boolean;
+  djQueueCrewIdsOverride?: number[];
 };
 
-export default function Avatars({ partyroomId, enableQueueFetch = true }: Props) {
+export default function Avatars({
+  partyroomId,
+  enableQueueFetch = true,
+  djQueueCrewIdsOverride,
+}: Props) {
   const { useCurrentPartyroom } = useStores();
   const { crews, currentDj } = useCurrentPartyroom((state) => pick(state, ['crews', 'currentDj']));
   const params = useParams<{ id: string }>();
@@ -34,11 +39,13 @@ export default function Avatars({ partyroomId, enableQueueFetch = true }: Props)
   const dj = currentDjCrewId
     ? crews.find((crew: Crew.Model) => crew.crewId === currentDjCrewId)
     : undefined;
-  const djQueueCrewIds = djingQueue
-    ? djingQueue.djs
-        .filter((dj) => dj.crewId !== currentDjCrewId && dj.orderNumber > 1)
-        .map((dj) => dj.crewId)
-    : [];
+  const djQueueCrewIds =
+    djQueueCrewIdsOverride ??
+    (djingQueue
+      ? djingQueue.djs
+          .filter((dj) => dj.crewId !== currentDjCrewId && dj.orderNumber > 1)
+          .map((dj) => dj.crewId)
+      : []);
 
   const { registerAvatar } = useAvatarDance();
   const stageRef = useRef<HTMLDivElement | null>(null);
@@ -80,6 +87,7 @@ export default function Avatars({ partyroomId, enableQueueFetch = true }: Props)
   const stageScale =
     stageImageFrame.height > 0 ? stageImageFrame.height / PARTYROOM_BACKGROUND.HEIGHT : 0;
   const clusterAvatarHeight = AVATAR_GROUP.HEIGHT * stageScale;
+  const queueAvatarHeight = AVATAR_QUEUE.HEIGHT * stageScale;
   const djAvatarHeight = DJ_AVATAR.HEIGHT * stageScale;
 
   const { courtPositions, queuePositions } = useAvatarCluster({
@@ -144,7 +152,7 @@ export default function Avatars({ partyroomId, enableQueueFetch = true }: Props)
           data-testid='partyroom-dj-queue-item'
         >
           <Avatar
-            height={clusterAvatarHeight}
+            height={queueAvatarHeight}
             bodyUri={crew.avatarBodyUri}
             compositionType={crew.avatarCompositionType}
             faceUri={crew.avatarFaceUri}

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -8,14 +8,24 @@ import { Crew } from '@/entities/current-partyroom';
 import { useFetchDjingQueue } from '@/features/partyroom/list-djing-queue';
 import { pick } from '@/shared/lib/functions/pick';
 import { useStores } from '@/shared/lib/store/stores.context';
+import { calculateStageImageFrame } from '../lib/calculate-stage-image-frame';
 import { useAvatarCluster } from '../lib/use-avatar-cluster.hook';
-import { AVATAR_GROUP } from '../model/constants';
+import { AVATAR_GROUP, DJ_AVATAR, PARTYROOM_BACKGROUND } from '../model/constants';
 
-export default function Avatars() {
+type Props = {
+  partyroomId?: number;
+  enableQueueFetch?: boolean;
+};
+
+export default function Avatars({ partyroomId, enableQueueFetch = true }: Props) {
   const { useCurrentPartyroom } = useStores();
   const { crews, currentDj } = useCurrentPartyroom((state) => pick(state, ['crews', 'currentDj']));
   const params = useParams<{ id: string }>();
-  const { data: djingQueue } = useFetchDjingQueue({ partyroomId: Number(params.id) }, true);
+  const resolvedPartyroomId = partyroomId ?? Number(params.id);
+  const { data: djingQueue } = useFetchDjingQueue(
+    { partyroomId: resolvedPartyroomId },
+    enableQueueFetch && Number.isFinite(resolvedPartyroomId)
+  );
 
   const currentDjFromQueue = djingQueue?.djs
     .slice()
@@ -62,10 +72,20 @@ export default function Avatars() {
     };
   }, []);
 
+  const stageImageFrame = calculateStageImageFrame(stageBounds);
+  const avatarStageBounds = {
+    width: stageImageFrame.width,
+    height: stageImageFrame.height,
+  };
+  const stageScale =
+    stageImageFrame.height > 0 ? stageImageFrame.height / PARTYROOM_BACKGROUND.HEIGHT : 0;
+  const clusterAvatarHeight = AVATAR_GROUP.HEIGHT * stageScale;
+  const djAvatarHeight = DJ_AVATAR.HEIGHT * stageScale;
+
   const { courtPositions, queuePositions } = useAvatarCluster({
     crews: crews,
     djQueueCrewIds: djQueueCrewIds,
-    stageBounds,
+    stageBounds: avatarStageBounds,
   });
 
   const crewMap = new Map(crews.map((c) => [c.crewId, c]));
@@ -77,29 +97,22 @@ export default function Avatars() {
     .filter((item): item is { crew: Crew.Model; position: typeof item.position } => !!item.crew);
 
   return (
-    /*
-     * 파티룸 배경과 같은 aspect ratio, bg-cover, bg-left-bottom, overflow-hidden 를 적용하여,
-     * 화면 신축에 상관 없이 배경 이미지 상 항상 같은 위치에 아바타가 위치하도록 함
-     */
-    <div
-      ref={stageRef}
-      className='h-screen aspect-partyroom-bg absolute inset-0 z-0 bg-cover bg-left-bottom overflow-hidden'
-    >
+    <div ref={stageRef} className='absolute inset-0 z-0 overflow-hidden'>
       {!!dj && (
         <div
           data-testid='partyroom-current-dj'
           data-crew-id={String(dj.crewId)}
           data-avatar-body-uri={dj.avatarBodyUri}
           data-reaction-type={dj.reactionType ?? ''}
-          className='relative'
+          className='absolute'
           style={{
-            top: '98%',
-            left: '16%',
-            transform: 'translate(-10%, -100%)',
+            top: `${stageImageFrame.offsetY + stageImageFrame.height * DJ_AVATAR.ANCHOR_Y_RATIO}px`,
+            left: `${stageImageFrame.offsetX + stageImageFrame.width * DJ_AVATAR.ANCHOR_X_RATIO}px`,
+            transform: DJ_AVATAR.TRANSLATE,
           }}
         >
           <Avatar
-            height={380}
+            height={djAvatarHeight}
             bodyUri={dj.avatarBodyUri}
             compositionType={dj.avatarCompositionType}
             faceUri={dj.avatarFaceUri}
@@ -124,14 +137,14 @@ export default function Avatars() {
           data-avatar-body-uri={crew.avatarBodyUri}
           data-reaction-type={crew.reactionType ?? ''}
           style={{
-            top: `${position.y}px`,
-            left: `${position.x}px`,
+            top: `${stageImageFrame.offsetY + position.y}px`,
+            left: `${stageImageFrame.offsetX + position.x}px`,
             transform: 'translate(-50%, -100%)',
           }}
           data-testid='partyroom-dj-queue-item'
         >
           <Avatar
-            height={AVATAR_GROUP.HEIGHT}
+            height={clusterAvatarHeight}
             bodyUri={crew.avatarBodyUri}
             compositionType={crew.avatarCompositionType}
             faceUri={crew.avatarFaceUri}
@@ -160,13 +173,13 @@ export default function Avatars() {
             data-avatar-body-uri={crew.avatarBodyUri}
             data-reaction-type={crew.reactionType ?? ''}
             style={{
-              top: `${position.y}px`,
-              left: `${position.x}px`,
+              top: `${stageImageFrame.offsetY + position.y}px`,
+              left: `${stageImageFrame.offsetX + position.x}px`,
               transform: 'translate(-100%, -100%)',
             }}
           >
             <Avatar
-              height={AVATAR_GROUP.HEIGHT}
+              height={clusterAvatarHeight}
               bodyUri={crew.avatarBodyUri}
               compositionType={crew.avatarCompositionType}
               faceUri={crew.avatarFaceUri}

--- a/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
@@ -114,5 +114,6 @@ export const StageRelativeLayout: Story = {
   args: {
     partyroomId: 1,
     enableQueueFetch: false,
+    djQueueCrewIdsOverride: [2],
   },
 };

--- a/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
@@ -1,0 +1,114 @@
+import { useEffect, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AvatarCompositionType, GradeType, MotionType } from '@/shared/api/http/types/@enums';
+import { useStores } from '@/shared/lib/store/stores.context';
+import Avatars from './avatars.component';
+
+const mockCrews = [
+  {
+    crewId: 1,
+    nickname: 'DJ Mono',
+    gradeType: GradeType.HOST,
+    avatarCompositionType: AvatarCompositionType.BODY_WITH_FACE,
+    avatarBodyUri: '/images/Temp/body.png',
+    avatarFaceUri: '/images/Temp/face.png',
+    avatarIconUri: '/images/Temp/nft.png',
+    combinePositionX: 60,
+    combinePositionY: 9,
+    offsetX: 0,
+    offsetY: 0,
+    scale: 1,
+    motionType: MotionType.NONE,
+  },
+  {
+    crewId: 2,
+    nickname: 'Queue One',
+    gradeType: GradeType.CLUBBER,
+    avatarCompositionType: AvatarCompositionType.BODY_WITH_FACE,
+    avatarBodyUri: '/images/Temp/body.png',
+    avatarFaceUri: '/images/Temp/face.png',
+    avatarIconUri: '/images/Temp/nft.png',
+    combinePositionX: 60,
+    combinePositionY: 9,
+    offsetX: -0.08,
+    offsetY: 0,
+    scale: 1,
+    motionType: MotionType.DANCE_TYPE_1,
+  },
+  {
+    crewId: 3,
+    nickname: 'Floor A',
+    gradeType: GradeType.CLUBBER,
+    avatarCompositionType: AvatarCompositionType.BODY_WITH_FACE,
+    avatarBodyUri: '/images/Temp/body.png',
+    avatarFaceUri: '/images/Temp/face.png',
+    avatarIconUri: '/images/Temp/nft.png',
+    combinePositionX: 60,
+    combinePositionY: 9,
+    offsetX: 0.05,
+    offsetY: 0.02,
+    scale: 1,
+    motionType: MotionType.NONE,
+  },
+  {
+    crewId: 4,
+    nickname: 'Floor B',
+    gradeType: GradeType.CLUBBER,
+    avatarCompositionType: AvatarCompositionType.BODY_WITH_FACE,
+    avatarBodyUri: '/images/Temp/body.png',
+    avatarFaceUri: '/images/Temp/face.png',
+    avatarIconUri: '/images/Temp/nft.png',
+    combinePositionX: 60,
+    combinePositionY: 9,
+    offsetX: 0,
+    offsetY: 0,
+    scale: 1,
+    motionType: MotionType.DANCE_TYPE_1,
+  },
+] as const;
+
+function SeedPartyroomStore({ children }: { children: ReactNode }) {
+  const { useCurrentPartyroom } = useStores();
+
+  useEffect(() => {
+    useCurrentPartyroom.getState().init({
+      crews: [...mockCrews],
+      currentDj: { crewId: 1 },
+    });
+
+    return () => {
+      useCurrentPartyroom.getState().reset();
+    };
+  }, [useCurrentPartyroom]);
+
+  return <>{children}</>;
+}
+
+const meta = {
+  title: 'features/PartyroomAvatars',
+  component: Avatars,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <SeedPartyroomStore>
+        <main className='relative w-screen h-screen bg-partyRoom bg-left-bottom overflow-hidden'>
+          <Story />
+        </main>
+      </SeedPartyroomStore>
+    ),
+  ],
+} satisfies Meta<typeof Avatars>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const StageRelativeLayout: Story = {
+  args: {
+    partyroomId: 1,
+    enableQueueFetch: false,
+  },
+};

--- a/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.stories.tsx
@@ -72,8 +72,12 @@ function SeedPartyroomStore({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     useCurrentPartyroom.getState().init({
+      id: 1,
+      me: undefined,
+      playbackActivated: false,
       crews: [...mockCrews],
       currentDj: { crewId: 1 },
+      notice: '',
     });
 
     return () => {


### PR DESCRIPTION
## 요약

- 현재 무대 배경 이미지를 기준으로 DJ / DJ queue / listener cluster 위치를 다시 조정했습니다.
- 화면 비율 변경, 배경 crop, zoom 상황에서도 아바타가 같은 배경 지점을 기준으로 유지되도록 정리했습니다.
- 새 아바타가 추가될 때 기존 아바타 위치는 유지하고, queue / listener 는 초반부터 작은 군집 형태로 시작한 뒤 점진적으로 바깥으로 확장되도록 보정했습니다.
- 대량 인원 상황과 순차 추가 상황을 재현할 수 있도록 debug playback route와 회귀 테스트를 추가했습니다.

## 변경 사항

- `PartyroomAvatars` 가 `background-size: cover` 기준의 실제 배경 프레임을 계산해서 DJ / queue / listener 를 배치하도록 수정했습니다.
- DJ / DJ queue / listener cluster 좌표와 크기 비율을 현재 stage background 기준으로 조정했습니다.
- queue / listener cluster 배치 로직을 개선했습니다.
  - 기존 아바타 위치 유지
  - 최소 간격 유지
  - 새 아바타는 군집 중심 근처에서 시작해서 바깥쪽으로 확장
  - queue / listener 초반 인원은 가로 1자 배치가 아니라 compact cluster 로 시작
- debug route를 추가했습니다.
  - `/dev/avatar-stage?queue=20&listeners=50&intervalMs=350`
  - `step / play / pause / reset` 으로 순차 추가 재현 가능
- regression coverage를 추가했습니다.
  - stage resize
  - dense cluster
  - 기존 아바타 위치 안정성
  - queue / listener 초기 compact clustering

## 테스트

- `yarn vitest run src/widgets/partyroom-avatars/lib/use-avatar-cluster.hook.test.ts src/widgets/partyroom-avatars/lib/calculate-stage-image-frame.test.ts`
- `yarn test:type`

## 확인 화면

- `public/tmp-avatar-stage-20q-50l-current.png`
- `public/tmp-avatar-stage-10q-25l.png`
- `public/tmp-avatar-stage-5q-10l.png`
- `public/tmp-avatar-stage-1q-1l.png`
- debug route: `https://localhost:3003/dev/avatar-stage?queue=20&listeners=50&intervalMs=350`

## 참고

- 검증용 캡처 PNG는 리뷰 확인을 위해 현재 워킹트리에만 남아 있습니다. GitHub PR 본문에는 직접 렌더되지 않습니다.
