### PR TITLE
fix(playlist): 썸네일 unoptimized 전환 — Vercel 이미지 최적화 402 우회 (#351)

### DIFF
--- a/src/entities/music-preview/ui/thumbnail-with-preview.component.test.tsx
+++ b/src/entities/music-preview/ui/thumbnail-with-preview.component.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ThumbnailWithPreview from './thumbnail-with-preview.component';
+
+// next/image 의 문서화된 동작을 충실히 모사한다.
+// - unoptimized=true  → 원본 src 그대로 (브라우저가 CDN 에서 직접 로드)
+// - 그 외             → Vercel 이미지 최적화 엔드포인트(/_next/image)로 래핑
+// 이로써 "썸네일이 최적화 경로를 거치는가"를 렌더 결과(img src)로 판정할 수 있다.
+vi.mock('next/image', () => ({
+  __esModule: true,
+  // next/image 전용 prop(priority/fill 등)은 DOM 으로 흘려보내지 않도록 걸러낸다.
+  default: ({
+    src,
+    alt,
+    unoptimized,
+    width,
+    quality = 75,
+    priority: _p,
+    fill: _f,
+    ...rest
+  }: any) => {
+    const resolvedSrc = unoptimized
+      ? src
+      : `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
+    return <img src={resolvedSrc} alt={alt} {...rest} />;
+  },
+}));
+
+// 프리뷰 스토어가 주입된 실제 prod 렌더 경로를 재현.
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useMusicPreview: () => ({
+      startPreview: vi.fn(),
+      stopPreview: vi.fn(),
+      isTrackPlaying: () => false,
+    }),
+  }),
+}));
+
+describe('ThumbnailWithPreview', () => {
+  const YOUTUBE_THUMBNAIL = 'https://i.ytimg.com/vi/xtnl8sPd6TM/hqdefault.jpg';
+
+  const renderThumbnail = () =>
+    render(
+      <ThumbnailWithPreview
+        previewTrack={{ id: 'xtnl8sPd6TM' } as never}
+        thumbnailSrc={YOUTUBE_THUMBNAIL}
+        thumbnailAlt='썸네일'
+        width={60}
+        height={34}
+      />
+    );
+
+  it('유튜브 썸네일은 Vercel 이미지 최적화(/_next/image)를 거치지 않고 원본 CDN src 로 렌더된다', () => {
+    renderThumbnail();
+
+    const img = screen.getByAltText('썸네일');
+
+    // YouTube 가 이미 제공하는 썸네일이라 재최적화 불필요 + 검색 결과는 매번 수십 장이라
+    // 최적화 시 Vercel 쿼터를 폭증시켜 402(Payment Required)를 유발한다.
+    expect(img.getAttribute('src')).toBe(YOUTUBE_THUMBNAIL);
+    expect(img.getAttribute('src')).not.toContain('_next/image');
+  });
+});

--- a/src/entities/music-preview/ui/thumbnail-with-preview.component.tsx
+++ b/src/entities/music-preview/ui/thumbnail-with-preview.component.tsx
@@ -55,6 +55,9 @@ export default function ThumbnailWithPreview({
           height={height}
           className={imageClassName}
           priority
+          // YouTube 가 이미 제공하는 썸네일이라 재최적화 이점이 없고, 검색 결과는 매번
+          // 수십 장이 새로 떠 Vercel 이미지 최적화 쿼터를 폭증(→ 402)시킨다. 원본 CDN 직접 로드.
+          unoptimized
         />
       </div>
     );
@@ -80,6 +83,9 @@ export default function ThumbnailWithPreview({
         height={height}
         className={imageClassName}
         priority
+        // YouTube 가 이미 제공하는 썸네일이라 재최적화 이점이 없고, 검색 결과는 매번
+        // 수십 장이 새로 떠 Vercel 이미지 최적화 쿼터를 폭증(→ 402)시킨다. 원본 CDN 직접 로드.
+        unoptimized
       />
 
       {/* 재생중 상태 표시 (항상 표시) */}


### PR DESCRIPTION
## 배경
음악 검색 모달 / 플레이리스트 트랙의 썸네일이 안 보이고 콘솔에 `402` 가 다량 출력. (#351)

## 근본 원인 (실측)
- 업스트림 `i.ytimg.com` 원본: `200 image/jpeg` 정상
- Vercel `/_next/image` 최적화: **`402 Payment Required` / `OPTIMIZED_IMAGE_REQUEST_PAYMENT_REQUIRED`**

→ 코드 버그가 아니라 **Vercel 이미지 최적화 사용량 한도 초과**. 썸네일은 전부 `ThumbnailWithPreview` → `next/image` 를 거쳐 최적화되는데, 검색은 키워드마다 결과 수십 장이 새로 떠 쿼터를 가장 빠르게 소진하는 주범.

## 변경
- `ThumbnailWithPreview` 의 `<Image>` 두 곳(스토어 fallback/메인 경로)에 `unoptimized` 지정 → 원본 CDN 직접 로드.
- 유튜브가 이미 제공하는 썸네일이라 재최적화 이점 없음. 검색 결과·플레이리스트 트랙이 공유하는 단일 진입점이라 한 군데로 동시 해결.
- 아바타/NFT 등 다른 이미지의 최적화는 그대로 유지(스코프 분리).

## 효과
- 썸네일이 `/_next/image` 를 안 거침 → 쿼터 소비 0, **배포 후 402 와 무관하게 썸네일 복구** + 재발 방지.

## 검증
- 회귀 테스트 신규: 썸네일이 `/_next/image` 가 아닌 원본 src 로 렌더됨을 검증 (RED→GREEN).
- 전체 스위트 `1325/1325` PASS, 린트/타입체크 클린.

## ⚠️ 이 PR 범위 밖 (별도 조치)
이미 소진된 쿼터로 아바타 등 **`unoptimized` 가 아닌 다른 최적화 이미지는 prod 에서 여전히 402**. Vercel 대시보드에서 Image Optimization 사용량 / Spend Limit 확인 필요(플랜 상향 또는 한도 조정).

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)