### PR TITLE
release: development → main (썸네일 402 우회, 2026-05-25)

### DIFF
--- a/src/entities/music-preview/ui/thumbnail-with-preview.component.test.tsx
+++ b/src/entities/music-preview/ui/thumbnail-with-preview.component.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ThumbnailWithPreview from './thumbnail-with-preview.component';
+
+// next/image 의 문서화된 동작을 충실히 모사한다.
+// - unoptimized=true  → 원본 src 그대로 (브라우저가 CDN 에서 직접 로드)
+// - 그 외             → Vercel 이미지 최적화 엔드포인트(/_next/image)로 래핑
+// 이로써 "썸네일이 최적화 경로를 거치는가"를 렌더 결과(img src)로 판정할 수 있다.
+vi.mock('next/image', () => ({
+  __esModule: true,
+  // next/image 전용 prop(priority/fill 등)은 DOM 으로 흘려보내지 않도록 걸러낸다.
+  default: ({
+    src,
+    alt,
+    unoptimized,
+    width,
+    quality = 75,
+    priority: _p,
+    fill: _f,
+    ...rest
+  }: any) => {
+    const resolvedSrc = unoptimized
+      ? src
+      : `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
+    return <img src={resolvedSrc} alt={alt} {...rest} />;
+  },
+}));
+
+// 프리뷰 스토어가 주입된 실제 prod 렌더 경로를 재현.
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useMusicPreview: () => ({
+      startPreview: vi.fn(),
+      stopPreview: vi.fn(),
+      isTrackPlaying: () => false,
+    }),
+  }),
+}));
+
+describe('ThumbnailWithPreview', () => {
+  const YOUTUBE_THUMBNAIL = 'https://i.ytimg.com/vi/xtnl8sPd6TM/hqdefault.jpg';
+
+  const renderThumbnail = () =>
+    render(
+      <ThumbnailWithPreview
+        previewTrack={{ id: 'xtnl8sPd6TM' } as never}
+        thumbnailSrc={YOUTUBE_THUMBNAIL}
+        thumbnailAlt='썸네일'
+        width={60}
+        height={34}
+      />
+    );
+
+  it('유튜브 썸네일은 Vercel 이미지 최적화(/_next/image)를 거치지 않고 원본 CDN src 로 렌더된다', () => {
+    renderThumbnail();
+
+    const img = screen.getByAltText('썸네일');
+
+    // YouTube 가 이미 제공하는 썸네일이라 재최적화 불필요 + 검색 결과는 매번 수십 장이라
+    // 최적화 시 Vercel 쿼터를 폭증시켜 402(Payment Required)를 유발한다.
+    expect(img.getAttribute('src')).toBe(YOUTUBE_THUMBNAIL);
+    expect(img.getAttribute('src')).not.toContain('_next/image');
+  });
+});

--- a/src/entities/music-preview/ui/thumbnail-with-preview.component.tsx
+++ b/src/entities/music-preview/ui/thumbnail-with-preview.component.tsx
@@ -55,6 +55,9 @@ export default function ThumbnailWithPreview({
           height={height}
           className={imageClassName}
           priority
+          // YouTube 가 이미 제공하는 썸네일이라 재최적화 이점이 없고, 검색 결과는 매번
+          // 수십 장이 새로 떠 Vercel 이미지 최적화 쿼터를 폭증(→ 402)시킨다. 원본 CDN 직접 로드.
+          unoptimized
         />
       </div>
     );
@@ -80,6 +83,9 @@ export default function ThumbnailWithPreview({
         height={height}
         className={imageClassName}
         priority
+        // YouTube 가 이미 제공하는 썸네일이라 재최적화 이점이 없고, 검색 결과는 매번
+        // 수십 장이 새로 떠 Vercel 이미지 최적화 쿼터를 폭증(→ 402)시킨다. 원본 CDN 직접 로드.
+        unoptimized
       />
 
       {/* 재생중 상태 표시 (항상 표시) */}


### PR DESCRIPTION
## 승격 내용
- #352 fix(playlist): 썸네일 unoptimized 전환 — Vercel 이미지 최적화 402 우회 (#351)

## 검증
- 로컬 develop 풀스택 e2e (Playwright a~d) 통과 — b는 배치 플래키였고 단독 재실행 GREEN.
- 직전 prod 릴리스(#350) 이후 development 에 추가된 변경 = #352.

## ⚠️ 사후
- Vercel production 배포 트리거. 썸네일은 `/_next/image` 미경유로 402 무관 복구.
- 별개: 다른 최적화 이미지(아바타 등)는 Vercel Image Optimization 사용량/Spend Limit 확인 필요(코드 외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)