### PR TITLE
fix(log): 진단 콘솔 로그를 비프로덕션(스테이징)에서만 노출하도록 게이트

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  // 빌드 타임 시스템 변수 VERCEL_ENV 를 클라이언트 번들에 NEXT_PUBLIC_ 으로 직접 인라인한다.
+  // Vercel 의 NEXT_PUBLIC_ 자동 prefix 노출 동작에 의존하지 않기 위함 —
+  // 프로젝트 설정 "Enable access to System Environment Variables" 토글만 ON 이면
+  // (= VERCEL_ENV 가 빌드에 제공되면) 진단 로그 게이트가 결정적으로 동작한다.
+  // 로컬엔 VERCEL_ENV 부재 → '' → 비프로덕션(진단 로그 노출). 참고: shouldEmitDiagnosticLog.
+  env: {
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? '',
+  },
   experimental: {
     webpackBuildWorker: true,
     serverComponentsExternalPackages: ['@resvg/resvg-js'],

--- a/src/shared/lib/functions/log/log-environment.test.ts
+++ b/src/shared/lib/functions/log/log-environment.test.ts
@@ -1,0 +1,51 @@
+import { isProdRuntime, shouldEmitDiagnosticLog } from './log-environment';
+
+describe('log-environment', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    window.debugLevel = 0;
+  });
+
+  describe('isProdRuntime', () => {
+    test("NEXT_PUBLIC_VERCEL_ENV='production' 이면 true", () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+      expect(isProdRuntime()).toBe(true);
+    });
+
+    test("NEXT_PUBLIC_VERCEL_ENV='preview'(스테이징) 이면 false", () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+      expect(isProdRuntime()).toBe(false);
+    });
+
+    test('미설정(로컬/테스트)이면 false', () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', '');
+      expect(isProdRuntime()).toBe(false);
+    });
+  });
+
+  describe('shouldEmitDiagnosticLog', () => {
+    test('preview(스테이징)에선 debugLevel 미상향이어도 true', () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+      window.debugLevel = 0;
+      expect(shouldEmitDiagnosticLog(0)).toBe(true);
+    });
+
+    test('로컬(미설정)에선 true', () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', '');
+      expect(shouldEmitDiagnosticLog(0)).toBe(true);
+    });
+
+    test('production + window.debugLevel 미상향이면 false (기본 침묵)', () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+      window.debugLevel = 0;
+      expect(shouldEmitDiagnosticLog(0)).toBe(false);
+      expect(shouldEmitDiagnosticLog()).toBe(false);
+    });
+
+    test('production + window.debugLevel 상향이면 true (긴급 escape hatch)', () => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+      window.debugLevel = 1;
+      expect(shouldEmitDiagnosticLog(0)).toBe(true);
+    });
+  });
+});

--- a/src/shared/lib/functions/log/log-environment.ts
+++ b/src/shared/lib/functions/log/log-environment.ts
@@ -1,0 +1,32 @@
+/**
+ * 버그 추적/관측용 콘솔 로그를 현재 런타임에서 emit 해도 되는지 판정한다.
+ *
+ * 정책(2026-05-25): 진단 로그는 비프로덕션 — 로컬 개발 + Vercel preview(스테이징/개발 배포) —
+ * 에서만 기본 노출된다. 프로덕션(`NEXT_PUBLIC_VERCEL_ENV === 'production'`)에선 침묵하되,
+ * 운영 중 긴급 디버깅을 위해 `window.debugLevel` 을 수동 상향하면 escape hatch 로 노출된다.
+ *
+ * `NEXT_PUBLIC_VERCEL_ENV` 는 Vercel 시스템 환경변수다 (production / preview / development).
+ * 로컬·테스트에선 미설정이므로 비프로덕션으로 간주한다.
+ * ⚠️ Vercel 프로젝트의 "Automatically expose System Environment Variables"(기본 ON)가
+ * 켜져 있어야 클라이언트 번들에 주입된다. 꺼져 있으면 prod 에서도 비프로덕션으로 간주되어
+ * 로그가 샌다 — 게이트가 무력화되면 이 변수의 주입 여부부터 확인할 것.
+ */
+export function isProdRuntime(): boolean {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+}
+
+/**
+ * 진단 로그 emit 가부를 반환한다.
+ *
+ * - 비프로덕션: 항상 `true` (window 접근 없이 즉시 반환).
+ * - 프로덕션: 기본 `false`, `window.debugLevel > debugLevel` 일 때만 `true`.
+ *
+ * @param debugLevel 이 값보다 `window.debugLevel` 이 클 때만 prod 에서 노출 (기본 0).
+ *
+ * 서버 컨텍스트(window 부재)에선 window 에 접근하지 않는다 — 비프로덕션은 첫 분기에서
+ * 반환되고, 프로덕션은 `typeof window` 가드로 단락된다 (L1 #314/#303 ReferenceError 회귀 방지).
+ */
+export function shouldEmitDiagnosticLog(debugLevel = 0): boolean {
+  if (!isProdRuntime()) return true;
+  return typeof window !== 'undefined' && window.debugLevel > debugLevel;
+}

