### PR TITLE
ci(e2e): preview deploy/e2e 파이프라인 concurrency 직렬화

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -5,6 +5,12 @@ on:
     branches: [development]
   workflow_dispatch:
 
+# 동시 run들이 공유 stg.pfplay.xyz 별칭을 레이스하지 않도록 파이프라인 직렬화 (이슈 #348).
+# 연속 머지 시 직전 run 취소 → 최신 development 상태만 deploy+e2e.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: deploy preview


### PR DESCRIPTION
## 요약
`preview deploy and e2e` 워크플로의 간헐 실패(공유 `stg.pfplay.xyz` 별칭 레이스)를 해소한다. Closes #348

## 변경
`.github/workflows/vercel-preview-e2e.yml` 최상위에 `concurrency` 그룹 추가:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## 원인 / 효과
- 워크플로는 development push마다 새 preview 배포 → **공유 별칭 `stg.pfplay.xyz` 재지정** → 그 별칭으로 e2e 실행. concurrency 부재로 **연속 머지 시 run들이 동시 실행되며 별칭을 서로 바꿔치기** → in-flight RSC abort + 셋업 네비게이션/렌더 타임아웃으로 e2e 간헐 실패.
- 직렬화하면 한 번에 하나의 deploy+e2e만 별칭을 점유. `cancel-in-progress: true` 라 연속 머지 시 직전 run을 취소하고 **최신 development 상태만** 테스트(레이스 제거 + CI 절약).

## 증거 (2026-05-25)
- #338·#341·#337·#346 1분 내 연속 머지 → run 4개 동시 실행, **#341 run만 실패** / 나머지 3개 GREEN.
- 실패 e2e 잡 **단독 재실행 GREEN** → 코드 회귀 아님, 별칭 레이스 확정.
- 실패 지점이 player 검증 이전의 파티룸 셋업 타임아웃 → 동시 머지된 player 변경(#341)과 무관.

## 비고
- 단일 run 콜드스타트 플래키는 기존 web#303 warmup이 부분 완화 중 — 본 PR 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)