--- a/src/shared/lib/functions/log/log-environment.ts
+++ b/src/shared/lib/functions/log/log-environment.ts
@@ -5,11 +5,12 @@
  * 에서만 기본 노출된다. 프로덕션(`NEXT_PUBLIC_VERCEL_ENV === 'production'`)에선 침묵하되,
  * 운영 중 긴급 디버깅을 위해 `window.debugLevel` 을 수동 상향하면 escape hatch 로 노출된다.
  *
- * `NEXT_PUBLIC_VERCEL_ENV` 는 Vercel 시스템 환경변수다 (production / preview / development).
- * 로컬·테스트에선 미설정이므로 비프로덕션으로 간주한다.
- * ⚠️ Vercel 프로젝트의 "Automatically expose System Environment Variables"(기본 ON)가
- * 켜져 있어야 클라이언트 번들에 주입된다. 꺼져 있으면 prod 에서도 비프로덕션으로 간주되어
- * 로그가 샌다 — 게이트가 무력화되면 이 변수의 주입 여부부터 확인할 것.
+ * `NEXT_PUBLIC_VERCEL_ENV` 는 next.config.js 에서 빌드 타임 `VERCEL_ENV`
+ * (production / preview / development) 를 인라인한 값이다. 로컬·테스트엔 미설정이므로
+ * 비프로덕션으로 간주한다.
+ * ⚠️ 빌드에 `VERCEL_ENV` 가 주입되려면 Vercel 프로젝트 설정 "Enable access to System
+ * Environment Variables" 토글이 ON 이어야 한다. 꺼지면 prod 에서도 '' → 비프로덕션으로
+ * 간주되어 로그가 샌다 — 게이트가 무력화되면 이 토글부터 확인할 것.
  */
 export function isProdRuntime(): boolean {
   return process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';

--- a/src/shared/lib/functions/log/with-debugger.node.test.ts
+++ b/src/shared/lib/functions/log/with-debugger.node.test.ts
@@ -1,19 +1,16 @@
 // @vitest-environment node
-// L1 (#314/#303): 서버측(SSR/RSC, window 부재)에서 withDebugger 가 무가드
+// L1 (#314/#303): 서버측(SSR/RSC, window 부재)에서 진단 로그 게이트가 무가드
 // `window.debugLevel` 접근으로 ReferenceError 즉사 → 공유 axios 전 요청이
 // 서버측에서 죽는 근본. 서버 컨텍스트에선 throw 없이 fallback 이어야 한다.
 import withDebugger from './with-debugger';
 
 describe('withDebugger (server / no window)', () => {
-  const prev = process.env.NODE_ENV;
-  beforeAll(() => {
-    process.env.NODE_ENV = 'production';
-  });
-  afterAll(() => {
-    process.env.NODE_ENV = prev;
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test('window 부재 + production 이면 throw 없이 fallback 반환, fn 미호출', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
     expect(typeof window).toBe('undefined');
 
     const fn = vi.fn();
@@ -23,13 +20,14 @@ describe('withDebugger (server / no window)', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  test('window 부재 + development 이면 기존대로 fn 호출(거동 보존)', () => {
-    process.env.NODE_ENV = 'development';
+  test('window 부재 + 비프로덕션(preview) 이면 throw 없이 fn 호출 (서버측 진단 로그 노출)', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+    expect(typeof window).toBe('undefined');
+
     const fn = vi.fn().mockReturnValue('r');
 
+    expect(() => withDebugger(0)(fn)('a')).not.toThrow();
     expect(withDebugger(0)(fn)('a')).toBe('r');
     expect(fn).toHaveBeenCalledWith('a');
-
-    process.env.NODE_ENV = 'production';
   });
 });

--- a/src/shared/lib/functions/log/with-debugger.test.ts
+++ b/src/shared/lib/functions/log/with-debugger.test.ts
@@ -1,13 +1,17 @@
 import withDebugger from './with-debugger';
 
 describe('withDebugger', () => {
-  describe('when production mode', () => {
-    beforeAll(() => {
-      process.env.NODE_ENV = 'production';
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('프로덕션 런타임 (NEXT_PUBLIC_VERCEL_ENV=production)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
     });
 
-    describe('when window.debugLevel is greater than given', () => {
-      test('should call the function', () => {
+    describe('window.debugLevel 가 기준보다 클 때 (긴급 escape hatch)', () => {
+      test('함수를 호출한다', () => {
         // Arrange
         const debugLevel = 0;
         const fn = vi.fn();
@@ -21,7 +25,7 @@ describe('withDebugger', () => {
         expect(fn).toHaveBeenCalledWith(...args);
       });
 
-      test('should return the result of the function', () => {
+      test('함수의 반환값을 돌려준다', () => {
         // Arrange
         const debugLevel = 0;
         const fn = vi.fn().mockReturnValue('result');
@@ -36,8 +40,8 @@ describe('withDebugger', () => {
       });
     });
 
-    describe('when window.debugLevel is equal to given', () => {
-      test('should not call the function', () => {
+    describe('window.debugLevel 가 기준과 같을 때', () => {
+      test('함수를 호출하지 않는다', () => {
         // Arrange
         const debugLevel = 1;
         const fn = vi.fn();
@@ -51,7 +55,7 @@ describe('withDebugger', () => {
         expect(fn).not.toHaveBeenCalledWith(...args);
       });
 
-      test('should return the fallback value', () => {
+      test('fallback 값을 반환한다', () => {
         // Arrange
         const debugLevel = 1;
         const fn = vi.fn();
@@ -66,8 +70,9 @@ describe('withDebugger', () => {
         expect(result).toBe(fallback);
       });
     });
-    describe('when window.debugLevel is less than given', () => {
-      test('should not call the function', () => {
+
+    describe('window.debugLevel 가 기준보다 작을 때', () => {
+      test('함수를 호출하지 않는다', () => {
         // Arrange
         const debugLevel = 2;
         const fn = vi.fn();
@@ -82,12 +87,33 @@ describe('withDebugger', () => {
       });
     });
   });
-  describe('when development mode', () => {
-    beforeAll(() => {
-      process.env.NODE_ENV = 'development';
+
+  describe('Vercel preview = 스테이징 (NEXT_PUBLIC_VERCEL_ENV=preview)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
     });
 
-    test('should call the function', () => {
+    test('debugLevel 를 상향하지 않아도 함수를 호출한다 (스테이징은 진단 로그 노출)', () => {
+      // Arrange
+      const debugLevel = 0;
+      const fn = vi.fn();
+      const args = [1, 2, 3];
+      window.debugLevel = debugLevel; // 미상향
+
+      // Act
+      withDebugger(debugLevel)(fn)(...args);
+
+      // Assert
+      expect(fn).toHaveBeenCalledWith(...args);
+    });
+  });
+
+  describe('비프로덕션 (NEXT_PUBLIC_VERCEL_ENV 미설정 — 로컬/테스트)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', '');
+    });
+
+    test('함수를 호출한다', () => {
       // Arrange
       const debugLevel = 0;
       const fn = vi.fn();

--- a/src/shared/lib/functions/log/with-debugger.ts
+++ b/src/shared/lib/functions/log/with-debugger.ts
@@ -1,13 +1,15 @@
+import { shouldEmitDiagnosticLog } from './log-environment';
+
 /**
- * debug 조건일때만 실행되는 함수를 반환합니다.
+ * 진단/디버그 로그용 래퍼. 비프로덕션(로컬 + Vercel preview=스테이징)에선 항상 실행하고,
+ * 프로덕션에선 침묵하되 `window.debugLevel` 수동 상향 시에만 실행한다.
+ *
+ * 환경 판정과 서버(window 부재) 안전성은 {@link shouldEmitDiagnosticLog} 에 위임한다.
  */
 export default function withDebugger(debugLevel: number) {
   return <T, P = void>(fn: (...args: T[]) => P, fallback?: P) =>
     (...args: T[]) => {
-      if (
-        process.env.NODE_ENV === 'development' ||
-        (typeof window !== 'undefined' && window.debugLevel > debugLevel)
-      ) {
+      if (shouldEmitDiagnosticLog(debugLevel)) {
         return fn(...args);
       }
       return fallback;

--- a/src/shared/lib/observability/client-events.test.ts
+++ b/src/shared/lib/observability/client-events.test.ts
@@ -1,0 +1,71 @@
+import { recordClientEvent } from './client-events';
+
+describe('recordClientEvent (환경 게이트)', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.debugLevel = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test('preview(스테이징)에선 info 이벤트를 console.info 로 emit 한다', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+
+    recordClientEvent({ type: 'PARTYROOM_SUBSCRIBE', partyroomId: 7 });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[client-obs]',
+      expect.objectContaining({ type: 'PARTYROOM_SUBSCRIBE', partyroomId: 7 })
+    );
+  });
+
+  test('production 에선 info 이벤트를 emit 하지 않는다 (기본 침묵)', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+
+    recordClientEvent({ type: 'PARTYROOM_SUBSCRIBE', partyroomId: 7 });
+
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test('production 에선 error 이벤트(EVENT_RECEIVED_FOREIGN)도 침묵한다', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+
+    recordClientEvent({
+      type: 'EVENT_RECEIVED_FOREIGN',
+      eventType: 'X',
+      receivedPartyroomId: 1,
+      currentPartyroomId: 2,
+      messageId: 'm',
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test('production + window.debugLevel 상향 시 escape hatch 로 emit 한다', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'production');
+    window.debugLevel = 1;
+
+    recordClientEvent({ type: 'WS_STOMP_ERROR', message: 'boom' });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[client-obs]',
+      expect.objectContaining({ type: 'WS_STOMP_ERROR' })
+    );
+  });
+
+  test('error 이벤트는 console.error, 그 외는 console.info 로 라우팅한다 (severity 보존)', () => {
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_ENV', 'preview');
+
+    recordClientEvent({ type: 'WS_STOMP_ERROR', message: 'boom' });
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/observability/client-events.ts
+++ b/src/shared/lib/observability/client-events.ts
@@ -1,10 +1,14 @@
+import { shouldEmitDiagnosticLog } from '@/shared/lib/functions/log/log-environment';
+
 /**
  * 클라이언트 측 관측 이벤트 스키마 (Observability Phase A5).
  *
- * Phase A 에선 `console.info`/`console.error` 로만 emit 된다 (OSS only 정책 —
- * 사용자 콘솔 dump 를 받아야 우리에게 도달). Phase B 에서 backend forward
- * endpoint 가 도입되면 {@link recordClientEvent} 구현부만 교체하면 되고,
- * 호출 지점은 변경 zero 다 (스키마를 미리 고정하는 것이 이 파일의 목적).
+ * `console.info`/`console.error` 로 emit 되지만, 진단 로그 정책(2026-05-25)에 따라
+ * 비프로덕션(로컬 + Vercel preview=스테이징)에서만 기본 노출된다. 프로덕션에선
+ * 침묵하되 `window.debugLevel` 수동 상향 시 escape hatch 로 노출된다
+ * ({@link shouldEmitDiagnosticLog}). Phase B 에서 backend forward endpoint 가
+ * 도입되면 {@link recordClientEvent} 구현부만 교체하면 되고, 호출 지점은 변경 zero 다
+ * (스키마를 미리 고정하는 것이 이 파일의 목적).
  */
 export type ClientObservabilityEvent =
   | { type: 'WS_CONNECT'; brokerURL: string }
@@ -30,6 +34,8 @@ export type ClientObservabilityEvent =
  * 그 외는 `console.info` 로 — ADR-009(error-monitoring) 의 severity 정책.
  */
 export function recordClientEvent(event: ClientObservabilityEvent): void {
+  if (!shouldEmitDiagnosticLog()) return;
+
   const isError = event.type === 'WS_STOMP_ERROR' || event.type === 'EVENT_RECEIVED_FOREIGN';
   (isError ? console.error : console.info)('[client-obs]', event);
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -7,8 +7,8 @@ declare global {
       NEXT_PUBLIC_ALCHEMY_PUBLIC_API_KEY: string;
       NEXT_PUBLIC_WAGMI_PROJECT_ID: string;
       NEXT_PUBLIC_USE_MOCK?: 'true' | 'false';
-      // Vercel 시스템 환경변수 (자동 주입). 진단 로그 게이트가 'production' 여부로 분기한다.
-      NEXT_PUBLIC_VERCEL_ENV?: 'production' | 'preview' | 'development';
+      // next.config.js 에서 빌드 타임 VERCEL_ENV 를 인라인. 진단 로그 게이트가 'production' 여부로 분기한다.
+      NEXT_PUBLIC_VERCEL_ENV?: 'production' | 'preview' | 'development' | '';
 
       // secret
       GOOGLE_ID: string;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -7,6 +7,8 @@ declare global {
       NEXT_PUBLIC_ALCHEMY_PUBLIC_API_KEY: string;
       NEXT_PUBLIC_WAGMI_PROJECT_ID: string;
       NEXT_PUBLIC_USE_MOCK?: 'true' | 'false';
+      // Vercel 시스템 환경변수 (자동 주입). 진단 로그 게이트가 'production' 여부로 분기한다.
+      NEXT_PUBLIC_VERCEL_ENV?: 'production' | 'preview' | 'development';
 
       // secret
       GOOGLE_ID: string;


### PR DESCRIPTION
## 요약
프로덕션(main)에 버그 추적용 콘솔 로그가 그대로 남던 문제를 수정한다. Closes #345

## 변경
- `log-environment.ts`(신규): 공유 판정자 `shouldEmitDiagnosticLog()` — `NEXT_PUBLIC_VERCEL_ENV !== 'production'`(로컬 + Vercel preview=스테이징)이면 노출, prod면 침묵하되 `window.debugLevel` 수동 상향 시 escape hatch.
- `with-debugger.ts`: 기존 `NODE_ENV` 게이트 → 공유 판정자로 교체. **이제 스테이징(preview)에서도 verbose 로그 노출**.
- `client-events.ts`: `recordClientEvent` 에 게이트 추가. prod 기본 침묵.
- `next.config.js`: 빌드 타임 `VERCEL_ENV` 를 `NEXT_PUBLIC_VERCEL_ENV` 로 직접 인라인 (Vercel 자동 prefix 노출 동작에 비의존, 결정적 동작).
- `types/global.d.ts`: `NEXT_PUBLIC_VERCEL_ENV` 타입 추가.
- ③ 실제 에러 핸들러의 `console.error/warn` 은 prod 가시성 위해 **그대로 유지**(스코프 밖).
- 서버(window 부재) 컨텍스트에선 window 접근 없이 판정 → L1 #314/#303 ReferenceError 회귀 방지.

## 검증
- 신규/갱신 테스트 RED→GREEN (log-environment · client-events · with-debugger jsdom+node)
- 전체 vitest **1318/1318** 통과 · `tsc --noEmit` 0 · eslint 0
- 빌드 시뮬레이션: `VERCEL_ENV=production`→인라인 `production`(억제), `=preview`→`preview`(노출), 로컬(미설정)→`''`(노출)

## 배포 전 확인 (운영)
- ⚠️ Vercel 프로젝트 설정 **"Enable access to System Environment Variables" 토글이 ON** 이어야 한다. 이게 빌드에 `VERCEL_ENV` 를 제공하고 next.config.js 가 이를 `NEXT_PUBLIC_VERCEL_ENV` 로 인라인한다. 꺼지면 prod 에서도 `''`→비프로덕션 취급되어 게이트가 fail-open(로그 샘) 한다.
- Production Branch = `main` 이어야 development 배포가 `preview` 로 잡혀 진단 로그가 스테이징에 노출된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)