### PR TITLE
fix(widgets-mobile/partyroom-display-board): chunk 3.1 — YouTube IFrame ToS 보존 재설계 (3-mode + autoplay gesture gate)

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -86,6 +86,9 @@ jobs:
           done
           exit 0
 
+      # chunk 3.1: display-board-tos-mobile project (iPhone 13) 가 mandatory.
+      # branch protection 의 required status checks 에 "Playwright E2E" job 등록 필수
+      # (사용자 GitHub UI 작업, PR 본문 체크리스트). job 자체는 yarn test:e2e 안에 포함됨.
       - run: yarn test:e2e
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/docs/superpowers/plans/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/plans/2026-05-29-mobile-display-board-tos-redesign.md
@@ -1,0 +1,2961 @@
+# 모바일 디스플레이 보드 — YouTube ToS 보존 재설계 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** chunk 2 의 `1px×1px+opacity-0` IFrame 숨김 (YouTube IFrame Player API ToS 위반) 을 풀폭/축소 토글 + 검정 placeholder 3-mode 디자인으로 대체하고, 데스크탑의 autoplay gesture gate 패턴을 모바일에 차용한다.
+
+**Architecture:** 데스크탑 `widgets/partyroom-display-board/*` 는 0 수정 (C3 sibling 사본 패턴). 모바일 widget 의 본문 + 7 신규 parts/hook 으로 3 모드 (A: 풀폭 / B: 80×45 / C: 비재생 placeholder) 를 wrapper-class 기반으로 구현. YoutubePlayer 의 width/height 는 항상 `'100%'` 고정 → wrapper Tailwind class 만 교체 → IFrame remount 차단. `useAutoplayGestureGate` hook 이 root 1 곳에서 호출되어 VideoFrame 내부 AutoplayGestureGate 와 NowPlayingRow 내부 TapToPlayButton 양쪽에 동일 `gate` state 를 props 로 주입 (single source of truth).
+
+**Tech Stack:** Next.js 14 (`'use client'`), TypeScript, Tailwind JIT (정적 class only), react-player/youtube (dynamic import, SSR off), Zustand (`useCurrentPartyroom`, `useUserPreferenceStore`), Vitest + jsdom + React Testing Library (unit/integration), Playwright (headed mandatory CI).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md` (v4, 16 결정 잠금)
+
+**Branch:** `feature/mobile-responsive-spec-3.1` (origin/development 기준 분기 완료)
+
+---
+
+## File Structure
+
+### 신규 (Create)
+
+| 경로                                                                                        | 책임                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 약 줄수 |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts`          | autoplay 차단 감지 + gesture release 단일 hook. 데스크탑 `video.component.tsx` 의 inline 패턴을 hook 으로 추출한 모바일 사본. `AUTOPLAY_DETECT_MS` 상수 export. `videoId` 변경 시 차단 re-arm.                                                                                                                                                                                                                                                                                                                                                             | ~80     |
+| `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`     | hook 8 케이스 (`AUTOPLAY_DETECT_MS` 상수 단언 + spec §7.1 7 케이스: 초기 state · onReady · 1500ms timeout · onPlay reset · handleGesturePlay · videoId 변경 re-arm · playable=false reset)                                                                                                                                                                                                                                                                                                                                                                 | ~180    |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx`       | Mode C 의 16:9 검정 박스 + inline 한국어 안내 텍스트 ("지금 재생 중인 곡이 없어요"). Props 없음.                                                                                                                                                                                                                                                                                                                                                                                                                                                           | ~25     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx`  | 텍스트 / aspect-video class / data-testid 단언 (3 케이스)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | ~40     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx`           | ▾/◂ 버튼. `expanded` + `onToggle` props. `aria-label` 분기, `aria-pressed={!expanded}`, `min-h-[44px] min-w-[44px]`.                                                                                                                                                                                                                                                                                                                                                                                                                                       | ~30     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx`      | aria-label expanded/collapsed 분기, 클릭 콜백, aria-pressed, 44×44 hit-area, positioning 부재 회귀 (5 케이스)                                                                                                                                                                                                                                                                                                                                                                                                                                              | ~75     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx`        | 트랙명·DJ·duration. `layout: 'column' \| 'row'` props.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ~40     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx`   | column 렌더, row 렌더, dj null 처리, layout 분기 class, parent flex 토큰 부재 회귀 (5 케이스)                                                                                                                                                                                                                                                                                                                                                                                                                                                              | ~75     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx`      | Mode B 의 release ▶ 버튼. `autoplayBlocked` && `!played` 시만 visible. 44×44 hit-area, `aria-label='재생'`.                                                                                                                                                                                                                                                                                                                                                                                                                                               | ~30     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx` | 차단 visible, 비차단 미렌더, 클릭 콜백, aria, hit-area (4 케이스)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | ~60     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`             | 3 mode orchestrator. wrapperClass(mode) 정적 리터럴 분기. YoutubePlayer (Mode A·B) + BlankPlaceholder (Mode C) + AutoplayGestureGate (Mode A 만 overlay) + ExpandToggle (Mode A·B). Constants export: `COLLAPSED_VIDEO_WIDTH`, `COLLAPSED_VIDEO_HEIGHT`.                                                                                                                                                                                                                                                                                                   | ~150    |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`        | 14 케이스 — VideoFrame 단일 컴포넌트 범위 (Mode A/B/C 렌더 3, 전환 4 (A↔B remount X, B↔C / C↔A / A↔C mount/unmount), autoplay overlay Mode A only 1, Mode B AutoplayGestureGate 미렌더 1, wrapperClass Mode B 정적 리터럴 1, JS 상수 ↔ wrapperClass sync 1, ToS 가드 2 회귀, videoId=null Props 안전 1). spec §7.1 의 cross-component 케이스 2건 (TapToPlayButton 렌더 위치, Mode B→A toggle 시 GestureGate single source) 은 Chunk 4 integration test 로 이전 — VideoFrame 단독 테스트로 검증 불가능 (TapToPlayButton 은 NowPlayingRow 소속, §6.5.3) | ~340    |
+| `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`     | 통합 테스트 12 케이스 (spec §7.2 list 10 + VideoFrame test 에서 이전한 cross-component 2: TapToPlayButton 가 NowPlayingRow 안 렌더 + Mode B autoplay → Mode A toggle 시 GestureGate 즉시 visible single source). spec §7.2 의 header `(9 케이스)` 는 outdated — 실제 list 는 10.                                                                                                                                                                                                                                                                           | ~330    |
+
+### 수정 (Modify)
+
+| 경로                                                                               | 변경 요약                                                                                                                                                                                                                                             |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx` | 본문 대규모 재설계: `useAutoplayGestureGate` 호출 (root), `<VideoFrame gate={…} />` mount, NowPlayingRow (`min-h-[44px]`) + `<TapToPlayButton />` sibling. 기존 1px IFrame 본문 / inline now-playing 텍스트 / 헤더 row 일부 흡수. ActionButtons 유지. |
+| `playwright.config.ts`                                                             | `display-board.tos` project 추가 (mobile viewport — iPhone 13/SE/Pixel 7). `e2e/mobile/` testMatch.                                                                                                                                                   |
+| `.github/workflows/vercel-preview-e2e.yml`                                         | mandatory job 명시 (현재 단일 `e2e` job 이라 추가 변경 최소; `yarn test:e2e` 가 신규 project 도 자동 포함되므로 README/주석 보강 + 사용자 단발 GitHub UI 작업 안내)                                                                                   |
+| `e2e/README.md`                                                                    | 신규 mobile project 안내 + branch protection required check 등록 안내                                                                                                                                                                                 |
+
+### 신규 e2e
+
+| 경로                                   | 책임                                                                                                                                                                                                                                                                                                              | 약 줄수 |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `e2e/mobile/display-board.tos.spec.ts` | Playwright headed mandatory test. Mode A 진입 IFrame visible + boundingBox ≥ 80×45 + computed style 단언, Toggle → Mode B (80×45 정확값) + 같은 IFrame element, Mode B → A 복귀 시 IFrame remount 없음, Mode C BlankPlaceholder visible + IFrame 미존재, chat scroll offset ≤ `CHAT_SCROLL_TOLERANCE_PX=10` 보존. | ~280    |
+
+### 디렉토리 합계
+
+- 신규: hook 1 + parts 6 + e2e 1 + test 8 = 16 files (~1650 lines)
+- 수정: 4 files
+- 데스크탑 0 수정
+
+---
+
+## Chunk 1: useAutoplayGestureGate Hook (Foundation)
+
+> 본 chunk 는 root 와 VideoFrame 양쪽이 의존하는 단일 상태 hook 을 TDD 로 먼저 만든다. Hook 은 데스크탑 `video.component.tsx:73-153` 의 inline 패턴 추출본이지만 데스크탑은 그대로 둔다 (C3 격리, §3 row 9). 본 chunk 가 완료되면 Chunk 2·3·4 가 모두 본 hook 의 단언된 인터페이스에 기반해 작성된다.
+
+### Task 1.1: 디렉토리 + 빈 hook stub 생성
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts`
+
+- [ ] **Step 1: 디렉토리 / 빈 hook + 상수 export stub 작성**
+
+파일 작성:
+
+```ts
+// src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+import type { RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+
+export const AUTOPLAY_DETECT_MS = 1500;
+
+interface UseAutoplayGestureGateArgs {
+  playerRef: RefObject<TReactPlayer | null>;
+  playable: boolean;
+  videoId: string | null;
+}
+
+export interface AutoplayGestureGate {
+  autoplayBlocked: boolean;
+  played: boolean;
+  playerReady: boolean;
+  handleGesturePlay: () => void;
+  onReady: (player: TReactPlayer) => void;
+  onStart: () => void;
+  onPlay: () => void;
+  onPause: () => void;
+}
+
+export default function useAutoplayGestureGate(
+  _args: UseAutoplayGestureGateArgs
+): AutoplayGestureGate {
+  throw new Error('not implemented');
+}
+```
+
+- [ ] **Step 2: TypeScript build sanity check**
+
+> 본 레포 (pfplay-web) 는 JDK 의존 없음. `JAVA_HOME` prefix 는 적용 영역 아님 (참고: [[reference_pfplay_platform_jdk]] 는 pfplay-platform 전용).
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors (stub 만 있어서 통과)
+
+- [ ] **Step 3: Commit stub**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+git commit -m "feat(widgets-mobile/partyroom-display-board): useAutoplayGestureGate hook stub + 인터페이스 + AUTOPLAY_DETECT_MS 상수"
+```
+
+### Task 1.2: 초기 state 단언 테스트 (RED)
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 파일 작성 — `초기 state 는 모두 false`**
+
+```ts
+// src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, test } from 'vitest';
+import type TReactPlayer from 'react-player';
+import useAutoplayGestureGate, { AUTOPLAY_DETECT_MS } from './use-autoplay-gesture-gate.hook';
+
+function setupHook({
+  playable = true,
+  videoId = 'abc' as string | null,
+}: { playable?: boolean; videoId?: string | null } = {}) {
+  return renderHook(() => {
+    const playerRef = useRef<TReactPlayer | null>(null);
+    return useAutoplayGestureGate({ playerRef, playable, videoId });
+  });
+}
+
+describe('useAutoplayGestureGate', () => {
+  test('AUTOPLAY_DETECT_MS = 1500 (spec §4.6, ms)', () => {
+    expect(AUTOPLAY_DETECT_MS).toBe(1500);
+  });
+
+  test('초기 state: autoplayBlocked / played / playerReady 모두 false', () => {
+    const { result } = setupHook();
+    expect(result.current.autoplayBlocked).toBe(false);
+    expect(result.current.played).toBe(false);
+    expect(result.current.playerReady).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -30`
+Expected: 2 tests, `초기 state` 가 FAIL (`'not implemented'` throw). `AUTOPLAY_DETECT_MS` 는 PASS.
+
+- [ ] **Step 3: hook 본문 — useState 3 개 + return 만 구현**
+
+`use-autoplay-gesture-gate.hook.ts` 본문 교체:
+
+```ts
+import { useState, type RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+
+export const AUTOPLAY_DETECT_MS = 1500;
+
+interface UseAutoplayGestureGateArgs {
+  playerRef: RefObject<TReactPlayer | null>;
+  playable: boolean;
+  videoId: string | null;
+}
+
+export interface AutoplayGestureGate {
+  autoplayBlocked: boolean;
+  played: boolean;
+  playerReady: boolean;
+  handleGesturePlay: () => void;
+  onReady: (player: TReactPlayer) => void;
+  onStart: () => void;
+  onPlay: () => void;
+  onPause: () => void;
+}
+
+export default function useAutoplayGestureGate({
+  playerRef,
+}: UseAutoplayGestureGateArgs): AutoplayGestureGate {
+  const [autoplayBlocked, setAutoplayBlocked] = useState(false);
+  const [played, setPlayed] = useState(false);
+  const [playerReady, setPlayerReady] = useState(false);
+
+  const handleGesturePlay = () => {
+    const internal = playerRef.current?.getInternalPlayer() as
+      | { playVideo?: () => void }
+      | undefined;
+    internal?.playVideo?.();
+    setAutoplayBlocked(false);
+  };
+
+  const onReady = (_player: TReactPlayer) => {
+    setPlayerReady(true);
+  };
+
+  const onStart = () => {
+    /* seekToLive 는 VideoFrame 의 외부 콜백에서 처리 (data 의존) */
+  };
+
+  const onPlay = () => {
+    setPlayed(true);
+    setAutoplayBlocked(false);
+  };
+
+  const onPause = () => {
+    /* 본 hook 은 onPause 의 자동 재개 폴백을 수행 안 함 (chunk 3.1 OUT, §9 risk #7) */
+  };
+
+  return {
+    autoplayBlocked,
+    played,
+    playerReady,
+    handleGesturePlay,
+    onReady,
+    onStart,
+    onPlay,
+    onPause,
+  };
+}
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 2 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts \
+        src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): useAutoplayGestureGate 초기 state + 상수 단언
+
+feat: useState 3개 + handleGesturePlay/onReady/onPlay 기본 구현"
+```
+
+### Task 1.3: onReady → playerReady=true (RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가**
+
+`describe('useAutoplayGestureGate', () => { ... })` 안에 추가:
+
+```ts
+test('onReady 호출 시 playerReady=true 로 전이', () => {
+  const { result } = setupHook();
+  const fakePlayer = {} as TReactPlayer;
+  // act 으로 감싸 React state update 반영
+  act(() => result.current.onReady(fakePlayer));
+  expect(result.current.playerReady).toBe(true);
+});
+```
+
+import 에 `act` 추가:
+
+```ts
+import { act, renderHook } from '@testing-library/react';
+```
+
+- [ ] **Step 2: 테스트 실행 → 즉시 GREEN (이미 onReady 가 setPlayerReady 호출)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 3 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): useAutoplayGestureGate onReady → playerReady 단언"
+```
+
+### Task 1.4: 1500ms timer → autoplayBlocked=true (RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts`
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가 (fake timer)**
+
+테스트 파일의 import 블록 끝 (마지막 `import …` 라인 직후, `function setupHook(...)` / `describe(...)` 보다 위) 에 vi 추가:
+
+```ts
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type TReactPlayer from 'react-player';
+import useAutoplayGestureGate, { AUTOPLAY_DETECT_MS } from './use-autoplay-gesture-gate.hook';
+```
+
+그리고 마지막 import 직후, `function setupHook(...)` 보다 위 top-level 위치에:
+
+```ts
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+```
+
+describe 안에 케이스 추가:
+
+```ts
+test('onReady 후 1500ms 내 onPlay 없으면 autoplayBlocked=true', () => {
+  const { result } = setupHook();
+  act(() => result.current.onReady({} as TReactPlayer));
+  act(() => {
+    vi.advanceTimersByTime(AUTOPLAY_DETECT_MS);
+  });
+  expect(result.current.autoplayBlocked).toBe(true);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED (timer effect 가 hook 에 없음)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 1 fail — `autoplayBlocked === false`.
+
+- [ ] **Step 3: hook 본문에 useEffect 추가**
+
+`use-autoplay-gesture-gate.hook.ts` 의 `useState` 3개 뒤, return 전에:
+
+```ts
+import { useEffect, useState, type RefObject } from 'react';
+// ... 기존 import 유지
+
+useEffect(() => {
+  if (!playerReady || played) return;
+  const timer = setTimeout(() => setAutoplayBlocked(true), AUTOPLAY_DETECT_MS);
+  return () => clearTimeout(timer);
+}, [playerReady, played, videoId]);
+```
+
+args destructure 도 확장:
+
+```ts
+{ playerRef, playable, videoId }: UseAutoplayGestureGateArgs
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 4 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts \
+        src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): autoplay 1500ms 차단 감지
+
+feat: useEffect timer — playerReady && !played 후 AUTOPLAY_DETECT_MS 경과 시 autoplayBlocked=true"
+```
+
+### Task 1.5: onPlay → played=true + autoplayBlocked=false (RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가**
+
+```ts
+test('onPlay 호출 시 played=true + autoplayBlocked=false', () => {
+  const { result } = setupHook();
+  act(() => result.current.onReady({} as TReactPlayer));
+  act(() => {
+    vi.advanceTimersByTime(AUTOPLAY_DETECT_MS);
+  });
+  expect(result.current.autoplayBlocked).toBe(true);
+  act(() => result.current.onPlay());
+  expect(result.current.played).toBe(true);
+  expect(result.current.autoplayBlocked).toBe(false);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN (이미 구현됨)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 5 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): onPlay 차단 해제 회귀"
+```
+
+### Task 1.6: handleGesturePlay → playVideo() (RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가 (mock player + handleGesturePlay)**
+
+```ts
+test('handleGesturePlay 가 internal playVideo() 호출 + autoplayBlocked=false 즉시 전환', () => {
+  const playVideo = vi.fn();
+  const fakePlayer = {
+    getInternalPlayer: () => ({ playVideo }),
+  } as unknown as TReactPlayer;
+
+  // playerRef 에 직접 fakePlayer 할당하기 위해 renderHook 안에서 ref 노출
+  const { result } = renderHook(() => {
+    const playerRef = useRef<TReactPlayer | null>(fakePlayer);
+    return {
+      gate: useAutoplayGestureGate({ playerRef, playable: true, videoId: 'abc' }),
+      playerRef,
+    };
+  });
+
+  // 차단 상태 시뮬레이션
+  act(() => result.current.gate.onReady(fakePlayer));
+  act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
+  expect(result.current.gate.autoplayBlocked).toBe(true);
+
+  act(() => result.current.gate.handleGesturePlay());
+  expect(playVideo).toHaveBeenCalledTimes(1);
+  expect(result.current.gate.autoplayBlocked).toBe(false);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN (이미 구현됨)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 6 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): handleGesturePlay internal.playVideo() 호출 단언"
+```
+
+### Task 1.7: videoId 변경 시 차단 detect 재armed (RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가 (videoId 변경 → played reset + 새 1500ms 타이머)**
+
+```ts
+test('videoId 변경 시 played reset + 새 1500ms 타이머 시작 (트랙 변경 시 차단 재armed)', () => {
+  let id = 'first' as string | null;
+  const { result, rerender } = renderHook(() => {
+    const playerRef = useRef<TReactPlayer | null>(null);
+    return useAutoplayGestureGate({ playerRef, playable: true, videoId: id });
+  });
+
+  act(() => result.current.onReady({} as TReactPlayer));
+  act(() => result.current.onPlay());
+  expect(result.current.played).toBe(true);
+  expect(result.current.autoplayBlocked).toBe(false);
+
+  // 트랙 변경
+  id = 'second';
+  rerender();
+
+  // played reset 됨
+  expect(result.current.played).toBe(false);
+
+  // 새 트랙도 1500ms 내 onPlay 없으면 차단
+  act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
+  expect(result.current.autoplayBlocked).toBe(true);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED (videoId 변경 시 played reset 로직 없음)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 1 fail — `played` 가 여전히 true.
+
+- [ ] **Step 3: hook 본문에 videoId reset useEffect 추가**
+
+`use-autoplay-gesture-gate.hook.ts` 의 기존 timer useEffect 위쪽에:
+
+```ts
+// 트랙 변경 시 played + autoplayBlocked reset → 새 트랙의 autoplay 차단을 재감지.
+useEffect(() => {
+  setPlayed(false);
+  setAutoplayBlocked(false);
+}, [videoId]);
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 7 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts \
+        src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): videoId 변경 시 차단 detect 재armed
+
+feat: videoId effect — played/autoplayBlocked reset → 새 트랙 1500ms 타이머 재시작 (spec §4.6 reviewer 1차 #7)"
+```
+
+### Task 1.8: playable=false 진입 시 state reset (Mode C 시뮬레이션, RED→GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts`
+
+- [ ] **Step 1: 테스트 추가**
+
+```ts
+test('playable=false 진입 시 모든 state reset (Mode C 진입 시 cleanup)', () => {
+  let playable = true;
+  const { result, rerender } = renderHook(() => {
+    const playerRef = useRef<TReactPlayer | null>(null);
+    return useAutoplayGestureGate({ playerRef, playable, videoId: 'abc' });
+  });
+
+  act(() => result.current.onReady({} as TReactPlayer));
+  act(() => result.current.onPlay());
+  expect(result.current.playerReady).toBe(true);
+  expect(result.current.played).toBe(true);
+
+  // Mode C 진입 시뮬레이션
+  playable = false;
+  rerender();
+
+  expect(result.current.playerReady).toBe(false);
+  expect(result.current.played).toBe(false);
+  expect(result.current.autoplayBlocked).toBe(false);
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 1 fail — `playerReady` 가 여전히 true.
+
+- [ ] **Step 3: hook 본문에 playable cleanup useEffect 추가**
+
+`use-autoplay-gesture-gate.hook.ts` 에 추가:
+
+```ts
+// Mode C (재생 가능 영상 없음) 진입 시 모든 state reset → 다음 재생 시 깨끗한 detect.
+useEffect(() => {
+  if (!playable) {
+    setPlayerReady(false);
+    setPlayed(false);
+    setAutoplayBlocked(false);
+  }
+}, [playable]);
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts 2>&1 | tail -20`
+Expected: 8 tests passed (7 spec + 1 상수).
+
+> Note: spec §7.1 의 hook 7 케이스 + `AUTOPLAY_DETECT_MS` 상수 단언 1 케이스 = 총 8 케이스 (Spec 의 "7 케이스" 는 상수 단언을 포함하지 않은 카운트).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts \
+        src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+git commit -m "test(widgets-mobile/partyroom-display-board): playable=false 진입 시 state reset
+
+feat: playable effect — Mode C 진입 시 playerReady/played/autoplayBlocked 모두 false 로 cleanup (spec §7.1)"
+```
+
+### Task 1.9: Chunk 1 회귀 + lint 확인
+
+- [ ] **Step 1: hook 테스트 전체 재실행**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/lib/ 2>&1 | tail -20`
+Expected: 8 tests passed, 1 test file.
+
+- [ ] **Step 2: 프로젝트 전체 lint (변경 파일만 빠른 path)**
+
+Run: `yarn lint --fix src/widgets-mobile/partyroom-display-board/lib/ 2>&1 | tail -20`
+Expected: 0 errors (warning 있어도 본 chunk 한정 회귀 0).
+
+- [ ] **Step 3: TypeScript build sanity**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: 누락 commit 확인**
+
+Run: `git status --short`
+Expected: empty (모든 변경 commit 됨).
+
+> **Chunk 1 완료.** Chunk 2 로 진행.
+
+---
+
+## Chunk 2: 정적 Parts — BlankPlaceholder · ExpandToggle · NowPlayingMeta · TapToPlayButton
+
+> 본 chunk 는 VideoFrame 의 leaf 컴포넌트 4 개를 TDD 로 독립 작성한다. Chunk 3 의 VideoFrame 이 이들을 props 로만 의존하도록 인터페이스를 잠근다. inline 한국어 (§3 row 11), 44×44 hit-area (iOS HIG, §3 row 5/6), aria-\* 정합 (§6.2/§6.5) 가 본 chunk 의 핵심 회귀 가드.
+
+> **책임 분리 잠금 (chunk 2 전체 적용)**:
+>
+> - **wrapper class 는 VideoFrame (Chunk 3) 단일 소유.** BlankPlaceholder 는 wrapper 내부 fill (`w-full h-full`) 만 책임 — `aspect-video`/`bg-black`/`rounded` 토큰을 중첩하지 않는다 (nested aspect-video 회피).
+> - **positioning 도 parent (VideoFrame/NowPlayingRow) 단일 소유.** ExpandToggle / TapToPlayButton 의 leaf 본문은 visual + 44×44 hit-area + aria 만. `absolute`/`top-1 right-1`/`flex-1 min-w-0` 같은 부모-context-의존 토큰 금지.
+> - **overlay 시각 styling (영상 위 대비/배경/rounded) 도 parent 책임.** ExpandToggle 가 영상 위에 얹히는 가독성 확보 (`bg-black/40`, `rounded-full`, padding 등) 는 Chunk 3 VideoFrame 의 wrapping div 가 가진다. leaf 는 transparent 가정 — 부모 wrapper 가 시각 컨텍스트를 결정.
+> - **NowPlayingMeta `layout` prop 의미**: 메타 _내부_ 배치 (column = 트랙/DJ/duration 세 줄 stack, row = 한 줄 inline). spec §4.2 Mode B 의 스케치는 video-box + meta 의 _외부_ 배치 시각화 — 외부 배치는 root MobilePartyroomDisplayBoard 의 NowPlayingRow 가 책임 (§4.4 / §6.4 / Chunk 4).
+
+### Task 2.1: BlankPlaceholder (Mode C 검정 박스)
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx`
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx`
+
+- [ ] **Step 1: 테스트 작성 (RED 3 케이스)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import BlankPlaceholder from './blank-placeholder.component';
+
+describe('BlankPlaceholder', () => {
+  test('inline 한국어 안내 텍스트 렌더 (spec §6.3, §3 row 11)', () => {
+    render(<BlankPlaceholder />);
+    expect(screen.getByText('지금 재생 중인 곡이 없어요')).toBeTruthy();
+  });
+
+  test('wrapper-fill class (w-full h-full + center) — wrapper aspect 책임은 VideoFrame', () => {
+    const { container } = render(<BlankPlaceholder />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bw-full\b/);
+    expect(root.className).toMatch(/\bh-full\b/);
+    expect(root.className).toMatch(/\bflex\b/);
+    expect(root.className).toMatch(/\bitems-center\b/);
+    expect(root.className).toMatch(/\bjustify-center\b/);
+    // 회귀 가드: BlankPlaceholder 자체에 aspect-video / bg-black / rounded 가 들어오면 nested 발생
+    expect(root.className).not.toMatch(/\baspect-video\b/);
+    expect(root.className).not.toMatch(/\bbg-black\b/);
+    expect(root.className).not.toMatch(/\brounded\b/);
+  });
+
+  test('data-testid="blank-placeholder" 단언 (통합 테스트 selector 안정성)', () => {
+    render(<BlankPlaceholder />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx 2>&1 | tail -20`
+Expected: 3 fail — `Cannot find module './blank-placeholder.component'`.
+
+- [ ] **Step 3: 컴포넌트 구현**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx
+import { FC } from 'react';
+
+/**
+ * Mode C (비재생) 안내 — inline 한국어 (spec §6.3, §3 row 11).
+ *
+ * **책임 분리**: 16:9 aspect / 검정 배경 / rounded 는 VideoFrame 의 wrapperClass('C')
+ * 가 책임. 본 컴포넌트는 그 wrapper 의 *fill* (w-full h-full) + 중앙 정렬 + 텍스트만.
+ * 중복 토큰을 두면 nested aspect-video / 중첩 bg-black 회귀 발생.
+ *
+ * Text styling: 기존 chunk 2 inline 의 `text-sm text-gray-500` 패턴 유지 (시각 회귀 0).
+ */
+const BlankPlaceholder: FC = () => {
+  return (
+    <div data-testid='blank-placeholder' className='w-full h-full flex items-center justify-center'>
+      <p className='text-sm text-gray-500'>지금 재생 중인 곡이 없어요</p>
+    </div>
+  );
+};
+
+export default BlankPlaceholder;
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx 2>&1 | tail -20`
+Expected: 3 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx \
+        src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): BlankPlaceholder — Mode C 16:9 검정 박스 + 한국어 안내 (spec §6.3)"
+```
+
+### Task 2.2: ExpandToggle (▾/◂ 버튼)
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx`
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx`
+
+- [ ] **Step 1: 테스트 작성 (RED 5 케이스)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import ExpandToggle from './expand-toggle.component';
+
+describe('ExpandToggle', () => {
+  test('expanded=true 시 aria-label="영상 가리기" + aria-pressed="false" (spec §6.2)', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe('영상 가리기');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('expanded=false 시 aria-label="영상 펼치기" + aria-pressed="true"', () => {
+    render(<ExpandToggle expanded={false} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe('영상 펼치기');
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('클릭 시 onToggle 콜백 1회 호출', () => {
+    const onToggle = vi.fn();
+    render(<ExpandToggle expanded={true} onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  test('44×44 hit-area class — min-h-[44px] + min-w-[44px] (iOS HIG, spec §6.2)', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/\bmin-h-\[44px\]/);
+    expect(btn.className).toMatch(/\bmin-w-\[44px\]/);
+  });
+
+  test('positioning 책임은 parent (VideoFrame) — leaf 본문은 absolute/top-*/right-* 미보유', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).not.toMatch(/\babsolute\b/);
+    expect(btn.className).not.toMatch(/\btop-/);
+    expect(btn.className).not.toMatch(/\bright-/);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx 2>&1 | tail -20`
+Expected: 5 fail — module not found.
+
+- [ ] **Step 3: 컴포넌트 구현**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx
+import { FC } from 'react';
+
+interface Props {
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * ▾/◂ 토글. controlled (state owner = MobilePartyroomDisplayBoard, spec §4.4).
+ *
+ * a11y (spec §6.2):
+ * - aria-label: expanded → '영상 가리기', collapsed → '영상 펼치기' (inline 한국어, §3 row 11)
+ * - aria-pressed: !expanded (collapsed 가 pressed state)
+ * - min-h/w 44px (iOS HIG hit-area)
+ *
+ * **positioning 책임은 parent (Chunk 3 VideoFrame).** 본문에 `absolute`/`top-*`/`right-*`
+ * 등을 두면 leaf 가 부모 layout 에 coupling 됨. 시각 styling 도 최소 (overlay 가 영상
+ * 위에 얹히는 상황은 parent 의 wrapper context — `bg-black/40` 등은 Chunk 3 에서 wrapping div 가 책임).
+ */
+const ExpandToggle: FC<Props> = ({ expanded, onToggle }) => {
+  return (
+    <button
+      type='button'
+      aria-label={expanded ? '영상 가리기' : '영상 펼치기'}
+      aria-pressed={!expanded}
+      onClick={onToggle}
+      className='min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-200'
+    >
+      {expanded ? '▾' : '◂'}
+    </button>
+  );
+};
+
+export default ExpandToggle;
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx 2>&1 | tail -20`
+Expected: 5 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx \
+        src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): ExpandToggle — ▾/◂ 토글 버튼 (controlled, 44×44 hit-area, spec §6.2)"
+```
+
+### Task 2.3: NowPlayingMeta (트랙메타 column/row)
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx`
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx`
+
+- [ ] **Step 1: 테스트 작성 (RED 5 케이스)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import NowPlayingMeta from './now-playing-meta.component';
+
+describe('NowPlayingMeta', () => {
+  test('layout="column": 트랙명·DJ·duration 3 라인 렌더 (Mode A 사용)', () => {
+    render(
+      <NowPlayingMeta
+        layout='column'
+        trackName='Test Track'
+        djNickname='DJ Alpha'
+        duration='3:45'
+      />
+    );
+    expect(screen.getByText('Test Track')).toBeTruthy();
+    expect(screen.getByText(/DJ Alpha/)).toBeTruthy();
+    expect(screen.getByText('3:45')).toBeTruthy();
+  });
+
+  test('layout="row": 트랙명·DJ·duration 모두 렌더 (Mode B 사용, 한 row)', () => {
+    render(
+      <NowPlayingMeta layout='row' trackName='Test Track' djNickname='DJ Beta' duration='2:10' />
+    );
+    expect(screen.getByText('Test Track')).toBeTruthy();
+    expect(screen.getByText(/DJ Beta/)).toBeTruthy();
+    expect(screen.getByText('2:10')).toBeTruthy();
+  });
+
+  test('djNickname=null 시 DJ 라인 미렌더 (트랙명·duration 만)', () => {
+    render(
+      <NowPlayingMeta layout='column' trackName='Solo Track' djNickname={null} duration='1:00' />
+    );
+    expect(screen.getByText('Solo Track')).toBeTruthy();
+    expect(screen.queryByText(/🎧/)).toBeNull();
+    expect(screen.getByText('1:00')).toBeTruthy();
+  });
+
+  test('layout 분기 root class — column 은 flex-col, row 는 flex-row', () => {
+    const { container, rerender } = render(
+      <NowPlayingMeta layout='column' trackName='T' djNickname={null} duration='0:00' />
+    );
+    const rootColumn = container.firstElementChild as HTMLElement;
+    expect(rootColumn.className).toMatch(/\bflex-col\b/);
+
+    rerender(<NowPlayingMeta layout='row' trackName='T' djNickname={null} duration='0:00' />);
+    const rootRow = container.firstElementChild as HTMLElement;
+    expect(rootRow.className).toMatch(/\bflex-row\b/);
+  });
+
+  test('row variant 도 parent flex 토큰 (flex-1 / min-w-0 등) 보유 X — 책임은 parent NowPlayingRow', () => {
+    const { container } = render(
+      <NowPlayingMeta layout='row' trackName='T' djNickname='D' duration='0:00' />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toMatch(/\bflex-1\b/);
+    expect(root.className).not.toMatch(/\bmin-w-0\b/);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx 2>&1 | tail -20`
+Expected: 5 fail — module not found.
+
+- [ ] **Step 3: 컴포넌트 구현**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx
+import { FC } from 'react';
+import { cn } from '@/shared/lib/functions/cn';
+
+interface Props {
+  layout: 'column' | 'row';
+  trackName: string;
+  djNickname: string | null;
+  /** `M:SS` 또는 `MM:SS` 사전 포맷 문자열. parent 가 책임. */
+  duration: string;
+}
+
+/**
+ * 트랙메타 (트랙명·DJ·duration) — Mode A = column, Mode B = row (spec §4.4 / §6.4 prop 정의).
+ *
+ * **`layout` prop 의미**: 본 컴포넌트 *내부* 의 배치만 결정.
+ * - column = 트랙명 / DJ / duration 세 줄 vertical stack (Mode A 시 16:9 박스 *아래*).
+ * - row    = 트랙명 · DJ · duration 한 줄 horizontal inline (Mode B 시 NowPlayingRow 안에서 TapToPlayButton 과 sibling).
+ *
+ * **외부 배치는 NowPlayingRow (Chunk 4 의 root MobilePartyroomDisplayBoard) 책임**.
+ * `flex-1` / `min-w-0` 등 부모-context-의존 토큰은 본문에 두지 않음 (책임 분리, Chunk 2 잠금).
+ *
+ * inline 한국어 (DJ 아이콘 = emoji, 본문 i18n 의존 0, §3 row 11).
+ */
+const NowPlayingMeta: FC<Props> = ({ layout, trackName, djNickname, duration }) => {
+  return (
+    <div
+      className={cn(
+        'flex',
+        layout === 'column' ? 'flex-col space-y-1' : 'flex-row items-center gap-2'
+      )}
+    >
+      <p className='text-base font-semibold text-white truncate'>{trackName}</p>
+      {djNickname && <p className='text-xs text-gray-500 truncate'>🎧 {djNickname}</p>}
+      <p className='text-xs text-gray-600 shrink-0'>{duration}</p>
+    </div>
+  );
+};
+
+export default NowPlayingMeta;
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx 2>&1 | tail -20`
+Expected: 5 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx \
+        src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): NowPlayingMeta — column/row 양 layout (spec §6.4)"
+```
+
+### Task 2.4: TapToPlayButton (Mode B release ▶)
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx`
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx`
+
+- [ ] **Step 1: 테스트 작성 (RED 4 케이스)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import TapToPlayButton from './tap-to-play-button.component';
+
+describe('TapToPlayButton', () => {
+  test('autoplayBlocked=true 시 visible (▶ 아이콘 + aria-label="재생", spec §6.5.2)', () => {
+    render(<TapToPlayButton autoplayBlocked={true} onTap={() => {}} />);
+    const btn = screen.getByRole('button', { name: '재생' });
+    expect(btn).toBeTruthy();
+  });
+
+  test('autoplayBlocked=false 시 미렌더 (release 후 hide)', () => {
+    const { container } = render(<TapToPlayButton autoplayBlocked={false} onTap={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('클릭 시 onTap 콜백 1회 호출', () => {
+    const onTap = vi.fn();
+    render(<TapToPlayButton autoplayBlocked={true} onTap={onTap} />);
+    fireEvent.click(screen.getByRole('button', { name: '재생' }));
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  test('44×44 hit-area class (iOS HIG, spec §6.5.2)', () => {
+    render(<TapToPlayButton autoplayBlocked={true} onTap={() => {}} />);
+    const btn = screen.getByRole('button', { name: '재생' });
+    expect(btn.className).toMatch(/\bmin-h-\[44px\]/);
+    expect(btn.className).toMatch(/\bmin-w-\[44px\]/);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx 2>&1 | tail -20`
+Expected: 4 fail — module not found.
+
+- [ ] **Step 3: 컴포넌트 구현**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx
+import { FC } from 'react';
+
+interface Props {
+  /**
+   * **합성 (pre-computed) prop**: root 에서 `gate.autoplayBlocked && !gate.played`
+   * 를 미리 계산해 내려주는 합성 boolean. 본 컴포넌트는 raw `gate.autoplayBlocked`
+   * 를 받지 않으며 `played` 도 받지 않는다 (spec §6.5.2 single source of truth).
+   */
+  autoplayBlocked: boolean;
+  onTap: () => void;
+}
+
+/**
+ * Mode B 의 release 경로 — autoplay 차단 시 NowPlayingMeta row 옆 sibling 으로
+ * 렌더. Mode A 는 AutoplayGestureGate (full overlay) 사용 — Mode B 는 80×45
+ * 영상 위 overlay 가 가독성·접근성 미흡이라 row sibling 으로 분리 (spec §6.5).
+ *
+ * **State 공유 보장 (spec §6.5.2)**:
+ * - `autoplayBlocked` prop = root 의 `gate.autoplayBlocked && !gate.played` 합성값.
+ * - `onTap` prop = root 의 `gate.handleGesturePlay` (AutoplayGestureGate 와 동일 함수).
+ * - 두 control 모두 동일 hook state 로 구동 → tap → handleGesturePlay → setAutoplayBlocked(false) → 두 control 동시 hide.
+ *
+ * **positioning 책임은 parent (NowPlayingRow)**. 본문에 `absolute`/`top-*` 등 두지 않음.
+ */
+const TapToPlayButton: FC<Props> = ({ autoplayBlocked, onTap }) => {
+  if (!autoplayBlocked) return null;
+  return (
+    <button
+      type='button'
+      aria-label='재생'
+      onClick={onTap}
+      className='shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded bg-white/90 text-black'
+    >
+      <svg width='20' height='20' viewBox='0 0 24 24' fill='currentColor' aria-hidden>
+        <path d='M8 5v14l11-7z' />
+      </svg>
+    </button>
+  );
+};
+
+export default TapToPlayButton;
+```
+
+- [ ] **Step 4: 테스트 GREEN 확인**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx 2>&1 | tail -20`
+Expected: 4 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx \
+        src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): TapToPlayButton — Mode B autoplay release ▶ 버튼 (single source, spec §6.5.2)"
+```
+
+### Task 2.5: Chunk 2 회귀 + lint + tsc
+
+- [ ] **Step 1: parts 디렉토리 전체 vitest**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/ 2>&1 | tail -30`
+Expected: 4 test files · 17 tests passed (BlankPlaceholder 3 + ExpandToggle 5 + NowPlayingMeta 5 + TapToPlayButton 4). 기존 `action-buttons.component.tsx` / `action-button.component.tsx` 는 테스트 미작성 — 본 chunk 스코프 외.
+
+- [ ] **Step 2: lint**
+
+Run: `yarn lint --fix src/widgets-mobile/partyroom-display-board/ui/parts/ 2>&1 | tail -20`
+Expected: 0 errors.
+
+- [ ] **Step 3: tsc**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: clean working tree 확인**
+
+Run: `git status --short`
+Expected: empty.
+
+> **Chunk 2 완료.** Chunk 3 (VideoFrame orchestrator) 로 진행.
+
+---
+
+## Chunk 3: VideoFrame Orchestrator (3-mode + ToS 가드)
+
+> VideoFrame 은 Chunk 1 의 hook gate state 와 Chunk 2 의 4 parts 를 props 로만 의존하는 **단일 mode orchestrator**. wrapper-based sizing (§4.5 wrapperClass) 로 YoutubePlayer 의 width/height='100%' 를 고정 → IFrame remount 위험 0. TapToPlayButton 은 본 Chunk 범위 외 (NowPlayingRow 소속, §6.5.3, Chunk 4).
+>
+> **본 chunk 의 핵심 회귀 가드**:
+>
+> - wrapperClass 가 정적 string 리터럴만 반환 (Tailwind JIT 정적 scan)
+> - JS 상수 (COLLAPSED_VIDEO_WIDTH/HEIGHT) ↔ wrapperClass 의 정적 토큰 sync
+> - Mode A↔B 전환 시 YoutubePlayer mock 호출 count 유지 (remount 없음 검증)
+> - ToS 가드: `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 모든 mode 부재
+> - ToS 가드: `data-testid='video-wrapper'` 에 `aria-hidden='true'` 직접 부착 안 됨
+
+### Task 3.1: VideoFrame stub + 인터페이스 잠금
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`
+
+- [ ] **Step 1: 인터페이스 + stub 본문 작성 (상수 export 포함)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+'use client';
+import dynamic from 'next/dynamic';
+import { FC, RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+import { YouTubeConfig } from 'react-player/youtube';
+import { useUserPreferenceStore } from '@/entities/preference';
+import { cn } from '@/shared/lib/functions/cn';
+import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+import BlankPlaceholder from './blank-placeholder.component';
+import ExpandToggle from './expand-toggle.component';
+
+// 데스크탑과 동일하게 SSR off 동적 import. C3 격리 — 데스크탑 사본 import 안 함.
+const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
+
+/**
+ * Mode B 의 collapsed video 박스 픽셀. **JS 상수는 Playwright headed assertion 용 documentary 값**.
+ * wrapperClass('B') 의 정적 Tailwind 토큰 (`w-[80px] h-[45px]`) 과 sync 가 유지되어야 함.
+ * 단위 테스트가 두 값 일치를 가드 (spec §4.5).
+ */
+export const COLLAPSED_VIDEO_WIDTH = 80;
+export const COLLAPSED_VIDEO_HEIGHT = 45;
+
+/**
+ * wrapper Tailwind class — **정적 string 리터럴만 반환**. `w-[${var}px]` 같은 runtime
+ * template 은 JIT 가 정적 scan 으로만 생성하므로 absent → wrapper 0×0 → ToS 위반 재발.
+ */
+export function wrapperClass(mode: 'A' | 'B' | 'C'): string {
+  switch (mode) {
+    case 'A':
+      return 'aspect-video w-full bg-black rounded';
+    case 'B':
+      return 'w-[80px] h-[45px] shrink-0 bg-black rounded';
+    case 'C':
+      return 'aspect-video w-full bg-black rounded';
+  }
+}
+
+interface Props {
+  videoId: string | null;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  playerRef: RefObject<TReactPlayer | null>;
+  gate: AutoplayGestureGate;
+}
+
+/**
+ * 3-mode 단일 orchestrator (spec §4.5, §6.1).
+ *
+ * - mode 'A' (재생 + expanded): 16:9 풀폭 IFrame + ExpandToggle ▾
+ * - mode 'B' (재생 + collapsed): 80×45 IFrame + ExpandToggle ◂
+ * - mode 'C' (videoId === null): BlankPlaceholder + 토글 미렌더
+ *
+ * YoutubePlayer width/height 는 **'100%' 고정** — 부모 wrapper class 만 교체 → IFrame
+ * remount 차단 (§4.5 핵심 보장).
+ */
+const VideoFrame: FC<Props> = (_props) => {
+  throw new Error('not implemented');
+};
+
+export default VideoFrame;
+
+/**
+ * @see https://developers.google.com/youtube/player_parameters
+ */
+const config: YouTubeConfig = {
+  playerVars: {
+    controls: 0,
+    autoplay: 1,
+    modestbranding: 1,
+    rel: 0,
+    autohide: 1,
+  },
+};
+
+// HACK: config 는 본문에서 곧 사용. 임시 미사용 lint 회피.
+void config;
+```
+
+- [ ] **Step 2: TypeScript build sanity**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors (stub 만 있어서 통과).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): VideoFrame stub + wrapperClass + COLLAPSED_VIDEO_* 상수 (spec §4.5)"
+```
+
+### Task 3.2: 테스트 파일 scaffold + react-player mock
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 파일 scaffold — react-player/youtube mock + helper setupFrame()**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import type TReactPlayer from 'react-player';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+import VideoFrame, {
+  COLLAPSED_VIDEO_HEIGHT,
+  COLLAPSED_VIDEO_WIDTH,
+  wrapperClass,
+} from './video-frame.component';
+
+// react-player/youtube 동적 import 를 vitest 모듈 mock 으로 단순화.
+// 호출 count 와 props 를 캡쳐해 remount / size prop 단언에 사용.
+const youtubePlayerCalls: Array<Record<string, unknown>> = [];
+vi.mock('react-player/youtube', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    youtubePlayerCalls.push(props);
+    return <div data-testid='youtube-player-mock' data-url={String(props.url ?? '')} />;
+  },
+}));
+
+// next/dynamic 의 SSR off 분기를 mock 으로 우회 — `react-player/youtube` mock 의
+// default 를 그대로 통과시킨다. vi.mock 은 hoisted 라 mock 이 본 라인 시점에 이미
+// 적용됨 — async importer 의 결과를 caching 만 하면 충분.
+vi.mock('next/dynamic', async () => {
+  const mod = await import('react-player/youtube');
+  return { __esModule: true, default: () => mod.default };
+});
+
+// useUserPreferenceStore mock — volume / muted 기본값
+vi.mock('@/entities/preference', () => ({
+  useUserPreferenceStore: vi.fn((selector: (s: { volume: number; muted: boolean }) => unknown) =>
+    selector({ volume: 1, muted: false })
+  ),
+}));
+
+function makeGate(overrides: Partial<AutoplayGestureGate> = {}): AutoplayGestureGate {
+  return {
+    autoplayBlocked: false,
+    played: false,
+    playerReady: false,
+    handleGesturePlay: vi.fn(),
+    onReady: vi.fn(),
+    onStart: vi.fn(),
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    ...overrides,
+  };
+}
+
+function Harness({
+  videoId,
+  expanded,
+  onToggleExpand,
+  gate,
+}: {
+  videoId: string | null;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  gate: AutoplayGestureGate;
+}) {
+  const playerRef = useRef<TReactPlayer | null>(null);
+  return (
+    <VideoFrame
+      videoId={videoId}
+      expanded={expanded}
+      onToggleExpand={onToggleExpand}
+      playerRef={playerRef}
+      gate={gate}
+    />
+  );
+}
+
+beforeEach(() => {
+  youtubePlayerCalls.length = 0;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 빈 파일 → 0 tests (scaffolding 정상)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 0 tests / "no test suite" warning (또는 vitest 가 0 test 로 PASS — describe 가 아직 없음). 어느 형태든 실행 자체는 통과.
+
+- [ ] **Step 3: Commit scaffold**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): VideoFrame 테스트 scaffold + react-player/dynamic mock + Harness"
+```
+
+### Task 3.3: 상수 + wrapperClass 정적 리터럴 단언 (Cases 11, 12 → 첫 GREEN)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: describe 블록 + 케이스 2개 (정적 리터럴 + 상수 sync)**
+
+테스트 파일 맨 끝에 추가:
+
+```tsx
+describe('VideoFrame · wrapperClass (정적 리터럴 가드, spec §4.5)', () => {
+  test('Mode A 리터럴: aspect-video w-full bg-black rounded', () => {
+    expect(wrapperClass('A')).toBe('aspect-video w-full bg-black rounded');
+  });
+
+  test('Mode B 리터럴: w-[80px] h-[45px] shrink-0 bg-black rounded — Tailwind JIT 정적 scan 안전', () => {
+    expect(wrapperClass('B')).toBe('w-[80px] h-[45px] shrink-0 bg-black rounded');
+  });
+
+  test('Mode C 리터럴: aspect-video w-full bg-black rounded', () => {
+    expect(wrapperClass('C')).toBe('aspect-video w-full bg-black rounded');
+  });
+
+  test('JS 상수 ↔ wrapperClass(B) 정적 리터럴 sync — 상수만 바뀌면 fail', () => {
+    expect(wrapperClass('B')).toContain(`w-[${COLLAPSED_VIDEO_WIDTH}px]`);
+    expect(wrapperClass('B')).toContain(`h-[${COLLAPSED_VIDEO_HEIGHT}px]`);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 즉시 GREEN (wrapperClass 는 stub 단계에서 이미 구현됨)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 4 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): wrapperClass 정적 리터럴 + JS 상수 sync 가드 (spec §7.1 #11, #12)"
+```
+
+### Task 3.4: Mode A 렌더 — YoutubePlayer 100% / wrapper class / ExpandToggle (Cases 1, 8) — RED → GREEN
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 추가 (RED 3 케이스)**
+
+테스트 파일에 새 describe 추가:
+
+```tsx
+describe('VideoFrame · Mode A (재생 + expanded)', () => {
+  test('YoutubePlayer mount + width=100% / height=100% / url 정상', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(youtubePlayerCalls).toHaveLength(1);
+    const props = youtubePlayerCalls[0];
+    expect(props.width).toBe('100%');
+    expect(props.height).toBe('100%');
+    expect(props.url).toBe('https://www.youtube.com/watch?v=abc');
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+  });
+
+  test('wrapper 가 wrapperClass("A") 정적 토큰 보유 + ExpandToggle ▾ (expanded=true)', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).toContain('w-full');
+    expect(wrapper.className).toContain('bg-black');
+    expect(wrapper.className).toContain('rounded');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+    expect(screen.queryByTestId('blank-placeholder')).toBeNull();
+  });
+
+  test('autoplayBlocked && !played 시 AutoplayGestureGate overlay 렌더 + 클릭 시 handleGesturePlay 호출', () => {
+    const handleGesturePlay = vi.fn();
+    const gate = makeGate({ autoplayBlocked: true, played: false, handleGesturePlay });
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={gate} />);
+    const overlay = screen.getByTestId('autoplay-gesture-gate');
+    fireEvent.click(overlay);
+    expect(handleGesturePlay).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → RED (VideoFrame 본문 throw)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 3 fail (Mode A 케이스 3개) — `not implemented` throw.
+
+- [ ] **Step 3: VideoFrame 본문 구현 — Mode A · Mode B · Mode C 모두 한 번에 (mode derive + wrapper + YoutubePlayer + BlankPlaceholder + AutoplayGestureGate overlay + ExpandToggle wrapping)**
+
+`video-frame.component.tsx` 의 `const VideoFrame: FC<Props> = (_props) => { throw new Error('not implemented'); };` 와 그 위 `import` 블록을 다음으로 교체:
+
+```tsx
+'use client';
+import dynamic from 'next/dynamic';
+import { FC, RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+import { YouTubeConfig } from 'react-player/youtube';
+import { useUserPreferenceStore } from '@/entities/preference';
+import { cn } from '@/shared/lib/functions/cn';
+import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+import BlankPlaceholder from './blank-placeholder.component';
+import ExpandToggle from './expand-toggle.component';
+
+const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
+```
+
+그리고 stub 본문을 다음으로 교체:
+
+```tsx
+const VideoFrame: FC<Props> = ({ videoId, expanded, onToggleExpand, playerRef, gate }) => {
+  const mode: 'A' | 'B' | 'C' = videoId === null ? 'C' : expanded ? 'A' : 'B';
+  const volume = useUserPreferenceStore((s) => s.volume);
+  const muted = useUserPreferenceStore((s) => s.muted);
+
+  const showOverlayGate = mode === 'A' && gate.autoplayBlocked && !gate.played;
+  const showToggle = mode === 'A' || mode === 'B';
+
+  return (
+    <div className='relative'>
+      <div data-testid='video-wrapper' className={cn('relative', wrapperClass(mode))}>
+        {mode === 'C' ? (
+          <BlankPlaceholder />
+        ) : (
+          <YoutubePlayer
+            key={`video-${gate.playerReady}-${gate.played}`}
+            url={`https://www.youtube.com/watch?v=${videoId}`}
+            playing={gate.playerReady}
+            volume={muted ? 0 : volume}
+            muted={muted}
+            width='100%'
+            height='100%'
+            className='bg-black rounded'
+            onReady={(player: TReactPlayer) => {
+              playerRef.current = player;
+              gate.onReady(player);
+            }}
+            onStart={gate.onStart}
+            onPlay={gate.onPlay}
+            onPause={gate.onPause}
+            config={config}
+          />
+        )}
+        {showOverlayGate && (
+          // z-20: autoplay 차단 시 overlay 가 ExpandToggle 을 의도적으로 가린다.
+          // 사용자가 토글 접근 전에 먼저 gesture release 를 해야 함 (UX 잠금).
+          <button
+            type='button'
+            data-testid='autoplay-gesture-gate'
+            aria-label='클릭하여 재생'
+            onClick={gate.handleGesturePlay}
+            className='absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-black/70 cursor-pointer'
+          >
+            <span className='flex items-center justify-center w-16 h-16 rounded-full bg-white/90'>
+              <svg width='28' height='28' viewBox='0 0 24 24' fill='black' aria-hidden>
+                <path d='M8 5v14l11-7z' />
+              </svg>
+            </span>
+            <span className='text-sm text-gray-100'>클릭하여 재생</span>
+          </button>
+        )}
+        {showToggle && (
+          <div className='absolute top-1 right-1 bg-black/40 rounded-full p-1'>
+            <ExpandToggle expanded={expanded} onToggle={onToggleExpand} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+마지막 `void config;` 라인 제거 (이제 본문에서 실 사용).
+
+- [ ] **Step 4: 테스트 실행 → Mode A GREEN + 상수 케이스 유지**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -30`
+Expected: 7 tests passed (4 wrapperClass + 3 Mode A).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx \
+        src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): VideoFrame Mode A — YoutubePlayer 100%/url + wrapper + ExpandToggle ▾ + AutoplayGestureGate overlay
+
+feat: 3-mode orchestrator 본문 — wrapper-based sizing (width=100%/height=100% 고정), wrapperClass(mode) 정적 토큰, ExpandToggle positioning (bg-black/40 rounded) 책임은 VideoFrame 의 wrapping div (Chunk 2 책임 분리 잠금 적용)"
+```
+
+### Task 3.5: Mode B 렌더 (Case 2) + Mode B 에서 AutoplayGestureGate 미렌더 (Case 8 partial)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 추가**
+
+```tsx
+describe('VideoFrame · Mode B (재생 + collapsed)', () => {
+  test('wrapper 가 wrapperClass("B") 정적 토큰 (80×45) + ExpandToggle ◂ (expanded=false)', () => {
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('w-[80px]');
+    expect(wrapper.className).toContain('h-[45px]');
+    expect(wrapper.className).toContain('shrink-0');
+    expect(wrapper.className).toContain('bg-black');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('YoutubePlayer width=100%/height=100% 그대로 (wrapper 만 80×45) — IFrame remount 회피', () => {
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(youtubePlayerCalls).toHaveLength(1);
+    expect(youtubePlayerCalls[0].width).toBe('100%');
+    expect(youtubePlayerCalls[0].height).toBe('100%');
+  });
+
+  test('Mode B 에서는 autoplayBlocked 라도 AutoplayGestureGate overlay 미렌더 (Mode A only)', () => {
+    const gate = makeGate({ autoplayBlocked: true, played: false });
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={gate} />);
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN (이미 Mode B 본문 동작)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 10 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): VideoFrame Mode B — 80×45 wrapper + width/height=100% + AutoplayGestureGate Mode A only (spec §6.5.1)"
+```
+
+### Task 3.6: Mode C 렌더 (Case 3) + Props 안전 videoId=null 강제 (Case 15)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 추가**
+
+```tsx
+describe('VideoFrame · Mode C (비재생, videoId=null)', () => {
+  test('BlankPlaceholder visible + YoutubePlayer 미렌더 + Toggle 미렌더', () => {
+    render(<Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: /영상/ })).toBeNull();
+  });
+
+  test('Props 안전: videoId=null 이면 expanded=true 라도 Mode C 강제 (Mode A 진입 안 됨)', () => {
+    render(<Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).not.toContain('w-[80px]');
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+  });
+
+  test('Props 안전: videoId=null + expanded=false 도 Mode C 강제 (Mode B 진입 안 됨)', () => {
+    render(<Harness videoId={null} expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 13 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): VideoFrame Mode C — BlankPlaceholder + YoutubePlayer 미렌더 + videoId=null Props 안전 (spec §7.1 #15)"
+```
+
+### Task 3.7: Mode 전환 — A↔B remount 없음, B↔C / C↔A / A↔C mount/unmount (Cases 4, 5, 6, 7)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 추가 (4 케이스)**
+
+```tsx
+describe('VideoFrame · Mode 전환', () => {
+  test('Mode A → B 전환: wrapper DOM element identity 보존 (remount 없음) + class 만 교체', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    const wrapperBefore = screen.getByTestId('video-wrapper');
+    const ytBefore = screen.getByTestId('youtube-player-mock');
+    expect(wrapperBefore.className).toContain('aspect-video');
+
+    rerender(
+      <Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    // 동일 컴포넌트 + 동일 key → React 가 동일 DOM element 보존 (referential equality).
+    // 이 reference 동등성이 IFrame remount 없음의 강한 증거 (selector 안정성보다 강함).
+    const wrapperAfter = screen.getByTestId('video-wrapper');
+    const ytAfter = screen.getByTestId('youtube-player-mock');
+    expect(wrapperAfter).toBe(wrapperBefore);
+    expect(ytAfter).toBe(ytBefore);
+    expect(wrapperAfter.className).toContain('w-[80px]');
+    expect(wrapperAfter.className).toContain('h-[45px]');
+    expect(wrapperAfter.className).not.toContain('aspect-video');
+  });
+
+  test('Mode B → C 전환: YoutubePlayer mock 호출 0회 (unmount, mode 시점 BlankPlaceholder)', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+    const callsBefore = youtubePlayerCalls.length;
+
+    rerender(
+      <Harness videoId={null} expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    // unmount 후에는 추가 mock 호출 없음
+    expect(youtubePlayerCalls.length).toBe(callsBefore);
+  });
+
+  test('Mode C → A 전환: BlankPlaceholder 사라지고 YoutubePlayer 신규 mount', () => {
+    const { rerender } = render(
+      <Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+
+    rerender(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+
+    expect(screen.queryByTestId('blank-placeholder')).toBeNull();
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+    expect(youtubePlayerCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('Mode A → C 전환: YoutubePlayer unmount + BlankPlaceholder mount (B→C 대칭 가드, spec §7.1 #12)', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+
+    rerender(
+      <Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 17 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): VideoFrame mode 전환 4건 — A↔B no-remount + B↔C / C↔A / A↔C mount/unmount (spec §7.1 #4~7, #12)"
+```
+
+### Task 3.8: ToS 가드 회귀 (Cases 13, 14)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`
+
+- [ ] **Step 1: 테스트 추가 (2 케이스)**
+
+```tsx
+describe('VideoFrame · ToS 가드 (회귀, spec §5)', () => {
+  test.each(['A', 'B', 'C'] as const)(
+    'Mode %s: wrapper className 에 hidden/opacity-0/w-px/h-px/pointer-events-none 토큰 부재',
+    (mode) => {
+      const videoId = mode === 'C' ? null : 'abc';
+      const expanded = mode === 'A' || mode === 'C';
+      render(
+        <Harness
+          videoId={videoId}
+          expanded={expanded}
+          onToggleExpand={() => {}}
+          gate={makeGate()}
+        />
+      );
+      const wrapper = screen.getByTestId('video-wrapper');
+      expect(wrapper.className).not.toMatch(/\bhidden\b/);
+      expect(wrapper.className).not.toMatch(/\bopacity-0\b/);
+      expect(wrapper.className).not.toMatch(/\bw-px\b/);
+      expect(wrapper.className).not.toMatch(/\bh-px\b/);
+      expect(wrapper.className).not.toMatch(/\bpointer-events-none\b/);
+    }
+  );
+
+  test('video-wrapper testid 에 aria-hidden="true" 직접 부착 안 됨', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.getAttribute('aria-hidden')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx 2>&1 | tail -20`
+Expected: 21 tests passed (test.each 3 mode × 1 = 3 추가 + aria 1 추가 = 17→21).
+
+> Note: spec §7.1 의 "ToS 가드 회귀" 1 항목은 plan 에서 `test.each` 로 3-mode parametrize → 3 개 단언 (실 테스트 카운트 3). aria-hidden 단언 1 → 합계 4 추가. 본 chunk 의 video-frame.test.tsx 누적 케이스 21 — File Structure 의 "14" 카운트는 logical 카운트 (test.each 의 3-mode 를 1 case 로 묶음) 기준. 누적 21 / 14 logical 의 차이는 의도된 회귀 강화.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): ToS 가드 회귀 — hidden/opacity-0/w-px/h-px/pointer-events-none 모든 mode 부재 + video-wrapper aria-hidden 부재 (spec §5, §7.1 #13/#14)"
+```
+
+### Task 3.9: Chunk 3 회귀 + lint + tsc
+
+- [ ] **Step 1: VideoFrame + parts 전체 vitest**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ 2>&1 | tail -30`
+Expected: 6 test files (hook 1 + parts 4 + video-frame 1) · 46 tests passed (hook 8 + parts 17 + video-frame 21).
+
+- [ ] **Step 2: lint**
+
+Run: `yarn lint --fix src/widgets-mobile/partyroom-display-board/ 2>&1 | tail -20`
+Expected: 0 errors.
+
+- [ ] **Step 3: tsc**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: clean working tree 확인**
+
+Run: `git status --short`
+Expected: empty.
+
+> **Chunk 3 완료.** Chunk 4 (root rewrite + integration tests) 로 진행.
+
+---
+
+## Chunk 4: Root Rewrite (MobilePartyroomDisplayBoard) + Integration Tests
+
+> 본 chunk 는 chunk 2 의 1px IFrame 본문을 폐기하고 VideoFrame + NowPlayingRow (NowPlayingMeta + TapToPlayButton) 를 mount 한다. `useAutoplayGestureGate` 가 root 에서 1회 호출되어 VideoFrame 의 AutoplayGestureGate 와 NowPlayingRow 의 TapToPlayButton 양쪽에 동일 `gate` state 를 주입 (§4.4 / §6.5.2 single source of truth).
+>
+> **본 chunk 의 핵심 회귀 가드**:
+>
+> - expanded state 가 토글 클릭 1곳에서만 변경 (트랙 변경·Mode C 진입·remount 자동 변환 없음, §4.4 불변식).
+> - Mode C → 재생 복귀 시 사용자 마지막 선택 (Mode A 또는 B) 으로 직접 진입.
+> - NowPlayingRow 는 `min-h-[44px]` 보유 → TapToPlayButton 의 iOS HIG hit-area 확보 (§6.4 reviewer 3차 #2).
+> - Cross-component single source: Mode B + autoplayBlocked → Mode A toggle 시 AutoplayGestureGate overlay 즉시 visible.
+
+### Task 4.1: Root component 본문 재설계 (chunk 2 의 1px IFrame 폐기)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`
+
+- [ ] **Step 1: 기존 본문을 신규 구조로 전체 교체**
+
+기존 `partyroom-display-board.component.tsx` 의 본문 (line 1~108) 을 다음으로 교체:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FC, useRef, useState } from 'react';
+import type TReactPlayer from 'react-player';
+import { useFetchPartyroomDetailSummary } from '@/features/partyroom/get-summary';
+import { cn } from '@/shared/lib/functions/cn';
+import { useStores } from '@/shared/lib/store/stores.context';
+import useAutoplayGestureGate from './lib/use-autoplay-gesture-gate.hook';
+import ActionButtons from './ui/parts/action-buttons.component';
+import NowPlayingMeta from './ui/parts/now-playing-meta.component';
+import TapToPlayButton from './ui/parts/tap-to-play-button.component';
+import VideoFrame from './ui/parts/video-frame.component';
+
+interface Props {
+  partyroomId: number;
+}
+
+/**
+ * 모바일 전광판 — chunk 3.1 재설계 (spec §4.2 / §6.*).
+ *
+ * 본 컴포넌트 책임:
+ * 1. expanded state owner (룸 mount 시 true, 토글 클릭만 변경, 다른 어떤 트리거도 자동 전환 X).
+ * 2. useAutoplayGestureGate 호출 — VideoFrame 의 overlay 와 NowPlayingRow 의 TapToPlayButton
+ *    양쪽에 동일 `gate` state 주입 (§4.4 / §6.5.2 single source of truth).
+ * 3. NowPlayingRow (min-h-[44px]) 로 NowPlayingMeta + TapToPlayButton 를 같은 row 로 wrap
+ *    → TapToPlayButton 의 iOS HIG 44×44 hit-area 확보 (§6.4 reviewer 3차 #2).
+ *
+ * 데스크탑 `widgets/partyroom-display-board/*` 는 0 수정 (§3 row 9).
+ *
+ * Header (뒤로·룸이름·⋮) 는 본 컴포넌트 직접 — page.tsx 는 모바일 룸에서 글로벌 `<Header />` 미렌더.
+ */
+const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
+  const router = useRouter();
+  const { useCurrentPartyroom } = useStores();
+  const playbackActivated = useCurrentPartyroom((state) => state.playbackActivated);
+  const playback = useCurrentPartyroom((state) => state.playback);
+  const currentDj = useCurrentPartyroom((state) => state.currentDj);
+  const crews = useCurrentPartyroom((state) => state.crews);
+  // 두번째 arg = chunk 2 의 기존 시그니처 그대로 유지 (suspense/enabled flag, 데스크탑 룸과 동일 패턴).
+  const { data: detailSummary } = useFetchPartyroomDetailSummary(partyroomId, true);
+  const partyroomTitle = detailSummary?.title ?? '';
+
+  const currentDjNickname = currentDj
+    ? (crews.find((c) => c.crewId === currentDj.crewId)?.nickname ?? null)
+    : null;
+
+  const [expanded, setExpanded] = useState(true);
+  const playerRef = useRef<TReactPlayer | null>(null);
+
+  const videoId = playbackActivated ? (playback?.linkId ?? null) : null;
+  const isPlaying = videoId !== null;
+  const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
+
+  const gate = useAutoplayGestureGate({ playerRef, playable: isPlaying, videoId });
+
+  // TapToPlayButton 합성 prop: AutoplayGestureGate 의 visible 조건과 동일 (single source).
+  const tapToPlayVisible = gate.autoplayBlocked && !gate.played;
+
+  return (
+    <div className={cn('sticky top-0 z-20 w-full bg-black border-b border-gray-800')}>
+      {/* 헤더 row: 뒤로 · 룸 이름 · ⋮ */}
+      <header className='flex items-center justify-between px-4 h-12'>
+        <button
+          aria-label='뒤로'
+          className='w-11 h-11 flex items-center justify-center text-gray-300'
+          onClick={() => router.push('/parties')}
+        >
+          ←
+        </button>
+        <h1 className='flex-1 text-center text-base font-semibold text-white truncate px-2'>
+          {partyroomTitle}
+        </h1>
+        <button
+          aria-label='메뉴'
+          className='w-11 h-11 flex items-center justify-center text-gray-300'
+        >
+          ⋮
+        </button>
+      </header>
+
+      {/* VideoFrame: 3-mode (A/B/C) — chunk 3 컴포넌트 */}
+      <div className='px-4 pt-3'>
+        <VideoFrame
+          videoId={videoId}
+          expanded={expanded}
+          onToggleExpand={() => setExpanded((v) => !v)}
+          playerRef={playerRef}
+          gate={gate}
+        />
+      </div>
+
+      {/* NowPlayingRow: 트랙메타 + TapToPlayButton (Mode B 만) — min-h 44 hit-area */}
+      {mode !== 'C' && playback && (
+        <div
+          data-testid='now-playing-row'
+          className='flex items-center min-h-[44px] px-4 pt-3 gap-3'
+        >
+          <div className={mode === 'A' ? 'w-full' : 'flex-1 min-w-0'}>
+            <NowPlayingMeta
+              layout={mode === 'A' ? 'column' : 'row'}
+              trackName={playback.name}
+              djNickname={currentDjNickname}
+              duration={playback.duration}
+            />
+          </div>
+          {mode === 'B' && (
+            <TapToPlayButton autoplayBlocked={tapToPlayVisible} onTap={gate.handleGesturePlay} />
+          )}
+        </div>
+      )}
+
+      {/* 리액션 (chunk 2 그대로) */}
+      <div className='flex gap-2 px-4 py-3'>
+        <ActionButtons />
+      </div>
+    </div>
+  );
+};
+
+export default MobilePartyroomDisplayBoard;
+```
+
+- [ ] **Step 2: TypeScript build sanity**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -15`
+Expected: 0 errors.
+
+- [ ] **Step 3: lint 빠른 검증**
+
+Run: `yarn lint --fix src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx 2>&1 | tail -15`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit (의도적으로 통합 테스트 RED 단계 — 본 task 만 push 하지 않음, 다음 task 와 함께)**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
+git commit -m "feat(widgets-mobile/partyroom-display-board): chunk 3.1 root rewrite — 1px IFrame 폐기 → VideoFrame + NowPlayingRow + useAutoplayGestureGate (spec §4.4)
+
+BREAKING: chunk 2 의 \`1px×1px+opacity-0\` IFrame 본문 제거. YouTube IFrame Player API ToS 위반 fix (spec §2.2). 통합 테스트는 후속 task 에서 추가."
+```
+
+### Task 4.2: 통합 테스트 scaffold — mocks + Harness
+
+**Files:**
+
+- Create: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 테스트 파일 scaffold (mock 외부 의존성)**
+
+```tsx
+// src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// react-player mock — VideoFrame test 와 동일 패턴
+const youtubePlayerCalls: Array<Record<string, unknown>> = [];
+vi.mock('react-player/youtube', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    youtubePlayerCalls.push(props);
+    return <div data-testid='youtube-player-mock' data-url={String(props.url ?? '')} />;
+  },
+}));
+vi.mock('next/dynamic', async () => {
+  const mod = await import('react-player/youtube');
+  return { __esModule: true, default: () => mod.default };
+});
+
+// next/navigation router mock
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// useFetchPartyroomDetailSummary mock
+vi.mock('@/features/partyroom/get-summary', () => ({
+  useFetchPartyroomDetailSummary: () => ({
+    data: { title: 'Test Room' },
+  }),
+}));
+
+// userPreference mock — volume 1 / muted false
+vi.mock('@/entities/preference', () => ({
+  useUserPreferenceStore: vi.fn((selector: (s: { volume: number; muted: boolean }) => unknown) =>
+    selector({ volume: 1, muted: false })
+  ),
+}));
+
+// ActionButtons mock — 리액션 외부 의존성 격리
+vi.mock('./ui/parts/action-buttons.component', () => ({
+  __esModule: true,
+  default: () => <div data-testid='action-buttons-mock' />,
+}));
+
+// useCurrentPartyroom mock — 테스트별 setMockStoreState 으로 갱신
+type StoreState = {
+  playbackActivated: boolean;
+  playback: { name: string; duration: string; linkId: string } | null;
+  currentDj: { crewId: number } | null;
+  crews: Array<{ crewId: number; nickname: string }>;
+};
+
+let storeState: StoreState = {
+  playbackActivated: true,
+  playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+  currentDj: { crewId: 1 },
+  crews: [{ crewId: 1, nickname: 'DJ A' }],
+};
+
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useCurrentPartyroom: (selector: (s: StoreState) => unknown) => selector(storeState),
+  }),
+}));
+
+function setStoreState(patch: Partial<StoreState>) {
+  storeState = { ...storeState, ...patch };
+}
+
+function resetStoreState() {
+  storeState = {
+    playbackActivated: true,
+    playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+    currentDj: { crewId: 1 },
+    crews: [{ crewId: 1, nickname: 'DJ A' }],
+  };
+}
+
+import MobilePartyroomDisplayBoard from './partyroom-display-board.component';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  youtubePlayerCalls.length = 0;
+  mockPush.mockClear();
+  resetStoreState();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+```
+
+- [ ] **Step 2: scaffold sanity (vitest 가 모듈 로드 자체는 통과)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 0 tests (describe 없음) 또는 0 test PASS — 모듈 로딩 자체 실패 없어야.
+
+- [ ] **Step 3: Commit scaffold**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): 통합 테스트 scaffold — store/router/dynamic/react-player mock"
+```
+
+### Task 4.3: 통합 #1~#3 — mount default + 토글 클릭 양방향 (Mode A↔B)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 첫 describe + 3 케이스 (mount, A→B, B→A)**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · 토글 라이프사이클', () => {
+  test('#1 룸 mount 시 expanded=true default → Mode A 진입 (16:9 wrapper + Toggle ▾)', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).toContain('w-full');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+
+  test('#2 토글 클릭 → Mode B (80×45 wrapper + Toggle ◂)', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('w-[80px]');
+    expect(wrapper.className).toContain('h-[45px]');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('#3 두 번째 토글 → Mode A 복귀', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    fireEvent.click(screen.getByRole('button', { name: '영상 펼치기' }));
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).toContain('w-full');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 3 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #1~#3 — mount default Mode A + 토글 양방향 (spec §7.2 #1~#3)"
+```
+
+### Task 4.4: 통합 #4 — playback null → Mode C (토글 hide)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 케이스 추가**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · Mode C 진입', () => {
+  test('#4 playback null → Mode C: BlankPlaceholder + 토글 미렌더 + NowPlayingRow 미렌더', () => {
+    setStoreState({ playbackActivated: false, playback: null });
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /영상/ })).toBeNull();
+    expect(screen.queryByTestId('now-playing-row')).toBeNull();
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 4 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #4 — playback null → Mode C / Toggle hide / NowPlayingRow hide (spec §7.2 #4)"
+```
+
+### Task 4.5: 통합 #5~#7 — expanded 보존 invariants (트랙 변경 / Mode C 진입·복귀)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 케이스 추가 (3 케이스)**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · expanded 보존 invariants', () => {
+  test('#5 토글 B → playback 트랙 변경 → expanded=false 그대로 (자동 expand 없음)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' })); // Mode B
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+
+    // 새 트랙
+    setStoreState({ playback: { name: 'Track 2', duration: '4:00', linkId: 'def' } });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+    expect(screen.getByTestId('video-wrapper').className).toContain('h-[45px]');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('#6 Mode B → playback null (Mode C) → playback 재할당 → 여전히 Mode B (마지막 사용자 선택 보존)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' })); // Mode B
+
+    setStoreState({ playbackActivated: false, playback: null });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 3', duration: '2:00', linkId: 'ghi' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+  });
+
+  test('#7 Mode A → Mode C → 재할당 → Mode A 복귀 (역대칭 가드)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    // Mode A 유지 (토글 안 누름)
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+
+    setStoreState({ playbackActivated: false, playback: null });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 4', duration: '1:30', linkId: 'jkl' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-full');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 7 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #5~#7 — expanded 보존 (트랙 변경 / Mode C 진입·복귀 사용자 선택 보존, spec §4.4 불변식)"
+```
+
+### Task 4.6: 통합 #8 — unmount/remount expanded reset
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 케이스 추가**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · component lifecycle', () => {
+  test('#8 룸 unmount → 다시 mount → expanded=true 로 reset (component-local state)', () => {
+    const { unmount } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' })); // Mode B
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+
+    unmount();
+
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    // mount default = expanded=true → Mode A
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 8 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #8 — unmount/remount expanded reset (component-local state, spec §7.2 #8)"
+```
+
+### Task 4.7: 통합 #9~#10 — autoplay 차단 회귀 (트랙 변경 + Mode C → 재진입)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 케이스 추가 (2 케이스 — fake timer 가 hook timer 잡음)**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
+  test('#9 트랙 변경 시 autoplay 차단 재armed: 새 videoId + 1500ms 후 차단 → release control 렌더', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    // Mode A 초기 — IFrame mount 됐다고 가정. onReady → onPlay 로 played=true 유지.
+    const firstYt = youtubePlayerCalls[0];
+    (firstYt.onReady as (p: unknown) => void)({} as unknown);
+    (firstYt.onPlay as () => void)();
+
+    // 새 트랙으로 videoId 변경 — hook 의 videoId effect 가 played reset (autoplayBlocked 도 reset)
+    // 단 playerReady 는 그대로 true 유지 (Chunk 1 Task 1.7 결정). timer effect 가 즉시 재armed.
+    setStoreState({ playback: { name: 'Track 2', duration: '4:00', linkId: 'def' } });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    // 새 트랙의 YoutubePlayer 호출에 대한 onReady 도 호출 — 본문은 production mount 시퀀스의
+    // 거울 (이미 playerReady=true 라 setPlayerReady(true) 는 no-op). 본 라인 제거 시 #9 PASS 여전.
+    // production 행동을 정확히 mirror 하기 위해 남김 (timer arming 의 trigger 는 videoId effect 임).
+    const newYt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    (newYt.onReady as (p: unknown) => void)({} as unknown);
+
+    // 1500ms 경과 → autoplayBlocked=true → Mode A 에서 AutoplayGestureGate 렌더
+    vi.advanceTimersByTime(1500);
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
+  });
+
+  test('#10 Mode C → 재할당 → onReady 후 1500ms 내 onPlay 없으면 차단 + release control 렌더 (cross-mode mount)', () => {
+    setStoreState({ playbackActivated: false, playback: null });
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    // 재할당
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 5', duration: '3:00', linkId: 'mno' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    (yt.onReady as (p: unknown) => void)({} as unknown);
+    vi.advanceTimersByTime(1500);
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    // expanded=true default 이므로 Mode A → AutoplayGestureGate overlay
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → GREEN**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -20`
+Expected: 10 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #9~#10 — autoplay 차단 재armed (트랙 변경 + Mode C cross-mode mount, spec §7.2 #9/#10)"
+```
+
+### Task 4.8: 통합 #11~#12 — cross-component single source (TapToPlayButton 위치 + Mode B→A toggle GestureGate)
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 케이스 추가 (2 케이스 — VideoFrame test 에서 이전됨)**
+
+```tsx
+describe('MobilePartyroomDisplayBoard · cross-component single source (VideoFrame test 에서 이전)', () => {
+  test('#11 Mode B + autoplay 차단: NowPlayingRow 안에 TapToPlayButton 렌더, VideoFrame overlay 미렌더', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    // Mode B 전환
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+
+    // autoplay 차단 시뮬: onReady 호출 후 1500ms 경과 → setAutoplayBlocked(true).
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    (yt.onReady as (p: unknown) => void)({} as unknown);
+    vi.advanceTimersByTime(1500);
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const row = screen.getByTestId('now-playing-row');
+    const tapButton = screen.getByRole('button', { name: '재생' });
+    expect(row.contains(tapButton)).toBe(true);
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
+  });
+
+  test('#12 Mode B + autoplay 차단 → Mode A 토글 → AutoplayGestureGate overlay 즉시 visible (single source 검증)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' })); // Mode B 진입
+
+    // autoplay 차단 시뮬
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    (yt.onReady as (p: unknown) => void)({} as unknown);
+    vi.advanceTimersByTime(1500);
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    // Mode B + 차단 상태 → TapToPlayButton visible
+    expect(screen.getByRole('button', { name: '재생' })).toBeTruthy();
+
+    // Mode A 로 토글 → gate state 그대로, 단지 mode 만 전환 → overlay 즉시 visible
+    fireEvent.click(screen.getByRole('button', { name: '영상 펼치기' }));
+
+    expect(screen.getByTestId('autoplay-gesture-gate')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: '재생' })).toBeNull();
+  });
+});
+```
+
+> **Test fragility note (last-resort fix)**: 본 plan 은 명시적 `rerender` 호출로 React state commit 을 강제. 그래도 fake timer 와 Zustand batch 의 순서 race 가 발생할 가능성이 있다 (React 18 의 automatic batching 가 microtask 경계에 의존). #11 또는 #12 가 fail 하면:
+>
+> 1차 fallback: `import { act } from 'react';` 후 timer 라인을 `act(() => vi.advanceTimersByTime(1500));` 로 래핑.
+> 2차 fallback: 본 case 직전에 `await Promise.resolve();` 로 microtask 비움 + 함수 시그니처 `async ({...}) => {...}` 로 변경.
+> 어느 fallback 도 케이스의 의도 (cross-component single source 검증) 를 해치지 않음.
+
+- [ ] **Step 2: 테스트 실행 → GREEN (timing 실패 시 `act` 래핑 patch)**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx 2>&1 | tail -30`
+Expected: 12 tests passed.
+
+- [ ] **Step 3: timing 실패 시 patch — `act` import + timer 라인 래핑**
+
+만약 #11 또는 #12 가 fail (autoplay-gesture-gate / 재생 버튼 not found) 한다면, 테스트 본문의 `vi.advanceTimersByTime(1500)` 호출을 다음으로 교체:
+
+```ts
+import { act } from 'react';
+// ... 본문 안에서
+act(() => {
+  vi.advanceTimersByTime(1500);
+});
+```
+
+다시 실행 후 GREEN 확인.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "test(widgets-mobile/partyroom-display-board): integration #11~#12 — cross-component single source (TapToPlayButton 위치 + Mode B→A toggle GestureGate, spec §6.5.2)"
+```
+
+### Task 4.9: Chunk 4 회귀 + lint + tsc
+
+- [ ] **Step 1: 위젯 전체 vitest**
+
+Run: `yarn vitest run src/widgets-mobile/partyroom-display-board/ 2>&1 | tail -30`
+Expected: 7 test files (hook 1 + parts 4 + video-frame 1 + integration 1) · 58 tests passed (46 + 12 integration).
+
+- [ ] **Step 2: 전체 unit test smoke (다른 위젯 회귀 0)**
+
+Run: `yarn test 2>&1 | tail -20`
+Expected: 모든 기존 테스트 PASS — chunk 3.1 변경 외 회귀 0.
+
+- [ ] **Step 3: lint**
+
+Run: `yarn lint --fix 2>&1 | tail -20`
+Expected: 0 errors.
+
+- [ ] **Step 4: tsc**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 5: clean working tree**
+
+Run: `git status --short`
+Expected: empty.
+
+> **Chunk 4 완료.** Chunk 5 (Playwright headed + CI workflow + PR open) 으로 진행.
+
+---
+
+## Chunk 5: Playwright Headed E2E + CI Workflow + PR Open
+
+> 본 chunk 는 unit/integration 레이어가 잡지 못하는 **ancestor visibility / sticky-top 높이 변화 / chat scroll 영향** 등의 ToS 가드 1차 게이트를 Playwright headed 로 추가하고, **mandatory CI job + branch protection required check** 등록 절차를 명시한다. 본 chunk 의 머지 후 chunk 3 + 3.1 단일 release 묶음으로 prod ship.
+>
+> **본 chunk 의 핵심 회귀 가드**:
+>
+> - IFrame visible (`toBeVisible()` 의 ancestor visibility 체크) + boundingBox ≥ 80×45 + viewport 안.
+> - Toggle 두 번 클릭 후 같은 IFrame element (`evaluateHandle` reference equality) — remount 회피.
+> - chat scroll offset 변화 ≤ `CHAT_SCROLL_TOLERANCE_PX=10` (sub-pixel rounding + 1 line-height jitter).
+> - mandatory job + branch protection required check **사용자 단발 GitHub UI 작업 필수** (spec §3 row 15).
+
+### Task 5.1: Playwright config — 모바일 project + auth fixture 분기 추가
+
+**Files:**
+
+- Modify: `playwright.config.ts`
+- Modify: `e2e/fixtures/auth.fixtures.ts`
+
+- [ ] **Step 1: `playwright.config.ts` 의 `projects` 배열 끝에 신규 entry 추가**
+
+```ts
+{
+  name: 'display-board-tos-mobile',
+  testMatch: /mobile\/display-board\.tos\.spec\.ts/,
+  use: { ...devices['iPhone 13'] },
+  dependencies: ['auth-a'],
+},
+```
+
+> dependency 로 `auth-a` 재사용 — 신규 setup 불필요. iPhone 13 (390×844) 으로 모바일 분기 진입. Pixel 7 / iPhone SE 매트릭스는 후속 polish.
+
+- [ ] **Step 2: `e2e/fixtures/auth.fixtures.ts` 의 `getAuthPrefix` 가 신규 spec 파일명을 인식하도록 분기 추가**
+
+기존 `getAuthPrefix` 의 `if (testFile.includes('e2e-d.')) return 'd';` 다음에 추가:
+
+```ts
+// chunk 3.1 — 모바일 디스플레이 보드 ToS 가드. user A storage state 재사용.
+if (testFile.includes('mobile/display-board')) {
+  return 'a';
+}
+```
+
+> 미수정 시 user1Context fixture resolve 단계에서 `throw new Error('No auth prefix configured for test file: …')` → spec 전체 RED.
+
+- [ ] **Step 3: tsc sanity**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add playwright.config.ts e2e/fixtures/auth.fixtures.ts
+git commit -m "chore(playwright): display-board-tos-mobile project — iPhone 13 + auth-a 재사용 + getAuthPrefix mobile 분기 (chunk 3.1 mandatory CI)"
+```
+
+### Task 5.2: e2e helper — 모바일 룸 진입 + 재생 활성 대기
+
+**Files:**
+
+- Create: `e2e/mobile/display-board.helpers.ts`
+
+- [ ] **Step 1: helper 작성 — 모바일 룸 진입 시 video-wrapper 가 visible 되기까지 대기**
+
+```ts
+// e2e/mobile/display-board.helpers.ts
+import { expect, type Page } from '@playwright/test';
+
+export const CHAT_SCROLL_TOLERANCE_PX = 10;
+
+/** chunk 3.1 spec §4.5 Mode B 의 collapsed video 박스 픽셀 (sync 가드는 unit test). */
+export const COLLAPSED_VIDEO_WIDTH = 80;
+export const COLLAPSED_VIDEO_HEIGHT = 45;
+
+/** 케이스마다 고유한 partyroom / playlist 이름 — desktop e2e-a 와 동시 사용 race 회피. */
+export const mobilePartyroomName = () => `MOBILE-TOS-${Date.now()}`;
+export const mobilePlaylistName = () => `mobile-tos-pl-${Date.now()}`;
+
+/**
+ * 모바일 룸 페이지로 진입 + video-wrapper 가 mount 되기까지 대기.
+ * 사용자가 이미 partyroomUrl 에 도달했다고 가정 (caller 가 partyroom 생성·입장 책임).
+ */
+export async function gotoMobileRoomAndWaitForVideo(page: Page, partyroomUrl: string) {
+  await page.goto(partyroomUrl);
+  await expect(page.getByTestId('video-wrapper')).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Playwright `toBeVisible()` 가 ancestor display/visibility/opacity 모두 체크.
+ * + boundingBox 단언으로 0×0 / off-screen 회귀까지 가드.
+ */
+export async function expectIframeToBeOnScreen(page: Page) {
+  const iframe = page.locator('iframe[src*="youtube.com/embed"]');
+  await expect(iframe).toBeVisible();
+  const box = await iframe.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+  expect(box.width).toBeGreaterThanOrEqual(COLLAPSED_VIDEO_WIDTH);
+  expect(box.height).toBeGreaterThanOrEqual(COLLAPSED_VIDEO_HEIGHT);
+  // viewport 내부 확인 (off-screen 좌표 아님)
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  if (!viewport) return;
+  expect(box.x).toBeGreaterThan(-box.width);
+  expect(box.y).toBeGreaterThan(-box.height);
+  expect(box.x).toBeLessThan(viewport.width);
+  expect(box.y).toBeLessThan(viewport.height);
+}
+
+/** Computed style 단언 — opacity > 0 && visibility !== 'hidden'. ancestor 가 가려도 잡힘. */
+export async function expectIframeNotVisuallyHidden(page: Page) {
+  const result = await page.locator('iframe[src*="youtube.com/embed"]').evaluate((el) => {
+    const style = window.getComputedStyle(el);
+    return { opacity: parseFloat(style.opacity), visibility: style.visibility };
+  });
+  expect(result.visibility).not.toBe('hidden');
+  expect(result.opacity).toBeGreaterThan(0);
+}
+```
+
+- [ ] **Step 2: tsc sanity**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/mobile/display-board.helpers.ts
+git commit -m "test(e2e/mobile): display-board helper — IFrame visible + boundingBox + computed style 단언 + 상수 (CHAT_SCROLL_TOLERANCE_PX, COLLAPSED_VIDEO_*)"
+```
+
+### Task 5.3: `display-board.tos.spec.ts` 본문 — Mode A/B/C IFrame 가드
+
+**Files:**
+
+- Create: `e2e/mobile/display-board.tos.spec.ts`
+
+- [ ] **Step 1: spec 본문 작성 — Mode A 진입 IFrame visible / boundingBox / computed style**
+
+```ts
+// e2e/mobile/display-board.tos.spec.ts
+import { expect } from '@playwright/test';
+import { test } from '../fixtures/auth.fixtures';
+import {
+  closePartyroom,
+  createPartyroom,
+  createPlaylistWithTracks,
+  enterPartyroomAndWaitUntilReady,
+  registerAsDj,
+} from '../helpers/partyroom.helpers';
+import {
+  CHAT_SCROLL_TOLERANCE_PX,
+  COLLAPSED_VIDEO_HEIGHT,
+  COLLAPSED_VIDEO_WIDTH,
+  expectIframeNotVisuallyHidden,
+  expectIframeToBeOnScreen,
+  gotoMobileRoomAndWaitForVideo,
+  mobilePartyroomName,
+  mobilePlaylistName,
+} from './display-board.helpers';
+
+/**
+ * chunk 3.1 spec §5 — ToS 보존 가드 (Playwright headed, mandatory CI).
+ *
+ * unit/integration 레이어가 잡지 못하는:
+ * - ancestor visibility (parent display:none, transform scale(0), off-viewport)
+ * - sticky-top 높이 변화의 chat scroll 영향
+ * - IFrame 의 실제 computed style (opacity / visibility)
+ *
+ * iPhone 13 (390×844) 단일 매트릭스 — 추가 viewport (SE / Pixel) 는 후속 polish.
+ *
+ * **세션 cleanup**: 각 케이스는 createPartyroom 으로 신규 룸을 만들고 끝에 closePartyroom.
+ * desktop e2e-a 와 동일 user storage state 재사용이지만 workers:1 직렬 + unique 이름으로 race 0.
+ */
+
+test('Mode A 진입: IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  await expectIframeToBeOnScreen(page);
+  await expectIframeNotVisuallyHidden(page);
+
+  await closePartyroom(page);
+});
+
+test('Mode A → Mode B 토글: wrapper 80×45 정확값 + IFrame 여전히 visible + DOM identity 보존', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  const iframeBefore = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  expect(iframeBefore).not.toBeNull();
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  // toggle 후 ◂ 버튼 등장까지 명시적 대기 — Mode B 진입 race 회피
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+
+  const wrapper = page.getByTestId('video-wrapper');
+  const wrapperBox = await wrapper.boundingBox();
+  expect(wrapperBox).not.toBeNull();
+  if (!wrapperBox) return;
+  expect(Math.round(wrapperBox.width)).toBe(COLLAPSED_VIDEO_WIDTH);
+  expect(Math.round(wrapperBox.height)).toBe(COLLAPSED_VIDEO_HEIGHT);
+
+  await expectIframeNotVisuallyHidden(page);
+
+  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  expect(iframeAfter).not.toBeNull();
+  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeBefore, iframeAfter]);
+  expect(sameElement).toBe(true);
+
+  await closePartyroom(page);
+});
+
+test('Mode B → Mode A 복귀: IFrame 동일 element + 16:9 wrapper 복귀', async ({ user1Context }) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  const iframeInitial = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  // Mode B 의 ◂ 버튼 visible 보장 후 두 번째 click
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+  await page.getByRole('button', { name: '영상 펼치기' }).click();
+  // Mode A 의 ▾ 복귀 보장
+  await expect(page.getByRole('button', { name: '영상 가리기' })).toBeVisible();
+
+  const wrapper = page.getByTestId('video-wrapper');
+  await expect(wrapper).toHaveClass(/aspect-video/);
+
+  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeInitial, iframeAfter]);
+  expect(sameElement).toBe(true);
+
+  await closePartyroom(page);
+});
+
+test('Mode C (재생 없음): BlankPlaceholder visible + IFrame 미존재', async ({ user1Context }) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  // 재생 활성화 없음 — DJ 등록 X / playlist X.
+
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  await expect(page.getByTestId('blank-placeholder')).toBeVisible();
+  await expect(page.locator('iframe[src*="youtube.com/embed"]')).toHaveCount(0);
+
+  await closePartyroom(page);
+});
+
+test('sticky-top 높이 변화 시 chat scroll offset ≤ CHAT_SCROLL_TOLERANCE_PX 보존', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  // chunk 3 의 partyroom-room-tabs 가 default chat 탭. 명시적 click 으로 안정화.
+  const chatTab = page.getByRole('tab', { name: /채팅/ }).first();
+  if (await chatTab.isVisible().catch(() => false)) {
+    await chatTab.click();
+  }
+
+  // chunk 3 의 partyroom-room-tabs 컨테이너 selector — `data-tab-content='chat'` 유지 (chunk 3 그대로).
+  const chatContainer = page.locator('[data-tab-content="chat"]').first();
+  await expect(chatContainer).toBeVisible();
+
+  await page.waitForTimeout(500);
+
+  const scrollBefore = await chatContainer.evaluate((el) => el.scrollTop);
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+  await page.waitForTimeout(300); // CSS transition 안정화 — `CHAT_SCROLL_TOLERANCE_PX` 가 sub-pixel jitter 흡수
+
+  const scrollAfter = await chatContainer.evaluate((el) => el.scrollTop);
+
+  const delta = Math.abs(scrollAfter - scrollBefore);
+  expect(delta).toBeLessThanOrEqual(CHAT_SCROLL_TOLERANCE_PX);
+
+  await closePartyroom(page);
+});
+```
+
+- [ ] **Step 2: 로컬 brief smoke — playwright config 가 spec 을 인식하는지**
+
+Run: `yarn playwright test --list 2>&1 | grep -i "display-board" | head -10`
+Expected: 5 tests listed (Mode A / A→B / B→A / Mode C / chat scroll).
+
+> **로컬 풀 실행은 백엔드 stack 필요** ([[reference_local_docker_compose]]). 본 task 는 list 만 검증 — 실제 e2e 실행은 CI 에서 (또는 후속 dev/stg 검증 단계). 시간 여유 시 로컬 docker compose + `yarn test:e2e:headed --project=display-board-tos-mobile` 으로 sanity.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/mobile/display-board.tos.spec.ts
+git commit -m "test(e2e/mobile): display-board.tos — 5 케이스 (Mode A IFrame visible / A↔B 토글 DOM identity / Mode C BlankPlaceholder / chat scroll offset 보존, spec §5/§7.3)"
+```
+
+### Task 5.4: CI workflow — display-board-tos-mobile project 명시 (mandatory job)
+
+**Files:**
+
+- Modify: `.github/workflows/vercel-preview-e2e.yml`
+- Modify: `e2e/README.md`
+
+- [ ] **Step 1: workflow 의 e2e job 에서 신규 project 실행 명시**
+
+현재 `yarn test:e2e` 는 모든 project 를 자동 실행 — 신규 `display-board-tos-mobile` project 도 자동 포함. workflow 변경은 **명시적 표시 + 사용자 단발 GitHub UI 작업 안내** 만:
+
+`.github/workflows/vercel-preview-e2e.yml` 의 `yarn test:e2e` 단계 직전에 주석 보강:
+
+```yaml
+# chunk 3.1: display-board-tos-mobile project (iPhone 13) 가 mandatory.
+# branch protection 의 required status checks 에 "Playwright E2E" job 등록 필수
+# (사용자 GitHub UI 작업, PR 본문 체크리스트). job 자체는 yarn test:e2e 안에 포함됨.
+- run: yarn test:e2e
+  env:
+    VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+```
+
+- [ ] **Step 2: `e2e/README.md` 갱신 — mobile 디렉토리 + branch protection 절차**
+
+`e2e/README.md` 끝에 추가:
+
+```markdown
+## chunk 3.1 — `e2e/mobile/` project
+
+모바일 viewport (iPhone 13) 전용 spec 들. `display-board-tos-mobile` project 가 `playwright.config.ts` 에 등록되어 `yarn test:e2e` 의 mandatory job 으로 실행.
+
+### `display-board.tos.spec.ts`
+
+YouTube IFrame Player API ToS 가드 (chunk 3.1 핵심):
+
+- Mode A IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님
+- Mode A↔B 토글 시 wrapper 80×45 정확값 + IFrame DOM identity 보존 (remount 회피)
+- Mode B→A 복귀 시 동일 IFrame element
+- Mode C 시 BlankPlaceholder visible + IFrame 미존재
+- sticky-top 높이 변화 시 chat scroll offset ≤ 10px 보존
+
+### Branch protection 등록 (사용자 단발 GitHub UI 작업)
+
+PR `feature/mobile-responsive-spec-3.1` 머지 **전** 다음 작업 필수 (chunk 3.1 spec §3 row 15, §10 step 6):
+
+1. GitHub repo Settings → Branches → `develop` 의 Branch protection rule 편집
+2. "Require status checks to pass before merging" 에 **`Playwright E2E`** job 추가 (이미 등록되어 있다면 OK)
+3. 동일 작업을 `release` 브랜치에도 적용
+
+본 단계 누락 시 mandatory 가 paper-only 가 됨. PR 본문 체크리스트에 명시.
+```
+
+- [ ] **Step 3: lint sanity**
+
+Run: `yarn lint --fix e2e/ 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/vercel-preview-e2e.yml e2e/README.md
+git commit -m "ci(playwright): display-board-tos mandatory job 명시 + e2e/README branch protection 절차 (chunk 3.1 spec §3 row 15)"
+```
+
+### Task 5.5: 풀 회귀 + tsc + lint + 누락 확인
+
+- [ ] **Step 1: 전체 unit + integration test**
+
+Run: `yarn test 2>&1 | tail -20`
+Expected: 모든 test PASS. chunk 3.1 신규 케이스 (hook 8 + parts 17 + video-frame 21 + integration 12 = 58) 포함.
+
+- [ ] **Step 2: tsc**
+
+Run: `yarn tsc --noEmit -p tsconfig.json 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 3: lint (전체)**
+
+Run: `yarn lint 2>&1 | tail -10`
+Expected: 0 errors.
+
+- [ ] **Step 4: Playwright spec list smoke**
+
+Run: `yarn playwright test --list 2>&1 | tail -30`
+Expected: 신규 5 spec 포함, 다른 project 정상.
+
+- [ ] **Step 5: clean working tree**
+
+Run: `git status --short`
+Expected: empty.
+
+### Task 5.6: 최종 commit 통합 + remote push
+
+> [[feedback_commit_consolidation_before_push]] 적용 — chunk 3.1 의 마이크로 commit 들을 logical 그룹으로 squash 또는 그대로 유지 (chunk 3.1 의 PR series 패턴 [[feedback_pr_series_workflow]] 가 atomic group 보존 선호).
+>
+> **결정**: chunk 별로 atomic group 보존 (chunk 1 / chunk 2 / chunk 3 / chunk 4 / chunk 5). 마이크로 commit 들은 chunk 단위로 의미 있는 단위라 squash 안 함. PR 본문 §12 에 각 chunk 매핑.
+
+- [ ] **Step 1: 커밋 카운트 + 로그 빠른 검증**
+
+Run: `git log origin/development..HEAD --oneline`
+Expected: chunk 1~5 의 atomic commit 들 (대략 30~40개). spec 5개 + hook 9 + parts 8 (4×2 commit pair) + video-frame 9 + root + integration 6 + e2e + ci ≈ 35~40.
+
+- [ ] **Step 2: push**
+
+```bash
+git push -u origin feature/mobile-responsive-spec-3.1
+```
+
+Expected: remote 브랜치 생성 + push 성공.
+
+### Task 5.7: PR open (한글)
+
+- [ ] **Step 1: PR 본문 작성 — 한글 ([[feedback_korean_issue_commit_pr]])**
+
+```bash
+gh pr create --base development --head feature/mobile-responsive-spec-3.1 --title "fix(widgets-mobile/partyroom-display-board): chunk 3.1 — YouTube IFrame ToS 보존 재설계 (3-mode + autoplay gesture gate)" --body "$(cat <<'EOF'
+## 배경
+
+chunk 2 의 모바일 디스플레이가 `1px×1px + opacity-0 + pointer-events-none` 로 YouTube IFrame 을 숨김 → **YouTube IFrame Player API 서비스 약관 위반**. prod ship 전 fix 필수 (chunk 3.1 spec §2.2).
+
+## 변경 요약 (5 chunk)
+
+- **Chunk 1**: \`useAutoplayGestureGate\` hook — autoplay 차단 감지 + gesture release single source. \`AUTOPLAY_DETECT_MS\` 상수 export. 데스크탑 \`video.component.tsx\` 의 inline 패턴 추출 (C3 격리, 데스크탑 0 수정).
+- **Chunk 2**: 정적 parts 4개 — BlankPlaceholder, ExpandToggle, NowPlayingMeta, TapToPlayButton. 책임 분리 잠금 (wrapper class / positioning / 시각 styling 은 parent 책임).
+- **Chunk 3**: \`VideoFrame\` orchestrator — 3 mode (A 풀폭 / B 80×45 / C 검정 placeholder) + wrapper-based sizing (YoutubePlayer width/height='100%' 고정, key 가 videoId/mode 미포함 → IFrame remount 회피).
+- **Chunk 4**: root \`MobilePartyroomDisplayBoard\` 재설계 — 1px IFrame 본문 폐기 → VideoFrame + NowPlayingRow (NowPlayingMeta + TapToPlayButton). expanded state 토글 클릭 1곳에서만 변경.
+- **Chunk 5**: Playwright headed mandatory CI — \`display-board.tos.spec.ts\` (Mode A/B/C + 토글 DOM identity + chat scroll 보존). branch protection required check 등록 (사용자 단발 GitHub UI 작업).
+
+## ToS 보존 (spec §5)
+
+3-layer 다중 방어:
+
+- **unit**: YoutubePlayer width/height='100%' 단언, wrapper class `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 부재 단언, `data-testid='video-wrapper'` 에 `aria-hidden='true'` 직접 부착 안 됨.
+- **integration**: Mode 분기 + expanded 보존 invariants + cross-component single source.
+- **Playwright headed (mandatory CI)**: ancestor visibility / computed style / boundingBox / viewport 안 / DOM identity / chat scroll 보존.
+
+## 결정 잠금 (spec §3)
+
+16 결정 잠금 — 본 PR 본문은 핵심만:
+
+- Mode A/B/C + 우상단 ▾/◂ 토글, collapsed 80×45 (iOS HIG 44×44 hit-area 근접)
+- 비재생 시 토글 hide (Mode C), expanded session-local (트랙 변경·Mode C 진입·복귀 모두 보존)
+- YoutubePlayer width/height='100%' 고정 + wrapper Tailwind class 만 교체 (remount 0)
+- 정적 Tailwind class only (`w-[80px]` 같은 arbitrary 정적 값. `w-[\${var}px]` runtime template 금지)
+- inline 한국어 (chunk 5 i18n catch-up 시 일괄 이주)
+- 데스크탑 \`widgets/partyroom-display-board/*\` 0 수정 (C3 sibling 사본)
+
+## 테스트 (총 58 + e2e 5)
+
+- hook 8 + parts 17 + video-frame 21 + integration 12 = **58 unit/integration**
+- e2e (mandatory): 5 케이스 (Mode A / A↔B / B→A / Mode C / chat scroll)
+
+## 체크리스트
+
+- [x] \`yarn test\` GREEN (chunk 5 task 5.5 검증)
+- [x] \`yarn tsc --noEmit\` 0 errors
+- [x] \`yarn lint\` 0 errors
+- [x] \`yarn playwright test --list\` 5 spec 등록 확인
+- [ ] **사용자 GitHub UI 작업**: Settings → Branches → \`develop\` / \`release\` 의 required check 에 \"Playwright E2E\" 등록 (spec §3 row 15, §10 step 6). 본 단계 누락 시 mandatory 가 paper-only.
+- [ ] **사용자 release 게이트**: chunk 3 (이미 develop 머지됨) 와 본 chunk 3.1 은 **단일 release 묶음으로 prod ship 필수** (spec §10 step 9). chunk 3 단독 prod 진입 시 1px×1px IFrame ToS 위반 그대로 ship — escalate.
+
+## Spec / Plan
+
+- Spec: \`docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md\` (v4, 16 결정 잠금)
+- Plan: \`docs/superpowers/plans/2026-05-29-mobile-display-board-tos-redesign.md\` (5 chunk, plan-reviewer Approved)
+
+## Risk + 후속
+
+- \`useAutoplayGestureGate\` (mobile) vs 데스크탑 inline 패턴 코드 중복 — chunk 3.1 머지 직후 GH 이슈 신규 등록 ("데스크탑·모바일 autoplay gesture-gate hook 통합 refactor", spec §9 risk #5).
+- 추가 viewport (iPhone SE / Pixel 7) 매트릭스 — 본 PR 은 iPhone 13 단일 매트릭스. 후속 polish.
+
+## 관련
+
+- pfplay-web #340 (모바일 반응형 전체 스코프)
+- chunk 3 PR #357 (머지됨, develop)
+EOF
+)" 2>&1 | tail -30
+```
+
+Expected: PR URL 출력.
+
+- [ ] **Step 2: PR URL 캡쳐 + 사용자 보고**
+
+PR 번호 / URL 을 메모리 갱신용으로 캡쳐. 신규 메모리 슬롯 `project_mobile_chunk31_pr_open` 작성 (Chunk 5 완료 후 별도 task 외 — execution agent 가 메모리 작성 책임).
+
+> **Chunk 5 완료 — chunk 3.1 PR open.** 이후 단계:
+>
+> 1. CI green 확인 (Playwright `display-board-tos-mobile` 포함)
+> 2. **사용자 GitHub UI 작업** (branch protection required check)
+> 3. **사용자 머지 트리거** → develop 진입
+> 4. chunk 3 (이미 develop 머지됨) + chunk 3.1 단일 release 묶음으로 release/main 승격 (사용자 트리거, spec §10 step 9)
+> 5. post-merge: 메모리 갱신 ([[project_mobile_chunk3_merged_chunk31_spec_ready]] 후속 — chunk 3.1 머지 진입점) + GH 이슈 신규 등록 (autoplay hook 통합 refactor)
+
+---

--- a/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-29
 **Chunk:** chunk 3.1 (chunk 3 polish follow-up — chunk 3 머지 직후 atomic PR)
-**Status:** Draft → spec-document-reviewer → 사용자 승인 → writing-plans
+**Status:** Draft v2 → spec-document-reviewer (2차) → 사용자 승인 → writing-plans
 
 ## 1. Goal
 
@@ -54,18 +54,21 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 
 ## 3. 결정 잠금 (brainstorming 산출물)
 
-| #   | 항목              | 결정                                                                                         |
-| --- | ----------------- | -------------------------------------------------------------------------------------------- |
-| 1   | chunk 구분        | chunk 3 머지 직후 chunk 3.1 후속 PR (atomic, develop 진입)                                   |
-| 2   | 재생 중 default   | **Mode A** — 16:9 풀폭 YoutubePlayer + 트랙메타                                              |
-| 3   | 비재생 default    | **Mode C** — 16:9 검정 placeholder 박스 (데스크탑 시각 연속성)                               |
-| 4   | 축소 토글         | 우상단 ▾ 아이콘 overlay. 클릭 시 Mode A↔Mode B 전환                                         |
-| 5   | Collapsed 크기    | **80×45 px** (iOS HIG 44×44 hit-area 근접, ToS 보수) + 트랙명·DJ 가로 row                    |
-| 6   | 비재생 시 토글    | hide (가릴 영상 없음) — 항상 Mode C                                                          |
-| 7   | State persistence | 룸 입장마다 `expanded=true` reset, component-local `useState`, 트랙 변경 시 자동 expand 없음 |
-| 8   | autoplay polish   | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉)                            |
-| 9   | 데스크탑 격리     | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                          |
-| 10  | lobby 카드 디테일 | 본 spec OUT — 별도 후속 결정                                                                 |
+| #   | 항목                 | 결정                                                                                                                                          |
+| --- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | chunk 구분           | chunk 3 머지 직후 chunk 3.1 후속 PR (atomic, develop 진입)                                                                                    |
+| 2   | 재생 중 default      | **Mode A** — 16:9 풀폭 YoutubePlayer + 트랙메타                                                                                               |
+| 3   | 비재생 default       | **Mode C** — 16:9 검정 placeholder 박스 (데스크탑 시각 연속성)                                                                                |
+| 4   | 축소 토글            | 우상단 ▾ 아이콘 overlay. 클릭 시 Mode A↔Mode B 전환                                                                                          |
+| 5   | Collapsed 크기       | **80×45 px** (iOS HIG 44×44 hit-area 근접, ToS 보수) + 트랙명·DJ 가로 row                                                                     |
+| 6   | 비재생 시 토글       | hide (가릴 영상 없음) — 항상 Mode C                                                                                                           |
+| 7   | State persistence    | 룸 mount 시 `expanded=true` 1회 init. component-local `useState`. **트랙 변경·Mode C 진입 모두 `expanded` 미수정 (사용자 마지막 선택 보존)**. |
+| 8   | autoplay polish      | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉). hook 입력에 `videoId` 포함 → 트랙 변경 시 차단 detect 재armed.             |
+| 9   | 데스크탑 격리        | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                                                                           |
+| 10  | lobby 카드 디테일    | 본 spec OUT — 별도 후속 결정                                                                                                                  |
+| 11  | i18n inline 한국어   | 본 chunk 도 chunk 2·3 의 inline 한국어 정책 유지. **chunk 5 catch-up 에서 모바일 i18n 키 일괄 이주 시 함께 처리**.                            |
+| 12  | YoutubePlayer 사이징 | **부모 wrapper 가 size 결정, YoutubePlayer 는 `width='100%' height='100%'` 고정** (prop 변경에 의한 remount 위험 회피).                       |
+| 13  | YoutubePlayer `key`  | `key={`video-${playerReady}-${played}`}` — 데스크탑과 동일. videoId/endTime/mode 미포함.                                                      |
 
 ## 4. Architecture
 
@@ -73,17 +76,19 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 
 | 경로                                                                                    | 변경                                                                                             |
 | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`      | 본문 대규모 재설계 (4 mode 핸들 + 토글)                                                          |
-| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`         | 신규 — 16:9 박스 + YoutubePlayer + autoplay gesture gate                                         |
-| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`    | 신규 — 4 mode 회귀 + ToS 가드                                                                    |
+| `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`      | 본문 대규모 재설계 (Mode 핸들 + 토글 wiring)                                                     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`         | 신규 — 16:9 wrapper + YoutubePlayer + autoplay gesture gate                                      |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`    | 신규 — 3 mode 회귀 + ToS 가드                                                                    |
 | `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx`       | 신규 — ▾/◂ 토글 버튼                                                                             |
 | `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx`  | 신규 — 클릭 콜백 + aria                                                                          |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx`   | 신규 — Mode C 검정 16:9 박스                                                                     |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx`    | 신규 — column/row 양 layout                                                                      |
 | `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts`      | 신규 — 데스크탑 `use-auto-resume-on-pause.hook.ts` 와 별개. autoplay 차단 감지 + gesture trigger |
 | `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts` | 신규                                                                                             |
 
 > **데스크탑 `widgets/partyroom-display-board/*` 0 수정** — C3 격리 (sibling 사본 패턴, chunk 2·3 와 동일 정책).
 
-### 4.2 4 mode layout 사양
+### 4.2 3 mode layout 사양
 
 ```
 ┌─────────────────── Mode A: 재생 + expanded (default) ───────────────────┐
@@ -122,7 +127,7 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Mode D (비재생+collapsed) 불가능** — 비재생 시 expanded 강제.
+**Mode D (비재생+collapsed) 미정의** — 비재생 시 Toggle hide 라 사용자가 진입 불가. **Mode C 는 `expanded` state 를 변경하지 않음** — 재생 재개 시 사용자 마지막 선택 (Mode A 또는 B) 으로 복귀.
 
 ### 4.3 컴포넌트 트리
 
@@ -130,124 +135,197 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 MobilePartyroomDisplayBoard (root, 'use client')
 ├─ <header> 헤더 row (뒤로 · 룸이름 · ⋮)
 │   — chunk 2 그대로
-└─ <section className='display-area'>
+└─ <section data-testid='display-area'>
     ├─ VideoFrame                       ← 신규
-    │   ├─ YoutubePlayer (dynamic import)
-    │   │   — Mode A: 16:9 풀폭 (aspect-video)
-    │   │   — Mode B: 80×45 fixed
-    │   │   — Mode C: 미렌더, 대신 BlankPlaceholder
+    │   ├─ <div className='video-wrapper'> 부모 wrapper (사이즈 결정)
+    │   │   — Mode A: 'aspect-video w-full'
+    │   │   — Mode B: 'w-20 h-[45px] shrink-0'
+    │   │   — Mode C: 'aspect-video w-full bg-black' (YoutubePlayer 미렌더, BlankPlaceholder 자리)
+    │   ├─ YoutubePlayer (dynamic import, Mode A·B 만 mount)
+    │   │   — width='100%' height='100%' 고정. 부모 wrapper class 가 실 크기 결정.
     │   ├─ BlankPlaceholder (Mode C 만)
-    │   │   — 16:9 + zZz 아이콘 + "지금 재생 중인 곡이 없어요"
-    │   ├─ AutoplayGestureGate
-    │   │   — autoplayBlocked && playable && expanded 시 overlay
-    │   └─ ExpandToggle (Mode A·B 만, Mode C hide)
-    ├─ NowPlayingMeta (Mode A·B 각각 다른 배치)
-    │   — Mode A: 박스 아래 column
-    │   — Mode B: 박스 우측 row
+    │   ├─ AutoplayGestureGate (Mode A 만 overlay — Mode B 80×45 에는 게이트 부착 안 함)
+    │   └─ ExpandToggle (Mode A·B 만 visible, Mode C 미렌더)
+    ├─ NowPlayingMeta (Mode A·B 별 layout)
+    │   — Mode A: 'column' (박스 아래 column)
+    │   — Mode B: 'row' (박스 우측 row)
     └─ ActionButtons (리액션, chunk 2 그대로)
 ```
 
 ### 4.4 State 모델
 
 ```tsx
-const [expanded, setExpanded] = useState(true); // 룸 입장마다 reset
-const [autoplayBlocked, setAutoplayBlocked] = useState(false);
-const [played, setPlayed] = useState(false);
-const [playerReady, setPlayerReady] = useState(false);
+// MobilePartyroomDisplayBoard 본문
+const [expanded, setExpanded] = useState(true); // 룸 mount 시 1회 init
 
 const playbackActivated = useCurrentPartyroom((s) => s.playbackActivated);
 const playback = useCurrentPartyroom((s) => s.playback);
-const isPlaying = playbackActivated && !!playback?.linkId;
+
+// 단일 trigger 값: linkId 가 있으면 재생 가능, 없으면 Mode C
+const videoId = playbackActivated ? (playback?.linkId ?? null) : null;
+const isPlaying = videoId !== null;
 
 // Mode 결정
 const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
 ```
 
-### 4.5 YoutubePlayer 크기 동적 지정
+**불변식**:
 
-react-player/youtube 는 `width`/`height` prop 으로 크기 지정. Mode A·B 전환 시 prop 만 바꾸고 컴포넌트 unmount/remount 회피 (재생 끊김 방지).
+- `setExpanded` 호출 지점 = **사용자 토글 클릭 이벤트 1곳뿐**. videoId 변화·track change·Mode C 진입 시 `expanded` 자동 변환 X.
+- Mode C 진입은 `videoId === null` 의 derived state. `expanded` 자체는 그대로 보존.
+- Mode C → A/B 복귀 시 (videoId 재할당) `expanded` 의 마지막 사용자 선택 그대로 → Mode A 또는 B 직접 진입.
+
+### 4.5 YoutubePlayer 사이징 — wrapper 기반 (remount 회피)
+
+reviewer 1차 이슈 #1 + #4 반영. react-player/youtube 의 width/height prop 변경이 IFrame remount 를 유발할 가능성을 차단:
 
 ```tsx
-<YoutubePlayer
-  url={`https://www.youtube.com/watch?v=${playback.linkId}`}
-  playing={playerReady}
-  volume={muted ? 0 : volume}
-  muted={muted}
-  width={mode === 'A' ? '100%' : '80px'}
-  height={mode === 'A' ? '100%' : '45px'}
-  className='bg-black rounded' // hidden 클래스 절대 추가 X
-  onReady={onPlayerReady}
-  onStart={onStart}
-  onPlay={onPlay}
-  onPause={onPause}
-  config={config}
-/>
+// VideoFrame 본문 발췌
+return (
+  <div className='relative'>
+    <div className={cn('relative', wrapperSizeClass(mode))}>
+      {mode === 'C' ? (
+        <BlankPlaceholder />
+      ) : (
+        <YoutubePlayer
+          key={`video-${playerReady}-${played}`}
+          url={`https://www.youtube.com/watch?v=${videoId}`}
+          playing={playerReady}
+          volume={muted ? 0 : volume}
+          muted={muted}
+          width='100%'
+          height='100%'
+          className='bg-black rounded' // hidden, opacity-0, w-px, h-px, pointer-events-none 절대 금지
+          onReady={onPlayerReady}
+          onStart={onStart}
+          onPlay={onPlay}
+          onPause={onPause}
+          config={config}
+        />
+      )}
+      {mode === 'A' && showGate && <AutoplayGestureGate onClick={handleGesturePlay} />}
+      {(mode === 'A' || mode === 'B') && <ExpandToggle expanded={expanded} onToggle={onToggleExpand} />}
+    </div>
+    {(mode === 'A' || mode === 'B') && <NowPlayingMeta layout={mode === 'A' ? 'column' : 'row'} … />}
+  </div>
+);
+
+function wrapperSizeClass(mode: 'A' | 'B' | 'C'): string {
+  switch (mode) {
+    case 'A':
+      return 'aspect-video w-full';
+    case 'B':
+      return `w-[${COLLAPSED_VIDEO_WIDTH}px] h-[${COLLAPSED_VIDEO_HEIGHT}px] shrink-0`;
+    case 'C':
+      return 'aspect-video w-full bg-black';
+  }
+}
+
+export const COLLAPSED_VIDEO_WIDTH = 80; // ToS 하한
+export const COLLAPSED_VIDEO_HEIGHT = 45;
 ```
 
-- `key` 에 `videoId`/`endTime` 포함 X (background tab autoplay 차단 회피, [[reference_frontend_playwright_debug]] 및 데스크탑 #341 결정 유지)
-- `playerClass` 에 `hidden` 절대 추가 X (ToS 가드)
+**핵심 보장**:
+
+1. YoutubePlayer 의 width/height prop 은 **항상 '100%'/'100%'** — react-player 내부 IFrame 재로드 위험 0.
+2. Mode A↔B 전환 = 부모 wrapper 의 Tailwind class 만 교체 → CSS-only 리사이즈, IFrame 안정성 유지.
+3. Mode A↔C, B↔C 전환 = YoutubePlayer 자체 mount/unmount (재생 가능 여부에 따라 IFrame 자체가 필요/불요). Mode C 진입 시 IFrame unmount 는 ToS 안전 (재생 안 함 → IFrame 불요).
+4. Mode B↔A 전환 시 IFrame mount 유지 → 재생 연속성.
+5. `key={`video-${playerReady}-${played}`}` 데스크탑 동일 — gesture-gate-release-then-replay 라이프사이클 보존. **mode·videoId·endTime 은 key 에 포함 X**.
 
 ### 4.6 useAutoplayGestureGate hook
 
-데스크탑의 `useAutoResumeOnPause` 와 별개. 모바일 first-mount 시 autoplay 가 차단됐는지 감지하고 gesture gate UI 표시:
-
 ```ts
-// Pseudo
-function useAutoplayGestureGate({ playerRef, playable }) {
+// Pseudo signature
+function useAutoplayGestureGate({
+  playerRef,
+  playable,
+  videoId, // ← reviewer 1차 #7: 트랙 변경 시 차단 detect 재armed
+}: {
+  playerRef: RefObject<TReactPlayer | null>;
+  playable: boolean;
+  videoId: string | null;
+}) {
   const [autoplayBlocked, setAutoplayBlocked] = useState(false);
   const [played, setPlayed] = useState(false);
   const [playerReady, setPlayerReady] = useState(false);
 
+  // onReady 후 1500ms 내 onPlay 가 없으면 차단으로 간주.
+  // videoId 변경 시 played reset → 새 트랙에 대해 다시 detect.
+  useEffect(() => {
+    if (!playerReady || played) return;
+    const timer = setTimeout(() => setAutoplayBlocked(true), AUTOPLAY_DETECT_MS);
+    return () => clearTimeout(timer);
+  }, [playerReady, played, videoId]); // ← videoId dep 가 핵심
+
   // onPlay → played=true, autoplayBlocked=false
   // onReady → playerReady=true, seekToLive
-  // 후 AUTOPLAY_DETECT_MS=1500ms 내 onPlay 없으면 autoplayBlocked=true
 
   const handleGesturePlay = () => {
     playerRef.current?.getInternalPlayer()?.playVideo?.();
     setAutoplayBlocked(false);
   };
 
-  return { autoplayBlocked, played, playerReady, handleGesturePlay /* setters */ };
+  return {
+    autoplayBlocked,
+    played,
+    playerReady,
+    handleGesturePlay,
+    onReady,
+    onStart,
+    onPlay,
+    onPause,
+  };
 }
+
+export const AUTOPLAY_DETECT_MS = 1500;
 ```
 
-본 hook 은 데스크탑 video.component.tsx 의 ll. 73-153 에서 추출한 패턴. 데스크탑 코드는 미수정. 만약 미래에 데스크탑·모바일이 공통 hook 으로 통합되면 그건 별도 리팩토링 작업.
+본 hook 은 데스크탑 `video.component.tsx:73-153` 의 패턴을 추출한 **모바일 전용 사본**. 데스크탑 본문은 미수정 (격리). **중복 코드 발생 — 본 spec §9 risk #5 로 등록 + 후속 GH 이슈로 통합 트래킹**.
 
 ## 5. ToS 보존 검증 포인트
 
-각 항목은 테스트로 회귀 가드 가능.
+각 항목은 단위·통합·**Playwright headed** 다층 가드.
 
-| 가드 항목                                                                    | 검증 방법                                                         |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Mode A: YoutubePlayer width/height 가 '100%' 또는 16:9 비율의 풀폭           | 통합 테스트에서 mock react-player 의 width/height prop 단언       |
-| Mode B: YoutubePlayer width ≥ 80px, height ≥ 45px (보수 하한)                | 통합 테스트 단언                                                  |
-| Mode C: YoutubePlayer 미렌더 (재생 안 함 → IFrame 불요) — placeholder 박스만 | mode='C' 시 react-player mock 호출 0 회 단언                      |
-| 어떤 mode 에서도 `className` 에 `hidden` 토큰 없음                           | className 정규식 단언 (`expect(class).not.toMatch(/\bhidden\b/)`) |
-| 어떤 mode 에서도 `opacity-0`, `w-px`, `h-px`, `pointer-events-none` 없음     | className 정규식 단언                                             |
-| aria-hidden=true 없음 (screen reader 접근성도 보존)                          | DOM 속성 단언                                                     |
+| 가드 항목                                                                                                            | 검증 방법                                                                                                                                                               | 레이어                |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| Mode A: YoutubePlayer width/height prop = '100%'/'100%'                                                              | 통합 테스트 — react-player mock 의 props 단언                                                                                                                           | unit/it               |
+| Mode A: 부모 wrapper 가 `aspect-video w-full` class 보유                                                             | DOM 단언                                                                                                                                                                | unit/it               |
+| Mode B: 부모 wrapper 의 width ≥ 80px, height ≥ 45px (정확값)                                                         | DOM class + Playwright `boundingBox()` 단언                                                                                                                             | unit + headed         |
+| Mode C: YoutubePlayer 미렌더, BlankPlaceholder 만 렌더                                                               | react-player mock 호출 0회 단언                                                                                                                                         | unit/it               |
+| 어떤 mode 에서도 YoutubePlayer wrapper 의 `className` 에 `hidden` 토큰 없음                                          | 정규식 `expect(class).not.toMatch(/\bhidden\b/)`                                                                                                                        | unit/it               |
+| 어떤 mode 에서도 wrapper className 에 `opacity-0`, `w-px`, `h-px`, `pointer-events-none` 없음                        | 정규식 단언                                                                                                                                                             | unit/it               |
+| YoutubePlayer wrapper / IFrame element 의 직접 부착 `aria-hidden='true'` 없음 (decorative SVG 등 내부 아이콘은 허용) | DOM 단언 — `expect(getByTestId('video-wrapper')).not.toHaveAttribute('aria-hidden')` 같이 scoping 명시                                                                  | unit/it               |
+| **Playwright 헤드드: IFrame 가 ancestor 에 의해 가려지지 않음**                                                      | Playwright `await expect(iframe).toBeVisible()` (built-in: ancestor display/visibility/opacity 모두 체크) + `await iframe.boundingBox()` 의 width >= 80 && height >= 45 | **headed (required)** |
+| **Playwright 헤드드: IFrame 의 computed CSS `visibility !== 'hidden'` && `opacity > 0`**                             | `await page.locator('iframe').evaluate(el => getComputedStyle(el))`                                                                                                     | **headed (required)** |
+| **Playwright 헤드드: IFrame 의 boundingBox 가 viewport 안에 있고 off-screen 아님**                                   | `boundingBox.x > -box.width && boundingBox.y > -box.height && < viewport edges`                                                                                         | **headed (required)** |
+
+**중요**: unit 레이어의 mock 은 ancestor visibility (parent `display:none`, `transform:scale(0)`, off-viewport positioning) 를 잡지 못함. **Playwright headed 가 ToS 가드의 1차 게이트**. CI 에서 반드시 실행되는 mandatory test 로 등록.
 
 ## 6. 컴포넌트 책임 분리
 
 ### 6.1 `VideoFrame`
 
-**책임**: 단일 root — 4 mode 중 하나를 렌더. ExpandToggle·BlankPlaceholder·YoutubePlayer·AutoplayGestureGate orchestration.
+**책임**: 단일 root — 3 mode 중 하나를 렌더. ExpandToggle·BlankPlaceholder·YoutubePlayer·AutoplayGestureGate orchestration.
 
-**Props**:
+**Props** (reviewer 1차 #8 — derive 단일화):
 
 ```ts
 interface VideoFrameProps {
-  isPlaying: boolean;
-  videoId: string | undefined;
+  videoId: string | null; // null = Mode C 강제
   expanded: boolean;
   onToggleExpand: () => void;
 }
+
+// VideoFrame 내부 derive
+const mode: 'A' | 'B' | 'C' = videoId === null ? 'C' : expanded ? 'A' : 'B';
 ```
 
 **Mode 분기**:
 
-- `!isPlaying || !videoId` → BlankPlaceholder (Mode C). Toggle hide.
-- `expanded` → YoutubePlayer 16:9 + Toggle ▾
-- `!expanded` → YoutubePlayer 80×45 + Toggle ◂
+- `videoId === null` → Mode C: BlankPlaceholder 렌더. ExpandToggle 미렌더 (사용자 진입 불가).
+- `videoId !== null && expanded` → Mode A: YoutubePlayer 16:9 + Toggle ▾.
+- `videoId !== null && !expanded` → Mode B: YoutubePlayer 80×45 + Toggle ◂.
 
 ### 6.2 `ExpandToggle`
 
@@ -264,7 +342,7 @@ interface ExpandToggleProps {
 
 **a11y**:
 
-- `<button>` + `aria-label={expanded ? '영상 가리기' : '영상 펼치기'}`
+- `<button>` + `aria-label={expanded ? '영상 가리기' : '영상 펼치기'}` (inline 한국어, §3 row 11)
 - `aria-pressed={!expanded}` (collapsed=pressed state)
 - min-h-[44px] min-w-[44px] hit-area
 
@@ -272,7 +350,7 @@ interface ExpandToggleProps {
 
 **책임**: Mode C 의 16:9 검정 박스 + 안내 텍스트.
 
-**Props**: 없음 (i18n 키 inline).
+**Props**: 없음. 본문 inline 한국어 ("지금 재생 중인 곡이 없어요") — §3 row 11 정책.
 
 ### 6.4 `NowPlayingMeta`
 
@@ -289,107 +367,150 @@ interface NowPlayingMetaProps {
 }
 ```
 
+### 6.5 `AutoplayGestureGate`
+
+**책임**: Mode A 의 IFrame 영역 위 overlay. autoplay 차단 시 visible, 클릭 시 `handleGesturePlay` 호출.
+
+**Mode B (80×45) 에서는 게이트 자체 미렌더** — 80×45 는 tap target 으로 좁고, 사용자가 Mode B 로 전환했다는 건 audio 청취 의도. autoplay 차단된 채 Mode B 일 때는 Mode A 로 자동 복귀 X (사용자 의도 보존), 단 audio 안 나는 상태 사용자 인지 가능.
+
+대신 Mode B 의 NowPlayingMeta 옆에 작은 ▶ 버튼 (tap-to-play) 추가 — Mode B 에서도 gesture release 경로 제공.
+
 ## 7. 테스트 전략
 
 ### 7.1 단위 테스트
 
-- `video-frame.component.test.tsx` (8 케이스)
-  - Mode A 렌더: YoutubePlayer 호출 (width=100%, height=100%), Toggle ▾, BlankPlaceholder 미렌더
-  - Mode B 렌더: YoutubePlayer width=80px height=45px, Toggle ◂
-  - Mode C 렌더: BlankPlaceholder visible, YoutubePlayer 미렌더, Toggle hide
-  - autoplayBlocked && expanded 시 gesture gate overlay 렌더, 클릭 시 playVideo() 호출
-  - ToS 가드: 모든 mode 에서 className 에 `hidden`/`opacity-0`/`w-px`/`h-px` 토큰 부재
-  - ToS 가드: Mode B 의 YoutubePlayer 가 width >= 80 & height >= 45 (정수 또는 px 문자열 파싱)
+- `video-frame.component.test.tsx` (11 케이스)
+  - Mode A 렌더: YoutubePlayer 호출 (width=100%, height=100%), wrapper class `aspect-video w-full`, Toggle ▾, BlankPlaceholder 미렌더.
+  - Mode B 렌더: YoutubePlayer width=100%/height=100% (그대로), wrapper class width=80 height=45, Toggle ◂.
+  - Mode C 렌더: BlankPlaceholder visible, YoutubePlayer 미렌더, Toggle 미렌더.
+  - Mode A→B 전환: YoutubePlayer mock 호출 count 유지 (remount X) + wrapper class 만 교체.
+  - Mode B→C 전환: YoutubePlayer mock unmount 단언.
+  - Mode C→A 전환: YoutubePlayer remount.
+  - autoplayBlocked && Mode A 시 gesture gate overlay 렌더, 클릭 시 playVideo() 호출.
+  - autoplayBlocked && Mode B 시 gate 미렌더, NowPlayingMeta 옆 ▶ tap-to-play 렌더.
+  - **ToS 가드 (회귀)**: 모든 mode 에서 wrapper className 에 `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 토큰 부재.
+  - **ToS 가드**: video-wrapper testid 가진 element 에 `aria-hidden='true'` 직접 부착 안 됨.
+  - Props 안전: `videoId=null && expanded=true/false` → Mode C 강제 진입 (Mode A/B 진입 안 됨).
 - `expand-toggle.component.test.tsx` (4 케이스)
-  - aria-label expanded·collapsed 분기
-  - 클릭 시 onToggle 콜백
-  - aria-pressed 단언
-  - 44×44 hit-area class 단언
-- `use-autoplay-gesture-gate.hook.test.ts` (5 케이스)
-  - 초기 ready/played/blocked 모두 false
-  - onReady 호출 후 playerReady=true + seekToLive 호출
-  - 1500ms 내 onPlay 없으면 autoplayBlocked=true
-  - onPlay 호출 시 played=true, autoplayBlocked=false
-  - handleGesturePlay 가 internal playVideo() 호출
+  - aria-label expanded·collapsed 분기.
+  - 클릭 시 onToggle 콜백.
+  - aria-pressed 단언.
+  - 44×44 hit-area class 단언.
+- `use-autoplay-gesture-gate.hook.test.ts` (7 케이스, reviewer 1차 #7 반영)
+  - 초기 ready/played/blocked 모두 false.
+  - onReady 호출 후 playerReady=true.
+  - 1500ms 내 onPlay 없으면 autoplayBlocked=true.
+  - onPlay 호출 시 played=true, autoplayBlocked=false.
+  - handleGesturePlay 가 internal playVideo() 호출.
+  - **videoId 변경 시 played reset + 1500ms 새 타이머 시작** (track change 시 차단 detect 재armed).
+  - **playable=false 진입 시 모든 state reset** (Mode C 진입 시 cleanup).
 
 ### 7.2 통합 테스트
 
-- `partyroom-display-board.component.test.tsx` (기존 없음, 신규 6 케이스)
-  - 룸 mount 시 expanded=true default
-  - 토글 클릭 → collapsed (Mode B)
-  - 다시 클릭 → expanded (Mode A)
-  - playback null → Mode C, toggle hide
-  - playback 변경 후에도 expanded state 보존 (자동 expand 없음)
-  - 룸 unmount → 다시 mount 시 expanded=true reset (component-local state)
+- `partyroom-display-board.component.test.tsx` (기존 없음, 신규 9 케이스, reviewer 1차 #2 반영)
+  - 룸 mount 시 expanded=true default.
+  - 토글 클릭 → collapsed (Mode B).
+  - 다시 클릭 → expanded (Mode A).
+  - playback null → Mode C, toggle hide.
+  - playback 변경 후에도 expanded state 보존 (자동 expand 없음).
+  - **Mode C → playback 재할당 → expanded 의 마지막 사용자 선택 (true 또는 false) 그대로 → Mode A 또는 B 진입** (Mode C 가 expanded 미수정 보장).
+  - **Mode B → playback null → Mode C → playback 재할당 → 여전히 Mode B** (사용자 collapse 유지).
+  - 룸 unmount → 다시 mount 시 expanded=true reset (component-local state).
+  - **트랙 변경 시 autoplay re-arm**: videoId 변경 + 1500ms 후 autoplayBlocked=true 단언 (Mode A 인데 autoplay 다시 차단된 케이스 시뮬레이션).
 
-### 7.3 헤드드 검증 (Playwright 사전 smoke)
+### 7.3 Playwright 헤드드 테스트 (**mandatory CI**)
 
-implementation 후 dev 서버 + Playwright mobile UA 로:
+reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 ancestor visibility / sticky-top 높이 변화 / chat 스크롤 영향 등을 가드.
 
-- Mode A·B·C 각 mode 의 IFrame 가시 영역 ≥ 80×45 단언 (getComputedStyle).
-- ToS 가드: `getComputedStyle(iframe).visibility !== 'hidden' && opacity !== '0'`.
-- 토글 클릭 후 IFrame width 가 80px 로 변하는지 (CSS computed 측정).
+- `display-board.tos.spec.ts` (신규 — `tests-e2e/mobile/` 디렉토리 또는 기존 e2e 위치 따름)
+  - Mode A 진입: `await expect(page.locator('iframe[src*="youtube.com/embed"]')).toBeVisible()` + `boundingBox()` width ≥ 80, height ≥ 45.
+  - Mode A 진입: computed style `visibility !== 'hidden'`, `opacity > 0`.
+  - Mode A 진입: `boundingBox()` 가 viewport 안에 있음 (off-screen 좌표 아님).
+  - Toggle 클릭 → Mode B: width === 80, height === 45 (정확값), IFrame 여전히 visible.
+  - Toggle 두 번째 클릭 → Mode A 복귀: 동일 IFrame element (selector 안정성) → remount 안 됨 검증.
+  - **sticky-top 높이 변화 시 chat scroll position 보존**: 채팅 탭 스크롤을 위로 올려둔 상태에서 Toggle 클릭 → chat scroll offset 변화 ≤ tolerance (~10px 허용).
+  - Mode C (playback null mock or 룸 입장 직후 첫 트랙 전): BlankPlaceholder visible, IFrame element 미존재.
+
+### 7.4 viewport / 환경 매트릭스 (Playwright)
+
+- iPhone 13 (390×844)
+- iPhone SE (375×667)
+- Pixel 7 (412×915)
+- 가로 orientation 1회 — toggle 후에도 IFrame ≥ 80×45 보존.
 
 ## 8. 스코프
 
 ### IN
 
 - `widgets-mobile/partyroom-display-board` 본문 재설계
-- VideoFrame·ExpandToggle·BlankPlaceholder·NowPlayingMeta 신규 sibling parts
-- useAutoplayGestureGate 신규 hook
-- 데스크탑 `useUserPreferenceStore` (volume·muted) 재사용 (read-only)
-- 데스크탑 `Playback.getInitialSeek` 재사용 (read-only)
-- ToS 가드 회귀 테스트
+- VideoFrame·ExpandToggle·BlankPlaceholder·NowPlayingMeta·AutoplayGestureGate 신규 sibling parts
+- useAutoplayGestureGate 신규 hook (mobile-only fork — §9 risk #5 등록)
+- 데스크탑 `useUserPreferenceStore` (volume·muted) 재사용 (read-only import)
+- 데스크탑 `Playback.getInitialSeek` 재사용 (read-only import)
+- ToS 가드 회귀 테스트 (3-layer: unit + integration + Playwright headed)
+- Playwright headed test 를 CI 의 mandatory 단계로 등록 (또는 stg vercel-preview-e2e workflow 에 추가)
 
 ### OUT
 
 - 데스크탑 `widgets/partyroom-display-board/*` 변경 0
 - chunk 2 의 `ActionButtons` (리액션) 변경 0
-- chunk 3 의 탭·채팅·크루 변경 0
+- chunk 3 의 탭·채팅·크루 변경 0 (단 sticky-top 높이 변화의 영향 가드는 §7.3 에서 검증)
 - DJ 큐 (chunk 4)
 - lobby 카드 디자인 (별도 결정)
 - 사용자가 영상 일부분만 hide 하거나 mute toggle 추가 — v1 스코프 아님 (현 결정은 mute=userPreferenceStore 따라감)
 - userPreference 에 expanded 영구 저장 (사용자 결정: session reset)
+- 데스크탑·모바일 autoplay hook 의 단일화 (§9 risk #5, 후속 작업)
+- Mode B 80×45 → 96×54 등 픽셀 조정 (상수 분리는 본 spec, 값 변경은 prod 후 사용자 결정)
 
 ## 9. 위험 + 트레이드오프
 
-| 위험                                                                                                               | 완화                                                                                                                        |
-| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| Mode A 풀폭 IFrame 이 sticky-top 점유 → 채팅 영역 잠식 (iPhone SE 568px 등 small viewport 에서 메시지 4~5 visible) | 사용자가 collapse 토글로 80×45 Mode B 전환 → 채팅 영역 ~150px 확보                                                          |
-| react-player 의 width/height prop 변경이 internal player remount 유발할 가능성                                     | `key` 에 width/height 포함 X. width 만 prop 변경 → react-player 내부 div 리사이즈만 발동, IFrame 재로드 X. 헤드드 검증 필수 |
-| autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                          | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보                                                                |
-| Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                       | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이                  |
-| 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용                   | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선                                                                     |
+| #   | 위험                                                                                                          | 완화                                                                                                                                                                                                                                                           |
+| --- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Mode A 풀폭 IFrame 이 sticky-top 점유 → 채팅 영역 잠식 (iPhone SE 568px 등 small viewport 메시지 4~5 visible) | 사용자가 collapse 토글로 80×45 Mode B 전환 → 채팅 영역 ~150px 확보                                                                                                                                                                                             |
+| 2   | react-player 의 width/height prop 변경 시 IFrame remount 위험                                                 | **해결됨** — §4.5 wrapper 기반 사이징 (YoutubePlayer width/height 항상 '100%' 고정, 부모 div Tailwind class 만 교체). Mode A↔B 전환 시 IFrame 자체 stability 유지. Playwright `display-board.tos.spec.ts` 의 "Toggle 두 번 클릭 → same element" 가 회귀 가드. |
+| 3   | autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                     | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보. Mode B 에서도 tap-to-play 경로 (§6.5) 제공.                                                                                                                                                      |
+| 4   | Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                  | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이. Playwright headed test 가 항상 ≥ 80×45 가드.                                                                                                       |
+| 5   | **`useAutoplayGestureGate` (mobile) 와 데스크탑 `video.component.tsx` inline 패턴 의 코드 중복 → 향후 drift** | (a) `AUTOPLAY_DETECT_MS` 상수는 mobile hook 에서 export. 향후 데스크탑이 import 하면 첫 단계 단일화. (b) **chunk 3.1 머지 직후 GH 이슈 신규 등록 — "데스크탑·모바일 autoplay hook 통합 (refactor)"**. PR 본문에 issue ref 포함.                                |
+| 6   | **sticky-top 높이 변화 (Mode A↔B, ~210px↔80px) 가 chunk 3 탭 컨테이너 scroll anchor 흔들기**                | (a) chunk 3 tabs 컨테이너가 이미 `flex-1 min-h-0` 라 layout shift 흡수. (b) chat scroll 은 `useChatMessagesScrollManager` 의 bottom-pin 으로 자연 복귀. (c) §7.3 Playwright "Toggle 클릭 후 chat scroll offset 변화 ≤ tolerance" 가 회귀 가드.                 |
+| 7   | 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용              | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선.                                                                                                                                                                                                       |
+| 8   | maintenance 모드 / system-announcement WS overlay 와의 z-index 충돌                                           | display-board 의 sticky-top z 는 chunk 2 의 `z-20`. maintenance overlay 는 더 높은 z (chunk 1·2 의 `WS overlay` 는 일반적으로 `z-50`). 본 spec 은 z 값 미변경. 헤드드 회귀 가드는 §7.3 외 별도 — 향후 모바일 maintenance scenario 가 정의될 때 verify.         |
+| 9   | Playwright headed test 의 CI 추가 비용·flakiness                                                              | 단일 mobile UA + 1~2 viewport. 별도 vercel-preview-e2e workflow 의 concurrency 잠금 ([[reference_e2e_preview_alias_race]]) 활용. flakiness 발생 시 단독 재실행으로 격리 가능 여부 진단 절차 미리 plan 에 명시.                                                 |
 
 ## 10. 마이그레이션 시나리오
 
-1. chunk 3 머지 → develop `feature/mobile-responsive-spec-3` 가 develop 으로 머지됨
-2. `feature/mobile-responsive-spec-3.1` 신규 브랜치 (origin/develop 기준 분기)
-3. chunk 3.1 plan 작성 (`docs/superpowers/plans/2026-XX-XX-mobile-display-board-tos-redesign.md`)
-4. plan-reviewer 통과 후 TDD 실행 (8~10 commits 예상)
-5. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지
-6. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**
+1. chunk 3 PR #357 머지 → `feature/mobile-responsive-spec-3` 가 develop 으로 머지됨.
+2. `feature/mobile-responsive-spec-3.1` 신규 브랜치 (origin/develop 기준 분기, [[feedback_branch_from_origin_develop]]).
+3. chunk 3.1 plan 작성 (`docs/superpowers/plans/2026-XX-XX-mobile-display-board-tos-redesign.md`).
+4. plan-reviewer 통과 후 TDD 실행 (10~12 commits 예상; reviewer 권장 spike 포함).
+5. Playwright headed mandatory test 가 CI 에 추가됐는지 확인.
+6. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지.
+7. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**.
+8. (post-merge) GH 이슈 신규 등록 — "데스크탑·모바일 autoplay gesture-gate hook 통합 refactor" (§9 risk #5).
 
 ## 11. 관련
 
 - 선행 chunk:
   - chunk 1 spec (`docs/superpowers/specs/2026-05-28-mobile-responsive-architecture-design.md`) — §3 chunk 분할, §4 모바일 layout 그림
   - chunk 3 plan (`docs/superpowers/plans/2026-05-29-mobile-responsive-chunk3-chat-crews-tabs.md`)
+  - chunk 3 PR `#357`
 - 데스크탑 baseline (read-only 참조):
   - `src/widgets/partyroom-display-board/ui/parts/video.component.tsx` (16:9 placeholder + autoplay gate)
   - `src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.ts` (블루투스 polish, OUT)
 - GH 이슈: pfplay-web#340 (모바일 반응형)
 - 관련 메모리:
   - [[feedback_pr_series_workflow]] (chunk 3.1 polish follow-up 패턴)
+  - [[feedback_branch_from_origin_develop]] (chunk 3.1 분기 정책)
   - [[reference_pfplay_web_local_dev_http_webpack]] (헤드드 검증 환경)
   - [[reference_frontend_playwright_debug]] (Playwright headed measure)
+  - [[reference_e2e_preview_alias_race]] (CI flakiness 진단 절차)
   - [[feedback_korean_issue_commit_pr]]
   - [[feedback_autonomous_execution]]
   - [[feedback_elegant_no_code_dirtying]]
+  - [[feedback_pfplay_web_i18n_drift]] (chunk 5 i18n catch-up 시 inline 한국어 이주)
   - [[project_mobile_responsive_chunk3_plan_ready]] (chunk 3 entry 메모리)
 
 ## 12. 다음
 
-1. spec-document-reviewer 루프 (이슈 발견 시 fix 후 재차)
-2. 사용자 spec 리뷰
-3. 통과 시 writing-plans skill 으로 plan 작성
+1. spec-document-reviewer 2차 루프 (1차에서 10 issues — 모두 spec 본문에 반영. 잔존 이슈 발견 시 fix 후 재차).
+2. 사용자 spec 리뷰.
+3. 통과 시 writing-plans skill 으로 plan 작성.

--- a/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
@@ -1,0 +1,395 @@
+# 모바일 디스플레이 보드 — YouTube ToS 보존 재설계 spec
+
+**Date:** 2026-05-29
+**Chunk:** chunk 3.1 (chunk 3 polish follow-up — chunk 3 머지 직후 atomic PR)
+**Status:** Draft → spec-document-reviewer → 사용자 승인 → writing-plans
+
+## 1. Goal
+
+모바일 룸 (`/parties/[id]` mobile branch) 의 sticky-top **디스플레이 보드 (`widgets-mobile/partyroom-display-board`)** 를 YouTube IFrame Player API 서비스 약관에 부합하도록 재설계한다. 사용자 통제 (축소/확장 토글) 도 함께 제공하되, 어떤 상태에서도 YouTube IFrame 이 시각적으로 가려지지 않도록 보장한다.
+
+부수적으로 데스크탑이 가진 autoplay 차단 감지 + gesture gate UX 를 모바일에도 차용한다 (현재 chunk 2 미보유).
+
+## 2. 배경: 왜 재설계가 필요한가
+
+### 2.1 chunk 2 의 현 모바일 디스플레이 (재설계 직전 상태)
+
+`widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx:88-102`
+
+```tsx
+{
+  playbackActivated && playback?.linkId && (
+    <div
+      aria-hidden
+      className='absolute pointer-events-none w-px h-px overflow-hidden opacity-0 -z-10'
+    >
+      <YoutubePlayer
+        url={`https://www.youtube.com/watch?v=${playback.linkId}`}
+        playing={playbackActivated}
+        muted={false}
+        volume={1}
+        width='1px'
+        height='1px'
+      />
+    </div>
+  );
+}
+```
+
+→ 재생 중 IFrame 이 **1px × 1px + opacity 0 + pointer-events:none**. 사실상 audio-only.
+
+### 2.2 YouTube IFrame Player API ToS 충돌
+
+YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다음 조항 (정확한 표현은 갱신되나 정신은 동일):
+
+> 임베디드 YouTube 플레이어는 사용자에게 표시되어야 하며, 오디오만 추출하는 백그라운드 재생은 허용되지 않는다 (YouTube Music 등 별도 라이선스 제외).
+
+> Embedded API 호출자는 비디오 플레이어의 일부를 숨기거나 동작을 변경해서는 안 된다 (이 정신은 1px hidden / opacity 0 패턴을 명백히 배제).
+
+위반 시 API 키 차단·앱 정지 사례 존재 (Spotify·Tubi 등). chunk 2 가 dev/stg 까지는 도달했으나 **prod ship 전 fix 필수**.
+
+### 2.3 데스크탑과의 시각 연속성 결손
+
+데스크탑 (`widgets/partyroom-display-board/ui/parts/video.component.tsx`) 은 **재생 안 해도 16:9 검정 placeholder 박스 항상 visible** (line 317-321). 모바일은 chunk 2 에서 텍스트 한 줄 (`'지금 재생 중인 곡이 없어요'`) 만 표시 → 사용자 UX 단절 ("디스플레이가 없으니 이상").
+
+## 3. 결정 잠금 (brainstorming 산출물)
+
+| #   | 항목              | 결정                                                                                         |
+| --- | ----------------- | -------------------------------------------------------------------------------------------- |
+| 1   | chunk 구분        | chunk 3 머지 직후 chunk 3.1 후속 PR (atomic, develop 진입)                                   |
+| 2   | 재생 중 default   | **Mode A** — 16:9 풀폭 YoutubePlayer + 트랙메타                                              |
+| 3   | 비재생 default    | **Mode C** — 16:9 검정 placeholder 박스 (데스크탑 시각 연속성)                               |
+| 4   | 축소 토글         | 우상단 ▾ 아이콘 overlay. 클릭 시 Mode A↔Mode B 전환                                         |
+| 5   | Collapsed 크기    | **80×45 px** (iOS HIG 44×44 hit-area 근접, ToS 보수) + 트랙명·DJ 가로 row                    |
+| 6   | 비재생 시 토글    | hide (가릴 영상 없음) — 항상 Mode C                                                          |
+| 7   | State persistence | 룸 입장마다 `expanded=true` reset, component-local `useState`, 트랙 변경 시 자동 expand 없음 |
+| 8   | autoplay polish   | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉)                            |
+| 9   | 데스크탑 격리     | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                          |
+| 10  | lobby 카드 디테일 | 본 spec OUT — 별도 후속 결정                                                                 |
+
+## 4. Architecture
+
+### 4.1 변경 영역
+
+| 경로                                                                                    | 변경                                                                                             |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`      | 본문 대규모 재설계 (4 mode 핸들 + 토글)                                                          |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx`         | 신규 — 16:9 박스 + YoutubePlayer + autoplay gesture gate                                         |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx`    | 신규 — 4 mode 회귀 + ToS 가드                                                                    |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx`       | 신규 — ▾/◂ 토글 버튼                                                                             |
+| `src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx`  | 신규 — 클릭 콜백 + aria                                                                          |
+| `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts`      | 신규 — 데스크탑 `use-auto-resume-on-pause.hook.ts` 와 별개. autoplay 차단 감지 + gesture trigger |
+| `src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts` | 신규                                                                                             |
+
+> **데스크탑 `widgets/partyroom-display-board/*` 0 수정** — C3 격리 (sibling 사본 패턴, chunk 2·3 와 동일 정책).
+
+### 4.2 4 mode layout 사양
+
+```
+┌─────────────────── Mode A: 재생 + expanded (default) ───────────────────┐
+│  ←   Main Stage   ⋮                                                      │
+│ ┌──────────────────────────────────────────────────────────┐       ▾    │
+│ │                                                          │            │
+│ │           YouTube IFrame 16:9 풀폭                       │            │
+│ │                                                          │            │
+│ └──────────────────────────────────────────────────────────┘            │
+│  🎵 Track name                                                          │
+│  🎧 DJ nickname                                                         │
+│  ❤ 0   👎 0   ⭐ 0                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+```
+┌─────────────────── Mode B: 재생 + collapsed ─────────────────────────────┐
+│  ←   Main Stage   ⋮                                                      │
+│ ┌────────┐                                                       ◂      │
+│ │ 80×45  │  🎵 Track name                                                │
+│ │  ▶     │  🎧 DJ nickname                                               │
+│ └────────┘                                                               │
+│  ❤ 0   👎 0   ⭐ 0                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+```
+┌─────────────────── Mode C: 비재생 (토글 hide) ───────────────────────────┐
+│  ←   Main Stage   ⋮                                                      │
+│ ┌──────────────────────────────────────────────────────────┐            │
+│ │                                                          │            │
+│ │              zZz... 지금 재생 중인 곡이 없어요             │            │
+│ │                       (검정 placeholder 16:9)              │            │
+│ └──────────────────────────────────────────────────────────┘            │
+│  (트랙메타 + 리액션 미표시, 또는 옅게)                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Mode D (비재생+collapsed) 불가능** — 비재생 시 expanded 강제.
+
+### 4.3 컴포넌트 트리
+
+```
+MobilePartyroomDisplayBoard (root, 'use client')
+├─ <header> 헤더 row (뒤로 · 룸이름 · ⋮)
+│   — chunk 2 그대로
+└─ <section className='display-area'>
+    ├─ VideoFrame                       ← 신규
+    │   ├─ YoutubePlayer (dynamic import)
+    │   │   — Mode A: 16:9 풀폭 (aspect-video)
+    │   │   — Mode B: 80×45 fixed
+    │   │   — Mode C: 미렌더, 대신 BlankPlaceholder
+    │   ├─ BlankPlaceholder (Mode C 만)
+    │   │   — 16:9 + zZz 아이콘 + "지금 재생 중인 곡이 없어요"
+    │   ├─ AutoplayGestureGate
+    │   │   — autoplayBlocked && playable && expanded 시 overlay
+    │   └─ ExpandToggle (Mode A·B 만, Mode C hide)
+    ├─ NowPlayingMeta (Mode A·B 각각 다른 배치)
+    │   — Mode A: 박스 아래 column
+    │   — Mode B: 박스 우측 row
+    └─ ActionButtons (리액션, chunk 2 그대로)
+```
+
+### 4.4 State 모델
+
+```tsx
+const [expanded, setExpanded] = useState(true); // 룸 입장마다 reset
+const [autoplayBlocked, setAutoplayBlocked] = useState(false);
+const [played, setPlayed] = useState(false);
+const [playerReady, setPlayerReady] = useState(false);
+
+const playbackActivated = useCurrentPartyroom((s) => s.playbackActivated);
+const playback = useCurrentPartyroom((s) => s.playback);
+const isPlaying = playbackActivated && !!playback?.linkId;
+
+// Mode 결정
+const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
+```
+
+### 4.5 YoutubePlayer 크기 동적 지정
+
+react-player/youtube 는 `width`/`height` prop 으로 크기 지정. Mode A·B 전환 시 prop 만 바꾸고 컴포넌트 unmount/remount 회피 (재생 끊김 방지).
+
+```tsx
+<YoutubePlayer
+  url={`https://www.youtube.com/watch?v=${playback.linkId}`}
+  playing={playerReady}
+  volume={muted ? 0 : volume}
+  muted={muted}
+  width={mode === 'A' ? '100%' : '80px'}
+  height={mode === 'A' ? '100%' : '45px'}
+  className='bg-black rounded' // hidden 클래스 절대 추가 X
+  onReady={onPlayerReady}
+  onStart={onStart}
+  onPlay={onPlay}
+  onPause={onPause}
+  config={config}
+/>
+```
+
+- `key` 에 `videoId`/`endTime` 포함 X (background tab autoplay 차단 회피, [[reference_frontend_playwright_debug]] 및 데스크탑 #341 결정 유지)
+- `playerClass` 에 `hidden` 절대 추가 X (ToS 가드)
+
+### 4.6 useAutoplayGestureGate hook
+
+데스크탑의 `useAutoResumeOnPause` 와 별개. 모바일 first-mount 시 autoplay 가 차단됐는지 감지하고 gesture gate UI 표시:
+
+```ts
+// Pseudo
+function useAutoplayGestureGate({ playerRef, playable }) {
+  const [autoplayBlocked, setAutoplayBlocked] = useState(false);
+  const [played, setPlayed] = useState(false);
+  const [playerReady, setPlayerReady] = useState(false);
+
+  // onPlay → played=true, autoplayBlocked=false
+  // onReady → playerReady=true, seekToLive
+  // 후 AUTOPLAY_DETECT_MS=1500ms 내 onPlay 없으면 autoplayBlocked=true
+
+  const handleGesturePlay = () => {
+    playerRef.current?.getInternalPlayer()?.playVideo?.();
+    setAutoplayBlocked(false);
+  };
+
+  return { autoplayBlocked, played, playerReady, handleGesturePlay /* setters */ };
+}
+```
+
+본 hook 은 데스크탑 video.component.tsx 의 ll. 73-153 에서 추출한 패턴. 데스크탑 코드는 미수정. 만약 미래에 데스크탑·모바일이 공통 hook 으로 통합되면 그건 별도 리팩토링 작업.
+
+## 5. ToS 보존 검증 포인트
+
+각 항목은 테스트로 회귀 가드 가능.
+
+| 가드 항목                                                                    | 검증 방법                                                         |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Mode A: YoutubePlayer width/height 가 '100%' 또는 16:9 비율의 풀폭           | 통합 테스트에서 mock react-player 의 width/height prop 단언       |
+| Mode B: YoutubePlayer width ≥ 80px, height ≥ 45px (보수 하한)                | 통합 테스트 단언                                                  |
+| Mode C: YoutubePlayer 미렌더 (재생 안 함 → IFrame 불요) — placeholder 박스만 | mode='C' 시 react-player mock 호출 0 회 단언                      |
+| 어떤 mode 에서도 `className` 에 `hidden` 토큰 없음                           | className 정규식 단언 (`expect(class).not.toMatch(/\bhidden\b/)`) |
+| 어떤 mode 에서도 `opacity-0`, `w-px`, `h-px`, `pointer-events-none` 없음     | className 정규식 단언                                             |
+| aria-hidden=true 없음 (screen reader 접근성도 보존)                          | DOM 속성 단언                                                     |
+
+## 6. 컴포넌트 책임 분리
+
+### 6.1 `VideoFrame`
+
+**책임**: 단일 root — 4 mode 중 하나를 렌더. ExpandToggle·BlankPlaceholder·YoutubePlayer·AutoplayGestureGate orchestration.
+
+**Props**:
+
+```ts
+interface VideoFrameProps {
+  isPlaying: boolean;
+  videoId: string | undefined;
+  expanded: boolean;
+  onToggleExpand: () => void;
+}
+```
+
+**Mode 분기**:
+
+- `!isPlaying || !videoId` → BlankPlaceholder (Mode C). Toggle hide.
+- `expanded` → YoutubePlayer 16:9 + Toggle ▾
+- `!expanded` → YoutubePlayer 80×45 + Toggle ◂
+
+### 6.2 `ExpandToggle`
+
+**책임**: 영상 우상단 ▾/◂ 토글. controlled.
+
+**Props**:
+
+```ts
+interface ExpandToggleProps {
+  expanded: boolean;
+  onToggle: () => void;
+}
+```
+
+**a11y**:
+
+- `<button>` + `aria-label={expanded ? '영상 가리기' : '영상 펼치기'}`
+- `aria-pressed={!expanded}` (collapsed=pressed state)
+- min-h-[44px] min-w-[44px] hit-area
+
+### 6.3 `BlankPlaceholder`
+
+**책임**: Mode C 의 16:9 검정 박스 + 안내 텍스트.
+
+**Props**: 없음 (i18n 키 inline).
+
+### 6.4 `NowPlayingMeta`
+
+**책임**: 트랙명·DJ·duration 텍스트 렌더. Mode A·B 가 같은 데이터를 다른 layout 으로.
+
+**Props**:
+
+```ts
+interface NowPlayingMetaProps {
+  layout: 'column' | 'row'; // A=column, B=row
+  trackName: string;
+  djNickname: string | null;
+  duration: string;
+}
+```
+
+## 7. 테스트 전략
+
+### 7.1 단위 테스트
+
+- `video-frame.component.test.tsx` (8 케이스)
+  - Mode A 렌더: YoutubePlayer 호출 (width=100%, height=100%), Toggle ▾, BlankPlaceholder 미렌더
+  - Mode B 렌더: YoutubePlayer width=80px height=45px, Toggle ◂
+  - Mode C 렌더: BlankPlaceholder visible, YoutubePlayer 미렌더, Toggle hide
+  - autoplayBlocked && expanded 시 gesture gate overlay 렌더, 클릭 시 playVideo() 호출
+  - ToS 가드: 모든 mode 에서 className 에 `hidden`/`opacity-0`/`w-px`/`h-px` 토큰 부재
+  - ToS 가드: Mode B 의 YoutubePlayer 가 width >= 80 & height >= 45 (정수 또는 px 문자열 파싱)
+- `expand-toggle.component.test.tsx` (4 케이스)
+  - aria-label expanded·collapsed 분기
+  - 클릭 시 onToggle 콜백
+  - aria-pressed 단언
+  - 44×44 hit-area class 단언
+- `use-autoplay-gesture-gate.hook.test.ts` (5 케이스)
+  - 초기 ready/played/blocked 모두 false
+  - onReady 호출 후 playerReady=true + seekToLive 호출
+  - 1500ms 내 onPlay 없으면 autoplayBlocked=true
+  - onPlay 호출 시 played=true, autoplayBlocked=false
+  - handleGesturePlay 가 internal playVideo() 호출
+
+### 7.2 통합 테스트
+
+- `partyroom-display-board.component.test.tsx` (기존 없음, 신규 6 케이스)
+  - 룸 mount 시 expanded=true default
+  - 토글 클릭 → collapsed (Mode B)
+  - 다시 클릭 → expanded (Mode A)
+  - playback null → Mode C, toggle hide
+  - playback 변경 후에도 expanded state 보존 (자동 expand 없음)
+  - 룸 unmount → 다시 mount 시 expanded=true reset (component-local state)
+
+### 7.3 헤드드 검증 (Playwright 사전 smoke)
+
+implementation 후 dev 서버 + Playwright mobile UA 로:
+
+- Mode A·B·C 각 mode 의 IFrame 가시 영역 ≥ 80×45 단언 (getComputedStyle).
+- ToS 가드: `getComputedStyle(iframe).visibility !== 'hidden' && opacity !== '0'`.
+- 토글 클릭 후 IFrame width 가 80px 로 변하는지 (CSS computed 측정).
+
+## 8. 스코프
+
+### IN
+
+- `widgets-mobile/partyroom-display-board` 본문 재설계
+- VideoFrame·ExpandToggle·BlankPlaceholder·NowPlayingMeta 신규 sibling parts
+- useAutoplayGestureGate 신규 hook
+- 데스크탑 `useUserPreferenceStore` (volume·muted) 재사용 (read-only)
+- 데스크탑 `Playback.getInitialSeek` 재사용 (read-only)
+- ToS 가드 회귀 테스트
+
+### OUT
+
+- 데스크탑 `widgets/partyroom-display-board/*` 변경 0
+- chunk 2 의 `ActionButtons` (리액션) 변경 0
+- chunk 3 의 탭·채팅·크루 변경 0
+- DJ 큐 (chunk 4)
+- lobby 카드 디자인 (별도 결정)
+- 사용자가 영상 일부분만 hide 하거나 mute toggle 추가 — v1 스코프 아님 (현 결정은 mute=userPreferenceStore 따라감)
+- userPreference 에 expanded 영구 저장 (사용자 결정: session reset)
+
+## 9. 위험 + 트레이드오프
+
+| 위험                                                                                                               | 완화                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Mode A 풀폭 IFrame 이 sticky-top 점유 → 채팅 영역 잠식 (iPhone SE 568px 등 small viewport 에서 메시지 4~5 visible) | 사용자가 collapse 토글로 80×45 Mode B 전환 → 채팅 영역 ~150px 확보                                                          |
+| react-player 의 width/height prop 변경이 internal player remount 유발할 가능성                                     | `key` 에 width/height 포함 X. width 만 prop 변경 → react-player 내부 div 리사이즈만 발동, IFrame 재로드 X. 헤드드 검증 필수 |
+| autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                          | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보                                                                |
+| Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                       | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이                  |
+| 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용                   | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선                                                                     |
+
+## 10. 마이그레이션 시나리오
+
+1. chunk 3 머지 → develop `feature/mobile-responsive-spec-3` 가 develop 으로 머지됨
+2. `feature/mobile-responsive-spec-3.1` 신규 브랜치 (origin/develop 기준 분기)
+3. chunk 3.1 plan 작성 (`docs/superpowers/plans/2026-XX-XX-mobile-display-board-tos-redesign.md`)
+4. plan-reviewer 통과 후 TDD 실행 (8~10 commits 예상)
+5. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지
+6. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**
+
+## 11. 관련
+
+- 선행 chunk:
+  - chunk 1 spec (`docs/superpowers/specs/2026-05-28-mobile-responsive-architecture-design.md`) — §3 chunk 분할, §4 모바일 layout 그림
+  - chunk 3 plan (`docs/superpowers/plans/2026-05-29-mobile-responsive-chunk3-chat-crews-tabs.md`)
+- 데스크탑 baseline (read-only 참조):
+  - `src/widgets/partyroom-display-board/ui/parts/video.component.tsx` (16:9 placeholder + autoplay gate)
+  - `src/widgets/partyroom-display-board/ui/parts/use-auto-resume-on-pause.hook.ts` (블루투스 polish, OUT)
+- GH 이슈: pfplay-web#340 (모바일 반응형)
+- 관련 메모리:
+  - [[feedback_pr_series_workflow]] (chunk 3.1 polish follow-up 패턴)
+  - [[reference_pfplay_web_local_dev_http_webpack]] (헤드드 검증 환경)
+  - [[reference_frontend_playwright_debug]] (Playwright headed measure)
+  - [[feedback_korean_issue_commit_pr]]
+  - [[feedback_autonomous_execution]]
+  - [[feedback_elegant_no_code_dirtying]]
+  - [[project_mobile_responsive_chunk3_plan_ready]] (chunk 3 entry 메모리)
+
+## 12. 다음
+
+1. spec-document-reviewer 루프 (이슈 발견 시 fix 후 재차)
+2. 사용자 spec 리뷰
+3. 통과 시 writing-plans skill 으로 plan 작성

--- a/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
@@ -180,6 +180,34 @@ const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
 - Mode C → A/B 복귀 시 (videoId 재할당) `expanded` 의 마지막 사용자 선택 그대로 → Mode A 또는 B 직접 진입.
 - **Mode C 진입 시 `expanded` 상태는 사용자에게 surfacing 안 함** (다음 재생 시 자동 복귀, 별도 indicator 없음). screen reader 도 Mode C 의 BlankPlaceholder 만 인식.
 
+**Hook 호출 지점 결정 (reviewer 3차 #1)**:
+
+`useAutoplayGestureGate` 는 **`MobilePartyroomDisplayBoard` 루트에서 1회 호출**. AutoplayGestureGate (VideoFrame 자식) 와 TapToPlayButton (NowPlayingMeta row 의 sibling) 양쪽 모두 동일 state 를 root → props 로 받음. 이 결정으로 §6.5.2 의 single source of truth 보장.
+
+```tsx
+// MobilePartyroomDisplayBoard 본문 (의사 코드)
+const [expanded, setExpanded] = useState(true);
+const playerRef = useRef<TReactPlayer | null>(null);
+const gate = useAutoplayGestureGate({ playerRef, playable: isPlaying, videoId });
+//    gate = { autoplayBlocked, played, playerReady, handleGesturePlay, onReady, onStart, onPlay, onPause }
+
+return (
+  <header />
+  <VideoFrame
+    videoId={videoId}
+    expanded={expanded}
+    onToggleExpand={() => setExpanded((v) => !v)}
+    playerRef={playerRef}
+    gate={gate} // ← autoplay state + handlers down
+  />
+  <NowPlayingRow>
+    <NowPlayingMeta layout={mode === 'A' ? 'column' : 'row'} … />
+    {mode === 'B' && <TapToPlayButton autoplayBlocked={gate.autoplayBlocked && !gate.played} onTap={gate.handleGesturePlay} />}
+  </NowPlayingRow>
+  <ActionButtons />
+);
+```
+
 ### 4.5 YoutubePlayer 사이징 — wrapper 기반 (remount 회피)
 
 reviewer 1차 이슈 #1 + #4 반영. react-player/youtube 의 width/height prop 변경이 IFrame remount 를 유발할 가능성을 차단:
@@ -317,18 +345,31 @@ export const AUTOPLAY_DETECT_MS = 1500;
 
 **책임**: 단일 root — 3 mode 중 하나를 렌더. ExpandToggle·BlankPlaceholder·YoutubePlayer·AutoplayGestureGate orchestration.
 
-**Props** (reviewer 1차 #8 — derive 단일화):
+**Props** (reviewer 1차 #8 + 3차 #1 — derive 단일화 + autoplay state injection):
 
 ```ts
 interface VideoFrameProps {
   videoId: string | null; // null = Mode C 강제
   expanded: boolean;
   onToggleExpand: () => void;
+  playerRef: RefObject<TReactPlayer | null>;
+  gate: {
+    autoplayBlocked: boolean;
+    played: boolean;
+    playerReady: boolean;
+    handleGesturePlay: () => void;
+    onReady: (player: TReactPlayer) => void;
+    onStart: () => void;
+    onPlay: () => void;
+    onPause: () => void;
+  };
 }
 
 // VideoFrame 내부 derive
 const mode: 'A' | 'B' | 'C' = videoId === null ? 'C' : expanded ? 'A' : 'B';
 ```
+
+→ **VideoFrame 은 hook 자체를 호출하지 않음**. Root (`MobilePartyroomDisplayBoard`) 가 `useAutoplayGestureGate` 호출 후 `gate` 객체를 props 로 주입. TapToPlayButton 도 동일 `gate` 를 받아 single source of truth 보장 (§4.4 결정).
 
 **Mode 분기**:
 
@@ -375,6 +416,20 @@ interface NowPlayingMetaProps {
   duration: string;
 }
 ```
+
+**Mode B 의 row 컨테이너 (NowPlayingRow)**:
+
+NowPlayingMeta + TapToPlayButton 을 같은 row 로 감싸는 wrapper. **이 row 컨테이너에 `min-h-[44px]` 가 강제** 되어야 TapToPlayButton 의 iOS HIG 44×44 hit-area 가 실제로 확보됨 (reviewer 3차 #2). NowPlayingMeta 단독 텍스트 line-height ~21px 라 row 가 자동 사이징되면 hit-area 미달.
+
+```tsx
+// MobilePartyroomDisplayBoard 본문 내
+<div className='flex items-center min-h-[44px] px-3 gap-3'>  {/* NowPlayingRow */}
+  <NowPlayingMeta layout={mode === 'A' ? 'column' : 'row'} … />
+  {mode === 'B' && <TapToPlayButton autoplayBlocked={gate.autoplayBlocked && !gate.played} onTap={gate.handleGesturePlay} />}
+</div>
+```
+
+§7.3 Playwright 가 row container 의 boundingBox().height >= 44 단언으로 가드.
 
 ### 6.5 `AutoplayGestureGate` + `TapToPlayButton`
 
@@ -437,6 +492,8 @@ interface TapToPlayButtonProps {
   - autoplayBlocked && Mode B 시 AutoplayGestureGate 미렌더, **TapToPlayButton** 이 NowPlayingMeta row 옆 렌더. 클릭 시 동일 handleGesturePlay 호출.
   - **Mode B + autoplayBlocked → Mode A toggle 시 GestureGate overlay 즉시 visible** (state single source 검증).
   - **wrapperClass()=Mode B 의 정적 리터럴 'w-[80px] h-[45px] ...' 단언** (Tailwind JIT 정적 scan 안전 가드).
+  - **JS 상수 ↔ wrapperClass 정적 리터럴 sync 가드**: `expect(wrapperClass('B')).toContain(\`w-[${COLLAPSED_VIDEO_WIDTH}px]\`)`+`expect(wrapperClass('B')).toContain(\`h-[${COLLAPSED_VIDEO_HEIGHT}px]\`)`. 두 값 중 하나만 변경되면 fail (테스트 내 template literal 은 Tailwind JIT 와 무관).
+  - **Mode A→C 전환: YoutubePlayer mock unmount** (B→C 대칭 가드).
   - **ToS 가드 (회귀)**: 모든 mode 에서 wrapper className 에 `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 토큰 부재.
   - **ToS 가드**: video-wrapper testid 가진 element 에 `aria-hidden='true'` 직접 부착 안 됨.
   - Props 안전: `videoId=null && expanded=true/false` → Mode C 강제 진입 (Mode A/B 진입 안 됨).
@@ -521,7 +578,7 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 | 3   | autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                     | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보. Mode B 에서도 tap-to-play 경로 (§6.5) 제공.                                                                                                                                                                                                     |
 | 4   | Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                  | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이. Playwright headed test 가 항상 ≥ 80×45 가드.                                                                                                                                                      |
 | 5   | **`useAutoplayGestureGate` (mobile) 와 데스크탑 `video.component.tsx` inline 패턴 의 코드 중복 → 향후 drift** | **본 chunk 에서는 코드 dedup 미실행 (acknowledge + 추적 only)**. (a) `AUTOPLAY_DETECT_MS` 상수 mobile hook 에서 export — 데스크탑이 import 하기 전까지 dormant. (b) chunk 3.1 머지 직후 GH 이슈 신규 등록 — "데스크탑·모바일 autoplay hook 통합 refactor". 본 spec mitigation = 후속 트래킹, drift 해소 아님. |
-| 6   | **sticky-top 높이 변화 (Mode A↔B, ~210px↔80px) 가 chunk 3 탭 컨테이너 scroll anchor 흔들기**                | (a) chunk 3 tabs 컨테이너가 이미 `flex-1 min-h-0` 라 layout shift 흡수. (b) chat scroll 은 `useChatMessagesScrollManager` 의 bottom-pin 으로 자연 복귀. (c) §7.3 Playwright "Toggle 클릭 후 chat scroll offset 변화 ≤ tolerance" 가 회귀 가드.                                                                |
+| 6   | **sticky-top 높이 변화 (Mode A↔B, ~210px↔80px) 가 chunk 3 탭 컨테이너 scroll anchor 흔들기**                | (a) chunk 3 tabs 컨테이너가 이미 `flex-1 min-h-0` 라 layout shift 흡수. (b) chat scroll 은 `useChatMessagesScrollManager` 의 bottom-pin 으로 자연 복귀. (c) §7.3 Playwright "Toggle 클릭 후 chat scroll offset 변화 ≤ `CHAT_SCROLL_TOLERANCE_PX` (§7.3, spec-locked 10px)" 가 회귀 가드.                      |
 | 7   | 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용              | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선.                                                                                                                                                                                                                                                      |
 | 8   | maintenance 모드 / system-announcement WS overlay 와의 z-index 충돌                                           | display-board 의 sticky-top z 는 chunk 2 의 `z-20`. maintenance overlay 는 더 높은 z (chunk 1·2 의 `WS overlay` 는 일반적으로 `z-50`). 본 spec 은 z 값 미변경. 헤드드 회귀 가드는 §7.3 외 별도 — 향후 모바일 maintenance scenario 가 정의될 때 verify.                                                        |
 | 9   | Playwright headed test 의 CI 추가 비용·flakiness                                                              | 단일 mobile UA + 1~2 viewport. 별도 vercel-preview-e2e workflow 의 concurrency 잠금 ([[reference_e2e_preview_alias_race]]) 활용. flakiness 발생 시 단독 재실행으로 격리 가능 여부 진단 절차 미리 plan 에 명시.                                                                                                |
@@ -532,11 +589,12 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 2. `feature/mobile-responsive-spec-3.1` 신규 브랜치 (origin/develop 기준 분기, [[feedback_branch_from_origin_develop]]).
 3. chunk 3.1 plan 작성 (`docs/superpowers/plans/2026-XX-XX-mobile-display-board-tos-redesign.md`).
 4. plan-reviewer 통과 후 TDD 실행 (10~12 commits 예상; reviewer 권장 spike 포함).
-5. Playwright headed mandatory test 가 CI 에 추가됐는지 확인.
-6. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지.
-7. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**.
-8. **Escalation 규칙**: chunk 3 가 chunk 3.1 머지 전에 `release/` 또는 `main` 에 도달할 경우 **즉시 escalate** — chunk 3 단독 prod 진입은 1px×1px IFrame ToS 위반 그대로 ship. chunk 3 + chunk 3.1 은 단일 release 묶음으로 ship 한다는 release-engineering invariant 잠금.
-9. (post-merge) GH 이슈 신규 등록 — "데스크탑·모바일 autoplay gesture-gate hook 통합 refactor" (§9 risk #5).
+5. Playwright headed mandatory test 가 CI 에 추가됐는지 확인 (`.github/workflows/vercel-preview-e2e.yml`).
+6. **사용자 GitHub UI 작업** (단발, chunk 3.1 PR 머지 전 필수): Settings → Branches → `develop` / `release` 의 required check 에 `display-board.tos` job 추가. 본 단계 누락 시 §3 row 15 의 mandatory gate 가 paper-only 가 됨. PR 본문 체크리스트에 명시 — 사용자가 확인 후 체크.
+7. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지.
+8. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**.
+9. **Escalation 규칙**: chunk 3 가 chunk 3.1 머지 전에 `release/` 또는 `main` 에 도달할 경우 **즉시 escalate** — chunk 3 단독 prod 진입은 1px×1px IFrame ToS 위반 그대로 ship. chunk 3 + chunk 3.1 은 단일 release 묶음으로 ship 한다는 release-engineering invariant 잠금.
+10. (post-merge) GH 이슈 신규 등록 — "데스크탑·모바일 autoplay gesture-gate hook 통합 refactor" (§9 risk #5).
 
 ## 11. 관련
 

--- a/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
@@ -54,21 +54,24 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 
 ## 3. 결정 잠금 (brainstorming 산출물)
 
-| #   | 항목                 | 결정                                                                                                                                          |
-| --- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | chunk 구분           | chunk 3 머지 직후 chunk 3.1 후속 PR (atomic, develop 진입)                                                                                    |
-| 2   | 재생 중 default      | **Mode A** — 16:9 풀폭 YoutubePlayer + 트랙메타                                                                                               |
-| 3   | 비재생 default       | **Mode C** — 16:9 검정 placeholder 박스 (데스크탑 시각 연속성)                                                                                |
-| 4   | 축소 토글            | 우상단 ▾ 아이콘 overlay. 클릭 시 Mode A↔Mode B 전환                                                                                          |
-| 5   | Collapsed 크기       | **80×45 px** (iOS HIG 44×44 hit-area 근접, ToS 보수) + 트랙명·DJ 가로 row                                                                     |
-| 6   | 비재생 시 토글       | hide (가릴 영상 없음) — 항상 Mode C                                                                                                           |
-| 7   | State persistence    | 룸 mount 시 `expanded=true` 1회 init. component-local `useState`. **트랙 변경·Mode C 진입 모두 `expanded` 미수정 (사용자 마지막 선택 보존)**. |
-| 8   | autoplay polish      | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉). hook 입력에 `videoId` 포함 → 트랙 변경 시 차단 detect 재armed.             |
-| 9   | 데스크탑 격리        | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                                                                           |
-| 10  | lobby 카드 디테일    | 본 spec OUT — 별도 후속 결정                                                                                                                  |
-| 11  | i18n inline 한국어   | 본 chunk 도 chunk 2·3 의 inline 한국어 정책 유지. **chunk 5 catch-up 에서 모바일 i18n 키 일괄 이주 시 함께 처리**.                            |
-| 12  | YoutubePlayer 사이징 | **부모 wrapper 가 size 결정, YoutubePlayer 는 `width='100%' height='100%'` 고정** (prop 변경에 의한 remount 위험 회피).                       |
-| 13  | YoutubePlayer `key`  | `key={`video-${playerReady}-${played}`}` — 데스크탑과 동일. videoId/endTime/mode 미포함.                                                      |
+| #   | 항목                 | 결정                                                                                                                                                                    |
+| --- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | chunk 구분           | chunk 3 머지 직후 chunk 3.1 후속 PR (atomic, develop 진입)                                                                                                              |
+| 2   | 재생 중 default      | **Mode A** — 16:9 풀폭 YoutubePlayer + 트랙메타                                                                                                                         |
+| 3   | 비재생 default       | **Mode C** — 16:9 검정 placeholder 박스 (데스크탑 시각 연속성)                                                                                                          |
+| 4   | 축소 토글            | 우상단 ▾ 아이콘 overlay. 클릭 시 Mode A↔Mode B 전환                                                                                                                    |
+| 5   | Collapsed 크기       | **80×45 px** (iOS HIG 44×44 hit-area 근접, ToS 보수) + 트랙명·DJ 가로 row                                                                                               |
+| 6   | 비재생 시 토글       | hide (가릴 영상 없음) — 항상 Mode C                                                                                                                                     |
+| 7   | State persistence    | 룸 mount 시 `expanded=true` 1회 init. component-local `useState`. **트랙 변경·Mode C 진입 모두 `expanded` 미수정 (사용자 마지막 선택 보존)**.                           |
+| 8   | autoplay polish      | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉). hook 입력에 `videoId` 포함 → 트랙 변경 시 차단 detect 재armed.                                       |
+| 9   | 데스크탑 격리        | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                                                                                                     |
+| 10  | lobby 카드 디테일    | 본 spec OUT — 별도 후속 결정                                                                                                                                            |
+| 11  | i18n inline 한국어   | 본 chunk 도 chunk 2·3 의 inline 한국어 정책 유지. **chunk 5 catch-up 에서 모바일 i18n 키 일괄 이주 시 함께 처리**.                                                      |
+| 12  | YoutubePlayer 사이징 | **부모 wrapper 가 size 결정, YoutubePlayer 는 `width='100%' height='100%'` 고정** (prop 변경에 의한 remount 위험 회피).                                                 |
+| 13  | YoutubePlayer `key`  | `key={`video-${playerReady}-${played}`}` — 데스크탑과 동일. videoId/endTime/mode 미포함.                                                                                |
+| 14  | Wrapper class 형식   | **정적 Tailwind class 만 사용** — `w-[${var}px]` 같은 runtime template 금지 (JIT 가 static scan 이라 생성 안 됨). 상수는 JS export 만 Playwright assertion 용.          |
+| 15  | Playwright CI 등록   | `.github/workflows/vercel-preview-e2e.yml` 의 mandatory job 으로 `display-board.tos.spec.ts` 추가 + branch protection required check 등록 (사용자 단발 GitHub UI 조작). |
+| 16  | Mode C UX            | Mode C 진입 시 `expanded` 상태를 사용자에게 surfacing 안 함 (다음 재생 시 자동 복귀, 별도 indicator 없음).                                                              |
 
 ## 4. Architecture
 
@@ -137,14 +140,15 @@ MobilePartyroomDisplayBoard (root, 'use client')
 │   — chunk 2 그대로
 └─ <section data-testid='display-area'>
     ├─ VideoFrame                       ← 신규
-    │   ├─ <div className='video-wrapper'> 부모 wrapper (사이즈 결정)
-    │   │   — Mode A: 'aspect-video w-full'
-    │   │   — Mode B: 'w-20 h-[45px] shrink-0'
-    │   │   — Mode C: 'aspect-video w-full bg-black' (YoutubePlayer 미렌더, BlankPlaceholder 자리)
+    │   ├─ <div data-testid='video-wrapper' className=wrapperClass(mode)> 부모 wrapper
+    │   │   — Mode A: 'aspect-video w-full bg-black rounded'  (정적 static class — Tailwind JIT 안전)
+    │   │   — Mode B: 'w-[80px] h-[45px] shrink-0 bg-black rounded'  (정적, w-[80px]·h-[45px] arbitrary 정적 값)
+    │   │   — Mode C: 'aspect-video w-full bg-black rounded'  (YoutubePlayer 미렌더, BlankPlaceholder 자리)
     │   ├─ YoutubePlayer (dynamic import, Mode A·B 만 mount)
     │   │   — width='100%' height='100%' 고정. 부모 wrapper class 가 실 크기 결정.
     │   ├─ BlankPlaceholder (Mode C 만)
-    │   ├─ AutoplayGestureGate (Mode A 만 overlay — Mode B 80×45 에는 게이트 부착 안 함)
+    │   ├─ AutoplayGestureGate (Mode A 만 overlay — Mode B 는 TapToPlayButton 으로 release)
+    │   ├─ TapToPlayButton (Mode B + autoplayBlocked 시만 visible. NowPlayingMeta row 옆 44×44 hit-area)
     │   └─ ExpandToggle (Mode A·B 만 visible, Mode C 미렌더)
     ├─ NowPlayingMeta (Mode A·B 별 layout)
     │   — Mode A: 'column' (박스 아래 column)
@@ -174,6 +178,7 @@ const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
 - `setExpanded` 호출 지점 = **사용자 토글 클릭 이벤트 1곳뿐**. videoId 변화·track change·Mode C 진입 시 `expanded` 자동 변환 X.
 - Mode C 진입은 `videoId === null` 의 derived state. `expanded` 자체는 그대로 보존.
 - Mode C → A/B 복귀 시 (videoId 재할당) `expanded` 의 마지막 사용자 선택 그대로 → Mode A 또는 B 직접 진입.
+- **Mode C 진입 시 `expanded` 상태는 사용자에게 surfacing 안 함** (다음 재생 시 자동 복귀, 별도 indicator 없음). screen reader 도 Mode C 의 BlankPlaceholder 만 인식.
 
 ### 4.5 YoutubePlayer 사이징 — wrapper 기반 (remount 회피)
 
@@ -210,18 +215,22 @@ return (
   </div>
 );
 
-function wrapperSizeClass(mode: 'A' | 'B' | 'C'): string {
+// **반드시 정적 string 리터럴 반환** — Tailwind JIT 가 source 정적 scan 만 함.
+// `w-[${N}px]` 같은 runtime template 은 생성되지 않아 wrapper 0×0 → ToS 위반 재발.
+function wrapperClass(mode: 'A' | 'B' | 'C'): string {
   switch (mode) {
     case 'A':
-      return 'aspect-video w-full';
+      return 'aspect-video w-full bg-black rounded';
     case 'B':
-      return `w-[${COLLAPSED_VIDEO_WIDTH}px] h-[${COLLAPSED_VIDEO_HEIGHT}px] shrink-0`;
+      return 'w-[80px] h-[45px] shrink-0 bg-black rounded';
     case 'C':
-      return 'aspect-video w-full bg-black';
+      return 'aspect-video w-full bg-black rounded';
   }
 }
 
-export const COLLAPSED_VIDEO_WIDTH = 80; // ToS 하한
+// JS 상수는 **Playwright headed test 의 boundingBox assertion 용 documentary 값**.
+// 변경 시 wrapperClass() 의 정적 리터럴과 동기화 필수 (단위 테스트가 두 값 일치를 가드).
+export const COLLAPSED_VIDEO_WIDTH = 80;
 export const COLLAPSED_VIDEO_HEIGHT = 45;
 ```
 
@@ -367,13 +376,51 @@ interface NowPlayingMetaProps {
 }
 ```
 
-### 6.5 `AutoplayGestureGate`
+### 6.5 `AutoplayGestureGate` + `TapToPlayButton`
 
-**책임**: Mode A 의 IFrame 영역 위 overlay. autoplay 차단 시 visible, 클릭 시 `handleGesturePlay` 호출.
+#### 6.5.1 `AutoplayGestureGate`
 
-**Mode B (80×45) 에서는 게이트 자체 미렌더** — 80×45 는 tap target 으로 좁고, 사용자가 Mode B 로 전환했다는 건 audio 청취 의도. autoplay 차단된 채 Mode B 일 때는 Mode A 로 자동 복귀 X (사용자 의도 보존), 단 audio 안 나는 상태 사용자 인지 가능.
+**책임**: Mode A 의 IFrame 영역 위 full overlay. `autoplayBlocked && played===false` 시 visible, 클릭 시 `handleGesturePlay` 호출.
 
-대신 Mode B 의 NowPlayingMeta 옆에 작은 ▶ 버튼 (tap-to-play) 추가 — Mode B 에서도 gesture release 경로 제공.
+**Props**:
+
+```ts
+interface AutoplayGestureGateProps {
+  onClick: () => void;
+}
+```
+
+Mode B 에서는 미렌더 (80×45 영역 위 overlay 가 가독성·접근성 미흡).
+
+#### 6.5.2 `TapToPlayButton`
+
+**책임**: Mode B 의 release 경로. NowPlayingMeta row 옆 sibling 으로 렌더. 동일 `autoplayBlocked && !played` 조건일 때 visible.
+
+**Props**:
+
+```ts
+interface TapToPlayButtonProps {
+  autoplayBlocked: boolean;
+  onTap: () => void; // = AutoplayGestureGate 와 동일한 handleGesturePlay
+}
+```
+
+**a11y / 사이징**:
+
+- `<button>` + `aria-label='재생'`
+- min-h-[44px] min-w-[44px] hit-area (NowPlayingMeta row 의 높이 ≥ 44px 확보 — Mode B 의 80×45 영상 박스보다 row 자체는 더 높음)
+- visible 시 ▶ 아이콘
+
+**State 공유 보장**:
+
+- AutoplayGestureGate 와 TapToPlayButton 은 **동일 `useAutoplayGestureGate` hook 의 single source of truth**.
+- 사용자가 Mode B 에서 autoplayBlocked=true 인 채 Mode A 로 toggle → Mode A 의 GestureGate 가 즉시 visible (state 가 동일).
+- 어느 쪽이든 tap → `handleGesturePlay` → `setAutoplayBlocked(false)` + `playVideo()` → played=true → 두 control 모두 hide.
+
+#### 6.5.3 owner 명시
+
+- VideoFrame 의 children 순서: `[BlankPlaceholder OR YoutubePlayer] → AutoplayGestureGate (Mode A 만) → ExpandToggle (Mode A·B 만)`.
+- TapToPlayButton 은 VideoFrame 의 sibling 으로 NowPlayingMeta row 안에 렌더. (즉 `MobilePartyroomDisplayBoard` 가 NowPlayingMeta + TapToPlayButton 을 같은 row 로 wrapping.)
 
 ## 7. 테스트 전략
 
@@ -387,7 +434,9 @@ interface NowPlayingMetaProps {
   - Mode B→C 전환: YoutubePlayer mock unmount 단언.
   - Mode C→A 전환: YoutubePlayer remount.
   - autoplayBlocked && Mode A 시 gesture gate overlay 렌더, 클릭 시 playVideo() 호출.
-  - autoplayBlocked && Mode B 시 gate 미렌더, NowPlayingMeta 옆 ▶ tap-to-play 렌더.
+  - autoplayBlocked && Mode B 시 AutoplayGestureGate 미렌더, **TapToPlayButton** 이 NowPlayingMeta row 옆 렌더. 클릭 시 동일 handleGesturePlay 호출.
+  - **Mode B + autoplayBlocked → Mode A toggle 시 GestureGate overlay 즉시 visible** (state single source 검증).
+  - **wrapperClass()=Mode B 의 정적 리터럴 'w-[80px] h-[45px] ...' 단언** (Tailwind JIT 정적 scan 안전 가드).
   - **ToS 가드 (회귀)**: 모든 mode 에서 wrapper className 에 `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 토큰 부재.
   - **ToS 가드**: video-wrapper testid 가진 element 에 `aria-hidden='true'` 직접 부착 안 됨.
   - Props 안전: `videoId=null && expanded=true/false` → Mode C 강제 진입 (Mode A/B 진입 안 됨).
@@ -417,6 +466,7 @@ interface NowPlayingMetaProps {
   - **Mode B → playback null → Mode C → playback 재할당 → 여전히 Mode B** (사용자 collapse 유지).
   - 룸 unmount → 다시 mount 시 expanded=true reset (component-local state).
   - **트랙 변경 시 autoplay re-arm**: videoId 변경 + 1500ms 후 autoplayBlocked=true 단언 (Mode A 인데 autoplay 다시 차단된 케이스 시뮬레이션).
+  - **Mode C → playback 재할당 (Mode A 또는 B) → onReady 후 1500ms 내 onPlay 없으면 autoplayBlocked=true → 적절한 release control 렌더** (cross-mode mount 후 autoplay re-arm 보장 — 룸 mount 후 첫 트랙 패턴).
 
 ### 7.3 Playwright 헤드드 테스트 (**mandatory CI**)
 
@@ -428,7 +478,7 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
   - Mode A 진입: `boundingBox()` 가 viewport 안에 있음 (off-screen 좌표 아님).
   - Toggle 클릭 → Mode B: width === 80, height === 45 (정확값), IFrame 여전히 visible.
   - Toggle 두 번째 클릭 → Mode A 복귀: 동일 IFrame element (selector 안정성) → remount 안 됨 검증.
-  - **sticky-top 높이 변화 시 chat scroll position 보존**: 채팅 탭 스크롤을 위로 올려둔 상태에서 Toggle 클릭 → chat scroll offset 변화 ≤ tolerance (~10px 허용).
+  - **sticky-top 높이 변화 시 chat scroll position 보존**: 채팅 탭 스크롤을 위로 올려둔 상태에서 Toggle 클릭 → chat scroll offset 변화 ≤ `CHAT_SCROLL_TOLERANCE_PX = 10` (sub-pixel rounding + 1 line-height jitter). **본 상수는 spec-locked — 회피용 상향 금지, 변경 시 별도 spec 갱신**.
   - Mode C (playback null mock or 룸 입장 직후 첫 트랙 전): BlankPlaceholder visible, IFrame element 미존재.
 
 ### 7.4 viewport / 환경 매트릭스 (Playwright)
@@ -448,7 +498,7 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 - 데스크탑 `useUserPreferenceStore` (volume·muted) 재사용 (read-only import)
 - 데스크탑 `Playback.getInitialSeek` 재사용 (read-only import)
 - ToS 가드 회귀 테스트 (3-layer: unit + integration + Playwright headed)
-- Playwright headed test 를 CI 의 mandatory 단계로 등록 (또는 stg vercel-preview-e2e workflow 에 추가)
+- `display-board.tos.spec.ts` 를 **`.github/workflows/vercel-preview-e2e.yml` 의 mandatory job 으로 등록**. 사용자 단발 GitHub UI 조작으로 branch protection 의 required check 에 추가 (chunk 3.1 머지 전 사용자가 확인). "또는" alternative 없음 — 단일 통합 경로.
 
 ### OUT
 
@@ -464,17 +514,17 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 
 ## 9. 위험 + 트레이드오프
 
-| #   | 위험                                                                                                          | 완화                                                                                                                                                                                                                                                           |
-| --- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Mode A 풀폭 IFrame 이 sticky-top 점유 → 채팅 영역 잠식 (iPhone SE 568px 등 small viewport 메시지 4~5 visible) | 사용자가 collapse 토글로 80×45 Mode B 전환 → 채팅 영역 ~150px 확보                                                                                                                                                                                             |
-| 2   | react-player 의 width/height prop 변경 시 IFrame remount 위험                                                 | **해결됨** — §4.5 wrapper 기반 사이징 (YoutubePlayer width/height 항상 '100%' 고정, 부모 div Tailwind class 만 교체). Mode A↔B 전환 시 IFrame 자체 stability 유지. Playwright `display-board.tos.spec.ts` 의 "Toggle 두 번 클릭 → same element" 가 회귀 가드. |
-| 3   | autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                     | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보. Mode B 에서도 tap-to-play 경로 (§6.5) 제공.                                                                                                                                                      |
-| 4   | Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                  | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이. Playwright headed test 가 항상 ≥ 80×45 가드.                                                                                                       |
-| 5   | **`useAutoplayGestureGate` (mobile) 와 데스크탑 `video.component.tsx` inline 패턴 의 코드 중복 → 향후 drift** | (a) `AUTOPLAY_DETECT_MS` 상수는 mobile hook 에서 export. 향후 데스크탑이 import 하면 첫 단계 단일화. (b) **chunk 3.1 머지 직후 GH 이슈 신규 등록 — "데스크탑·모바일 autoplay hook 통합 (refactor)"**. PR 본문에 issue ref 포함.                                |
-| 6   | **sticky-top 높이 변화 (Mode A↔B, ~210px↔80px) 가 chunk 3 탭 컨테이너 scroll anchor 흔들기**                | (a) chunk 3 tabs 컨테이너가 이미 `flex-1 min-h-0` 라 layout shift 흡수. (b) chat scroll 은 `useChatMessagesScrollManager` 의 bottom-pin 으로 자연 복귀. (c) §7.3 Playwright "Toggle 클릭 후 chat scroll offset 변화 ≤ tolerance" 가 회귀 가드.                 |
-| 7   | 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용              | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선.                                                                                                                                                                                                       |
-| 8   | maintenance 모드 / system-announcement WS overlay 와의 z-index 충돌                                           | display-board 의 sticky-top z 는 chunk 2 의 `z-20`. maintenance overlay 는 더 높은 z (chunk 1·2 의 `WS overlay` 는 일반적으로 `z-50`). 본 spec 은 z 값 미변경. 헤드드 회귀 가드는 §7.3 외 별도 — 향후 모바일 maintenance scenario 가 정의될 때 verify.         |
-| 9   | Playwright headed test 의 CI 추가 비용·flakiness                                                              | 단일 mobile UA + 1~2 viewport. 별도 vercel-preview-e2e workflow 의 concurrency 잠금 ([[reference_e2e_preview_alias_race]]) 활용. flakiness 발생 시 단독 재실행으로 격리 가능 여부 진단 절차 미리 plan 에 명시.                                                 |
+| #   | 위험                                                                                                          | 완화                                                                                                                                                                                                                                                                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Mode A 풀폭 IFrame 이 sticky-top 점유 → 채팅 영역 잠식 (iPhone SE 568px 등 small viewport 메시지 4~5 visible) | 사용자가 collapse 토글로 80×45 Mode B 전환 → 채팅 영역 ~150px 확보                                                                                                                                                                                                                                            |
+| 2   | react-player 의 width/height prop 변경 시 IFrame remount 위험                                                 | **해결됨** — §4.5 wrapper 기반 사이징 (YoutubePlayer width/height 항상 '100%' 고정, 부모 div Tailwind class 만 교체). Mode A↔B 전환 시 IFrame 자체 stability 유지. Playwright `display-board.tos.spec.ts` 의 "Toggle 두 번 클릭 → same element" 가 회귀 가드.                                                |
+| 3   | autoplay gesture gate UX 가 모바일에 처음 도입 → 새로고침·shortlink 진입 사용자 경험 변화                     | 데스크탑 baseline 검증된 패턴 — 모바일도 동일 UX 일관성 확보. Mode B 에서도 tap-to-play 경로 (§6.5) 제공.                                                                                                                                                                                                     |
+| 4   | Mode B 의 80×45 가 작아 YouTube ToS 향후 갱신 시 위반 가능성                                                  | 픽셀 상수 분리 (`COLLAPSED_VIDEO_WIDTH = 80`, `COLLAPSED_VIDEO_HEIGHT = 45`) → 향후 96×54 등으로 조정 용이. Playwright headed test 가 항상 ≥ 80×45 가드.                                                                                                                                                      |
+| 5   | **`useAutoplayGestureGate` (mobile) 와 데스크탑 `video.component.tsx` inline 패턴 의 코드 중복 → 향후 drift** | **본 chunk 에서는 코드 dedup 미실행 (acknowledge + 추적 only)**. (a) `AUTOPLAY_DETECT_MS` 상수 mobile hook 에서 export — 데스크탑이 import 하기 전까지 dormant. (b) chunk 3.1 머지 직후 GH 이슈 신규 등록 — "데스크탑·모바일 autoplay hook 통합 refactor". 본 spec mitigation = 후속 트래킹, drift 해소 아님. |
+| 6   | **sticky-top 높이 변화 (Mode A↔B, ~210px↔80px) 가 chunk 3 탭 컨테이너 scroll anchor 흔들기**                | (a) chunk 3 tabs 컨테이너가 이미 `flex-1 min-h-0` 라 layout shift 흡수. (b) chat scroll 은 `useChatMessagesScrollManager` 의 bottom-pin 으로 자연 복귀. (c) §7.3 Playwright "Toggle 클릭 후 chat scroll offset 변화 ≤ tolerance" 가 회귀 가드.                                                                |
+| 7   | 데스크탑 `Video.component.tsx` 의 `useAutoResumeOnPause` (블루투스 이어폰 제거 등) 모바일 미적용              | 본 spec OUT — chunk 4 또는 별도. 데스크탑 baseline 우선.                                                                                                                                                                                                                                                      |
+| 8   | maintenance 모드 / system-announcement WS overlay 와의 z-index 충돌                                           | display-board 의 sticky-top z 는 chunk 2 의 `z-20`. maintenance overlay 는 더 높은 z (chunk 1·2 의 `WS overlay` 는 일반적으로 `z-50`). 본 spec 은 z 값 미변경. 헤드드 회귀 가드는 §7.3 외 별도 — 향후 모바일 maintenance scenario 가 정의될 때 verify.                                                        |
+| 9   | Playwright headed test 의 CI 추가 비용·flakiness                                                              | 단일 mobile UA + 1~2 viewport. 별도 vercel-preview-e2e workflow 의 concurrency 잠금 ([[reference_e2e_preview_alias_race]]) 활용. flakiness 발생 시 단독 재실행으로 격리 가능 여부 진단 절차 미리 plan 에 명시.                                                                                                |
 
 ## 10. 마이그레이션 시나리오
 
@@ -485,7 +535,8 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 5. Playwright headed mandatory test 가 CI 에 추가됐는지 확인.
 6. PR 생성 (한글 [[feedback_korean_issue_commit_pr]]) → CI green → 머지.
 7. release/main 까지 chunk 3 와 묶음 prod ship — **chunk 3.1 가 chunk 3 의 ToS 위반 hotfix 역할이므로 prod ship 직전 필수 게이트**.
-8. (post-merge) GH 이슈 신규 등록 — "데스크탑·모바일 autoplay gesture-gate hook 통합 refactor" (§9 risk #5).
+8. **Escalation 규칙**: chunk 3 가 chunk 3.1 머지 전에 `release/` 또는 `main` 에 도달할 경우 **즉시 escalate** — chunk 3 단독 prod 진입은 1px×1px IFrame ToS 위반 그대로 ship. chunk 3 + chunk 3.1 은 단일 release 묶음으로 ship 한다는 release-engineering invariant 잠금.
+9. (post-merge) GH 이슈 신규 등록 — "데스크탑·모바일 autoplay gesture-gate hook 통합 refactor" (§9 risk #5).
 
 ## 11. 관련
 

--- a/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md
@@ -65,7 +65,7 @@ YouTube API 서비스 약관 (developers.google.com/youtube/terms 등) 중 다�
 | 7   | State persistence    | 룸 mount 시 `expanded=true` 1회 init. component-local `useState`. **트랙 변경·Mode C 진입 모두 `expanded` 미수정 (사용자 마지막 선택 보존)**.                           |
 | 8   | autoplay polish      | 데스크탑 `autoplayBlocked` + gesture gate 패턴 모바일 차용 (동봉). hook 입력에 `videoId` 포함 → 트랙 변경 시 차단 detect 재armed.                                       |
 | 9   | 데스크탑 격리        | 데스크탑 `widgets/partyroom-display-board/*` 변경 0                                                                                                                     |
-| 10  | lobby 카드 디테일    | 본 spec OUT — 별도 후속 결정                                                                                                                                            |
+| 10  | lobby 카드 디테일    | 본 spec OUT — **chunk 5 catch-up 의 design backlog**. 현 chunk 2 모바일 카드는 v1 minimal viable, 완성품 아님 (사용자 확정).                                            |
 | 11  | i18n inline 한국어   | 본 chunk 도 chunk 2·3 의 inline 한국어 정책 유지. **chunk 5 catch-up 에서 모바일 i18n 키 일괄 이주 시 함께 처리**.                                                      |
 | 12  | YoutubePlayer 사이징 | **부모 wrapper 가 size 결정, YoutubePlayer 는 `width='100%' height='100%'` 고정** (prop 변경에 의한 remount 위험 회피).                                                 |
 | 13  | YoutubePlayer `key`  | `key={`video-${playerReady}-${played}`}` — 데스크탑과 동일. videoId/endTime/mode 미포함.                                                                                |
@@ -563,7 +563,7 @@ reviewer 1차 #3 + #6 반영. unit/integration 레이어가 잡지 못하는 anc
 - chunk 2 의 `ActionButtons` (리액션) 변경 0
 - chunk 3 의 탭·채팅·크루 변경 0 (단 sticky-top 높이 변화의 영향 가드는 §7.3 에서 검증)
 - DJ 큐 (chunk 4)
-- lobby 카드 디자인 (별도 결정)
+- **lobby 카드 디자인 디테일** — chunk 2 의 현 모바일 카드 (1 컬럼 + 풀폭 썸네일 + 텍스트 메타) 는 **v1 minimal viable, 완성품 아님** (2026-05-29 사용자 framing 확정). 데스크탑 격차 (아바타 아이콘들·backdrop blur·Typography 일관성·PFInfoOutline) 는 **chunk 5 catch-up 의 design backlog** 로 추적. chunk 5 시점에서 별도 brainstorming → spec 분기 필요. 본 chunk 3.1 의 IN 아님.
 - 사용자가 영상 일부분만 hide 하거나 mute toggle 추가 — v1 스코프 아님 (현 결정은 mute=userPreferenceStore 따라감)
 - userPreference 에 expanded 영구 저장 (사용자 결정: session reset)
 - 데스크탑·모바일 autoplay hook 의 단일화 (§9 risk #5, 후속 작업)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -201,3 +201,25 @@ E2E selector는 "UI 구현 세부사항에 덜 묶이고, 로케일/동적 데�
 - C, D에서 추가한 selector는 당장 제거하지 않는다.
 - 다만 새 selector를 더 추가할 때는 먼저 role/text로 가능한지 확인한다.
 - `src/shared` 공용 컴포넌트에 테스트 전용 prop을 더 퍼뜨리기 전에, feature 레벨 wrapper나 container로 해결 가능한지 먼저 본다.
+
+## chunk 3.1 — `e2e/mobile/` project
+
+모바일 viewport (iPhone 13) 전용 spec 들. `display-board-tos-mobile` project 가 `playwright.config.ts` 에 등록되어 `yarn test:e2e` 의 mandatory job 으로 실행.
+
+### `display-board.tos.spec.ts`
+
+YouTube IFrame Player API ToS 가드 (chunk 3.1 핵심):
+
+- Mode A IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님
+- Mode A↔B 토글 시 wrapper 80×45 정확값 + IFrame DOM identity 보존 (remount 회피)
+- Mode B→A 복귀 시 동일 IFrame element
+- Mode C 시 BlankPlaceholder visible + IFrame 미존재
+- sticky-top 높이 변화 시 chat scroll offset ≤ 10px 보존
+
+### Branch protection 등록 (사용자 단발 GitHub UI 작업)
+
+PR `feature/mobile-responsive-spec-3.1` 머지 **전** 다음 작업 필수 (chunk 3.1 spec §3 row 15, §10 step 6):
+
+1. GitHub repo Settings → Branches → `develop` 의 Branch protection rule 편집
+2. "Require status checks to pass before merging" 에 **`Playwright E2E`** job 추가 (이미 등록되어 있다면 OK)
+3. 동일 작업을 `release` 브랜치에도 적용

--- a/e2e/fixtures/auth.fixtures.ts
+++ b/e2e/fixtures/auth.fixtures.ts
@@ -55,5 +55,10 @@ function getAuthPrefix(testFile: string) {
     return 'd';
   }
 
+  // chunk 3.1 — 모바일 디스플레이 보드 ToS 가드. user A storage state 재사용.
+  if (testFile.includes('mobile/display-board') || testFile.includes('mobile\\display-board')) {
+    return 'a';
+  }
+
   throw new Error(`No auth prefix configured for test file: ${testFile}`);
 }

--- a/e2e/mobile/display-board.helpers.ts
+++ b/e2e/mobile/display-board.helpers.ts
@@ -1,0 +1,39 @@
+import { expect, type Page } from '@playwright/test';
+
+export const CHAT_SCROLL_TOLERANCE_PX = 10;
+export const COLLAPSED_VIDEO_WIDTH = 80;
+export const COLLAPSED_VIDEO_HEIGHT = 45;
+
+export const mobilePartyroomName = () => `MOBILE-TOS-${Date.now()}`;
+export const mobilePlaylistName = () => `mobile-tos-pl-${Date.now()}`;
+
+export async function gotoMobileRoomAndWaitForVideo(page: Page, partyroomUrl: string) {
+  await page.goto(partyroomUrl);
+  await expect(page.getByTestId('video-wrapper')).toBeVisible({ timeout: 30_000 });
+}
+
+export async function expectIframeToBeOnScreen(page: Page) {
+  const iframe = page.locator('iframe[src*="youtube.com/embed"]');
+  await expect(iframe).toBeVisible();
+  const box = await iframe.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+  expect(box.width).toBeGreaterThanOrEqual(COLLAPSED_VIDEO_WIDTH);
+  expect(box.height).toBeGreaterThanOrEqual(COLLAPSED_VIDEO_HEIGHT);
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  if (!viewport) return;
+  expect(box.x).toBeGreaterThan(-box.width);
+  expect(box.y).toBeGreaterThan(-box.height);
+  expect(box.x).toBeLessThan(viewport.width);
+  expect(box.y).toBeLessThan(viewport.height);
+}
+
+export async function expectIframeNotVisuallyHidden(page: Page) {
+  const result = await page.locator('iframe[src*="youtube.com/embed"]').evaluate((el) => {
+    const style = window.getComputedStyle(el);
+    return { opacity: parseFloat(style.opacity), visibility: style.visibility };
+  });
+  expect(result.visibility).not.toBe('hidden');
+  expect(result.opacity).toBeGreaterThan(0);
+}

--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -1,0 +1,158 @@
+import { expect } from '@playwright/test';
+import {
+  CHAT_SCROLL_TOLERANCE_PX,
+  COLLAPSED_VIDEO_HEIGHT,
+  COLLAPSED_VIDEO_WIDTH,
+  expectIframeNotVisuallyHidden,
+  expectIframeToBeOnScreen,
+  gotoMobileRoomAndWaitForVideo,
+  mobilePartyroomName,
+  mobilePlaylistName,
+} from './display-board.helpers';
+import { test } from '../fixtures/auth.fixtures';
+import {
+  closePartyroom,
+  createPartyroom,
+  createPlaylistWithTracks,
+  enterPartyroomAndWaitUntilReady,
+  registerAsDj,
+} from '../helpers/partyroom.helpers';
+
+/**
+ * chunk 3.1 spec §5 — ToS 보존 가드 (Playwright headed, mandatory CI).
+ *
+ * iPhone 13 (390×844) 단일 매트릭스 — 추가 viewport (SE / Pixel) 는 후속 polish.
+ * 세션 cleanup: 각 케이스는 createPartyroom 으로 신규 룸 + 끝에 closePartyroom.
+ */
+
+test('Mode A 진입: IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  await expectIframeToBeOnScreen(page);
+  await expectIframeNotVisuallyHidden(page);
+
+  await closePartyroom(page);
+});
+
+test('Mode A → Mode B 토글: wrapper 80×45 정확값 + IFrame 여전히 visible + DOM identity 보존', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  const iframeBefore = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  expect(iframeBefore).not.toBeNull();
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+
+  const wrapper = page.getByTestId('video-wrapper');
+  const wrapperBox = await wrapper.boundingBox();
+  expect(wrapperBox).not.toBeNull();
+  if (!wrapperBox) return;
+  expect(Math.round(wrapperBox.width)).toBe(COLLAPSED_VIDEO_WIDTH);
+  expect(Math.round(wrapperBox.height)).toBe(COLLAPSED_VIDEO_HEIGHT);
+
+  await expectIframeNotVisuallyHidden(page);
+
+  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  expect(iframeAfter).not.toBeNull();
+  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeBefore, iframeAfter]);
+  expect(sameElement).toBe(true);
+
+  await closePartyroom(page);
+});
+
+test('Mode B → Mode A 복귀: IFrame 동일 element + 16:9 wrapper 복귀', async ({ user1Context }) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  const iframeInitial = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+  await page.getByRole('button', { name: '영상 펼치기' }).click();
+  await expect(page.getByRole('button', { name: '영상 가리기' })).toBeVisible();
+
+  const wrapper = page.getByTestId('video-wrapper');
+  await expect(wrapper).toHaveClass(/aspect-video/);
+
+  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeInitial, iframeAfter]);
+  expect(sameElement).toBe(true);
+
+  await closePartyroom(page);
+});
+
+test('Mode C (재생 없음): BlankPlaceholder visible + IFrame 미존재', async ({ user1Context }) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  await expect(page.getByTestId('blank-placeholder')).toBeVisible();
+  await expect(page.locator('iframe[src*="youtube.com/embed"]')).toHaveCount(0);
+
+  await closePartyroom(page);
+});
+
+test('sticky-top 높이 변화 시 chat scroll offset ≤ CHAT_SCROLL_TOLERANCE_PX 보존', async ({
+  user1Context,
+}) => {
+  test.setTimeout(120_000);
+  const page = await user1Context.newPage();
+
+  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
+  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
+  await createPlaylistWithTracks(page, mobilePlaylistName());
+  await registerAsDj(page);
+  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+  const chatTab = page.getByRole('tab', { name: /채팅/ }).first();
+  if (await chatTab.isVisible().catch(() => false)) {
+    await chatTab.click();
+  }
+
+  const chatContainer = page.locator('[data-tab-content="chat"]').first();
+  await expect(chatContainer).toBeVisible();
+
+  await page.waitForTimeout(500);
+
+  const scrollBefore = await chatContainer.evaluate((el) => el.scrollTop);
+
+  await page.getByRole('button', { name: '영상 가리기' }).click();
+  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+  await page.waitForTimeout(300);
+
+  const scrollAfter = await chatContainer.evaluate((el) => el.scrollTop);
+
+  const delta = Math.abs(scrollAfter - scrollBefore);
+  expect(delta).toBeLessThanOrEqual(CHAT_SCROLL_TOLERANCE_PX);
+
+  await closePartyroom(page);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -88,5 +88,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['auth-d'],
     },
+    {
+      name: 'display-board-tos-mobile',
+      testMatch: /mobile\/display-board\.tos\.spec\.ts/,
+      use: { ...devices['iPhone 13'] },
+      dependencies: ['auth-a'],
+    },
   ],
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { useRef } from 'react';
+import type TReactPlayer from 'react-player';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import useAutoplayGestureGate, { AUTOPLAY_DETECT_MS } from './use-autoplay-gesture-gate.hook';
+
+function setupHook({
+  playable = true,
+  videoId = 'abc' as string | null,
+}: { playable?: boolean; videoId?: string | null } = {}) {
+  return renderHook(() => {
+    const playerRef = useRef<TReactPlayer | null>(null);
+    return useAutoplayGestureGate({ playerRef, playable, videoId });
+  });
+}
+
+describe('useAutoplayGestureGate', () => {
+  test('AUTOPLAY_DETECT_MS = 1500 (spec §4.6, ms)', () => {
+    expect(AUTOPLAY_DETECT_MS).toBe(1500);
+  });
+
+  test('초기 state: autoplayBlocked / played / playerReady 모두 false', () => {
+    const { result } = setupHook();
+    expect(result.current.autoplayBlocked).toBe(false);
+    expect(result.current.played).toBe(false);
+    expect(result.current.playerReady).toBe(false);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -4,7 +4,7 @@
 import { useRef } from 'react';
 import type TReactPlayer from 'react-player';
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import useAutoplayGestureGate, { AUTOPLAY_DETECT_MS } from './use-autoplay-gesture-gate.hook';
 
 function setupHook({
@@ -16,6 +16,13 @@ function setupHook({
     return useAutoplayGestureGate({ playerRef, playable, videoId });
   });
 }
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('useAutoplayGestureGate', () => {
   test('AUTOPLAY_DETECT_MS = 1500 (spec §4.6, ms)', () => {
@@ -34,5 +41,14 @@ describe('useAutoplayGestureGate', () => {
     const fakePlayer = {} as TReactPlayer;
     act(() => result.current.onReady(fakePlayer));
     expect(result.current.playerReady).toBe(true);
+  });
+
+  test('onReady 후 1500ms 내 onPlay 없으면 autoplayBlocked=true', () => {
+    const { result } = setupHook();
+    act(() => result.current.onReady({} as TReactPlayer));
+    act(() => {
+      vi.advanceTimersByTime(AUTOPLAY_DETECT_MS);
+    });
+    expect(result.current.autoplayBlocked).toBe(true);
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -3,7 +3,7 @@
  */
 import { useRef } from 'react';
 import type TReactPlayer from 'react-player';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import useAutoplayGestureGate, { AUTOPLAY_DETECT_MS } from './use-autoplay-gesture-gate.hook';
 
@@ -27,5 +27,12 @@ describe('useAutoplayGestureGate', () => {
     expect(result.current.autoplayBlocked).toBe(false);
     expect(result.current.played).toBe(false);
     expect(result.current.playerReady).toBe(false);
+  });
+
+  test('onReady 호출 시 playerReady=true 로 전이', () => {
+    const { result } = setupHook();
+    const fakePlayer = {} as TReactPlayer;
+    act(() => result.current.onReady(fakePlayer));
+    expect(result.current.playerReady).toBe(true);
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -86,4 +86,25 @@ describe('useAutoplayGestureGate', () => {
     expect(playVideo).toHaveBeenCalledTimes(1);
     expect(result.current.gate.autoplayBlocked).toBe(false);
   });
+
+  test('videoId 변경 시 played reset + 새 1500ms 타이머 시작 (트랙 변경 시 차단 재armed)', () => {
+    let id = 'first' as string | null;
+    const { result, rerender } = renderHook(() => {
+      const playerRef = useRef<TReactPlayer | null>(null);
+      return useAutoplayGestureGate({ playerRef, playable: true, videoId: id });
+    });
+
+    act(() => result.current.onReady({} as TReactPlayer));
+    act(() => result.current.onPlay());
+    expect(result.current.played).toBe(true);
+    expect(result.current.autoplayBlocked).toBe(false);
+
+    id = 'second';
+    rerender();
+
+    expect(result.current.played).toBe(false);
+
+    act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
+    expect(result.current.autoplayBlocked).toBe(true);
+  });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -63,4 +63,27 @@ describe('useAutoplayGestureGate', () => {
     expect(result.current.played).toBe(true);
     expect(result.current.autoplayBlocked).toBe(false);
   });
+
+  test('handleGesturePlay 가 internal playVideo() 호출 + autoplayBlocked=false 즉시 전환', () => {
+    const playVideo = vi.fn();
+    const fakePlayer = {
+      getInternalPlayer: () => ({ playVideo }),
+    } as unknown as TReactPlayer;
+
+    const { result } = renderHook(() => {
+      const playerRef = useRef<TReactPlayer | null>(fakePlayer);
+      return {
+        gate: useAutoplayGestureGate({ playerRef, playable: true, videoId: 'abc' }),
+        playerRef,
+      };
+    });
+
+    act(() => result.current.gate.onReady(fakePlayer));
+    act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
+    expect(result.current.gate.autoplayBlocked).toBe(true);
+
+    act(() => result.current.gate.handleGesturePlay());
+    expect(playVideo).toHaveBeenCalledTimes(1);
+    expect(result.current.gate.autoplayBlocked).toBe(false);
+  });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -51,4 +51,16 @@ describe('useAutoplayGestureGate', () => {
     });
     expect(result.current.autoplayBlocked).toBe(true);
   });
+
+  test('onPlay 호출 시 played=true + autoplayBlocked=false', () => {
+    const { result } = setupHook();
+    act(() => result.current.onReady({} as TReactPlayer));
+    act(() => {
+      vi.advanceTimersByTime(AUTOPLAY_DETECT_MS);
+    });
+    expect(result.current.autoplayBlocked).toBe(true);
+    act(() => result.current.onPlay());
+    expect(result.current.played).toBe(true);
+    expect(result.current.autoplayBlocked).toBe(false);
+  });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -107,4 +107,24 @@ describe('useAutoplayGestureGate', () => {
     act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
     expect(result.current.autoplayBlocked).toBe(true);
   });
+
+  test('playable=false 진입 시 모든 state reset (Mode C 진입 시 cleanup)', () => {
+    let playable = true;
+    const { result, rerender } = renderHook(() => {
+      const playerRef = useRef<TReactPlayer | null>(null);
+      return useAutoplayGestureGate({ playerRef, playable, videoId: 'abc' });
+    });
+
+    act(() => result.current.onReady({} as TReactPlayer));
+    act(() => result.current.onPlay());
+    expect(result.current.playerReady).toBe(true);
+    expect(result.current.played).toBe(true);
+
+    playable = false;
+    rerender();
+
+    expect(result.current.playerReady).toBe(false);
+    expect(result.current.played).toBe(false);
+    expect(result.current.autoplayBlocked).toBe(false);
+  });
 });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -29,6 +29,11 @@ export default function useAutoplayGestureGate({
   const [playerReady, setPlayerReady] = useState(false);
 
   useEffect(() => {
+    setPlayed(false);
+    setAutoplayBlocked(false);
+  }, [videoId]);
+
+  useEffect(() => {
     if (!playerReady || played) return;
     const timer = setTimeout(() => setAutoplayBlocked(true), AUTOPLAY_DETECT_MS);
     return () => clearTimeout(timer);

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -22,11 +22,20 @@ export interface AutoplayGestureGate {
 
 export default function useAutoplayGestureGate({
   playerRef,
+  playable,
   videoId,
 }: UseAutoplayGestureGateArgs): AutoplayGestureGate {
   const [autoplayBlocked, setAutoplayBlocked] = useState(false);
   const [played, setPlayed] = useState(false);
   const [playerReady, setPlayerReady] = useState(false);
+
+  useEffect(() => {
+    if (!playable) {
+      setPlayerReady(false);
+      setPlayed(false);
+      setAutoplayBlocked(false);
+    }
+  }, [playable]);
 
   useEffect(() => {
     setPlayed(false);

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -1,4 +1,4 @@
-import { useState, type RefObject } from 'react';
+import { useEffect, useState, type RefObject } from 'react';
 import type TReactPlayer from 'react-player';
 
 export const AUTOPLAY_DETECT_MS = 1500;
@@ -22,10 +22,17 @@ export interface AutoplayGestureGate {
 
 export default function useAutoplayGestureGate({
   playerRef,
+  videoId,
 }: UseAutoplayGestureGateArgs): AutoplayGestureGate {
   const [autoplayBlocked, setAutoplayBlocked] = useState(false);
   const [played, setPlayed] = useState(false);
   const [playerReady, setPlayerReady] = useState(false);
+
+  useEffect(() => {
+    if (!playerReady || played) return;
+    const timer = setTimeout(() => setAutoplayBlocked(true), AUTOPLAY_DETECT_MS);
+    return () => clearTimeout(timer);
+  }, [playerReady, played, videoId]);
 
   const handleGesturePlay = () => {
     const internal = playerRef.current?.getInternalPlayer() as

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -1,5 +1,4 @@
-// src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
-import type { RefObject } from 'react';
+import { useState, type RefObject } from 'react';
 import type TReactPlayer from 'react-player';
 
 export const AUTOPLAY_DETECT_MS = 1500;
@@ -21,8 +20,46 @@ export interface AutoplayGestureGate {
   onPause: () => void;
 }
 
-export default function useAutoplayGestureGate(
-  _args: UseAutoplayGestureGateArgs
-): AutoplayGestureGate {
-  throw new Error('not implemented');
+export default function useAutoplayGestureGate({
+  playerRef,
+}: UseAutoplayGestureGateArgs): AutoplayGestureGate {
+  const [autoplayBlocked, setAutoplayBlocked] = useState(false);
+  const [played, setPlayed] = useState(false);
+  const [playerReady, setPlayerReady] = useState(false);
+
+  const handleGesturePlay = () => {
+    const internal = playerRef.current?.getInternalPlayer() as
+      | { playVideo?: () => void }
+      | undefined;
+    internal?.playVideo?.();
+    setAutoplayBlocked(false);
+  };
+
+  const onReady = (_player: TReactPlayer) => {
+    setPlayerReady(true);
+  };
+
+  const onStart = () => {
+    /* seekToLive 는 VideoFrame 의 외부 콜백에서 처리 (data 의존) */
+  };
+
+  const onPlay = () => {
+    setPlayed(true);
+    setAutoplayBlocked(false);
+  };
+
+  const onPause = () => {
+    /* 본 hook 은 onPause 의 자동 재개 폴백을 수행 안 함 (chunk 3.1 OUT, §9 risk #7) */
+  };
+
+  return {
+    autoplayBlocked,
+    played,
+    playerReady,
+    handleGesturePlay,
+    onReady,
+    onStart,
+    onPlay,
+    onPause,
+  };
 }

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -1,0 +1,28 @@
+// src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+import type { RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+
+export const AUTOPLAY_DETECT_MS = 1500;
+
+interface UseAutoplayGestureGateArgs {
+  playerRef: RefObject<TReactPlayer | null>;
+  playable: boolean;
+  videoId: string | null;
+}
+
+export interface AutoplayGestureGate {
+  autoplayBlocked: boolean;
+  played: boolean;
+  playerReady: boolean;
+  handleGesturePlay: () => void;
+  onReady: (player: TReactPlayer) => void;
+  onStart: () => void;
+  onPlay: () => void;
+  onPause: () => void;
+}
+
+export default function useAutoplayGestureGate(
+  _args: UseAutoplayGestureGateArgs
+): AutoplayGestureGate {
+  throw new Error('not implemented');
+}

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -120,3 +120,51 @@ describe('MobilePartyroomDisplayBoard · Mode C 진입', () => {
     expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
   });
 });
+
+describe('MobilePartyroomDisplayBoard · expanded 보존 invariants', () => {
+  test('#5 토글 B → playback 트랙 변경 → expanded=false 그대로', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+
+    setStoreState({ playback: { name: 'Track 2', duration: '4:00', linkId: 'def' } });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+    expect(screen.getByTestId('video-wrapper').className).toContain('h-[45px]');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('#6 Mode B → playback null → playback 재할당 → 여전히 Mode B (사용자 선택 보존)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+
+    setStoreState({ playbackActivated: false, playback: null });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 3', duration: '2:00', linkId: 'ghi' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+  });
+
+  test('#7 Mode A → Mode C → 재할당 → Mode A 복귀 (역대칭)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+
+    setStoreState({ playbackActivated: false, playback: null });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 4', duration: '1:30', linkId: 'jkl' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-full');
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -57,6 +57,8 @@ vi.mock('@/shared/lib/store/stores.context', () => ({
   }),
 }));
 
+// 후속 task 에서 사용
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function setStoreState(patch: Partial<StoreState>) {
   storeState = { ...storeState, ...patch };
 }
@@ -80,4 +82,32 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+});
+
+describe('MobilePartyroomDisplayBoard · 토글 라이프사이클', () => {
+  test('#1 룸 mount 시 expanded=true default → Mode A 진입', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).toContain('w-full');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+
+  test('#2 토글 클릭 → Mode B (80×45)', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('w-[80px]');
+    expect(wrapper.className).toContain('h-[45px]');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('#3 두 번째 토글 → Mode A 복귀', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    fireEvent.click(screen.getByRole('button', { name: '영상 펼치기' }));
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
 });

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -231,3 +231,45 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
     expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
   });
 });
+
+describe('MobilePartyroomDisplayBoard · cross-component single source', () => {
+  test('#11 Mode B + autoplay 차단: NowPlayingRow 안에 TapToPlayButton 렌더, overlay 미렌더', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    act(() => {
+      (yt.onReady as (p: unknown) => void)({} as unknown);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const row = screen.getByTestId('now-playing-row');
+    const tapButton = screen.getByRole('button', { name: '재생' });
+    expect(row.contains(tapButton)).toBe(true);
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
+  });
+
+  test('#12 Mode B + autoplay 차단 → Mode A 토글 → overlay 즉시 visible (single source)', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    act(() => {
+      (yt.onReady as (p: unknown) => void)({} as unknown);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.getByRole('button', { name: '재생' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '영상 펼치기' }));
+
+    expect(screen.getByTestId('autoplay-gesture-gate')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: '재생' })).toBeNull();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const youtubePlayerCalls: Array<Record<string, unknown>> = [];
+vi.mock('react-player/youtube', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    youtubePlayerCalls.push(props);
+    return <div data-testid='youtube-player-mock' data-url={String(props.url ?? '')} />;
+  },
+}));
+vi.mock('next/dynamic', async () => {
+  const mod = await import('react-player/youtube');
+  return { __esModule: true, default: () => mod.default };
+});
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/features/partyroom/get-summary', () => ({
+  useFetchPartyroomDetailSummary: () => ({ data: { title: 'Test Room' } }),
+}));
+
+vi.mock('@/entities/preference', () => ({
+  useUserPreferenceStore: vi.fn((selector: (s: { volume: number; muted: boolean }) => unknown) =>
+    selector({ volume: 1, muted: false })
+  ),
+}));
+
+vi.mock('./ui/parts/action-buttons.component', () => ({
+  __esModule: true,
+  default: () => <div data-testid='action-buttons-mock' />,
+}));
+
+type StoreState = {
+  playbackActivated: boolean;
+  playback: { name: string; duration: string; linkId: string } | null;
+  currentDj: { crewId: number } | null;
+  crews: Array<{ crewId: number; nickname: string }>;
+};
+
+let storeState: StoreState = {
+  playbackActivated: true,
+  playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+  currentDj: { crewId: 1 },
+  crews: [{ crewId: 1, nickname: 'DJ A' }],
+};
+
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useCurrentPartyroom: (selector: (s: StoreState) => unknown) => selector(storeState),
+  }),
+}));
+
+function setStoreState(patch: Partial<StoreState>) {
+  storeState = { ...storeState, ...patch };
+}
+function resetStoreState() {
+  storeState = {
+    playbackActivated: true,
+    playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+    currentDj: { crewId: 1 },
+    crews: [{ crewId: 1, nickname: 'DJ A' }],
+  };
+}
+
+import MobilePartyroomDisplayBoard from './partyroom-display-board.component';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  youtubePlayerCalls.length = 0;
+  mockPush.mockClear();
+  resetStoreState();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -57,8 +57,6 @@ vi.mock('@/shared/lib/store/stores.context', () => ({
   }),
 }));
 
-// 후속 task 에서 사용
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function setStoreState(patch: Partial<StoreState>) {
   storeState = { ...storeState, ...patch };
 }
@@ -109,5 +107,16 @@ describe('MobilePartyroomDisplayBoard · 토글 라이프사이클', () => {
     const wrapper = screen.getByTestId('video-wrapper');
     expect(wrapper.className).toContain('aspect-video');
     expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+});
+
+describe('MobilePartyroomDisplayBoard · Mode C 진입', () => {
+  test('#4 playback null → Mode C: BlankPlaceholder + 토글 미렌더 + NowPlayingRow 미렌더', () => {
+    setStoreState({ playbackActivated: false, playback: null });
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /영상/ })).toBeNull();
+    expect(screen.queryByTestId('now-playing-row')).toBeNull();
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const youtubePlayerCalls: Array<Record<string, unknown>> = [];
@@ -180,5 +180,54 @@ describe('MobilePartyroomDisplayBoard · component lifecycle', () => {
     render(<MobilePartyroomDisplayBoard partyroomId={1} />);
     expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
     expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+});
+
+describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
+  test('#9 트랙 변경 시 autoplay 차단 재armed: 새 videoId + 1500ms 후 차단 → release control 렌더', () => {
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const firstYt = youtubePlayerCalls[0];
+    act(() => {
+      (firstYt.onReady as (p: unknown) => void)({} as unknown);
+      (firstYt.onPlay as () => void)();
+    });
+
+    setStoreState({ playback: { name: 'Track 2', duration: '4:00', linkId: 'def' } });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const newYt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    act(() => {
+      (newYt.onReady as (p: unknown) => void)({} as unknown);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
+  });
+
+  test('#10 Mode C → 재할당 → onReady 후 1500ms 내 onPlay 없으면 차단 + release control 렌더', () => {
+    setStoreState({ playbackActivated: false, playback: null });
+    const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+
+    setStoreState({
+      playbackActivated: true,
+      playback: { name: 'Track 5', duration: '3:00', linkId: 'mno' },
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
+    act(() => {
+      (yt.onReady as (p: unknown) => void)({} as unknown);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
+
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -168,3 +168,17 @@ describe('MobilePartyroomDisplayBoard · expanded 보존 invariants', () => {
     expect(screen.getByTestId('video-wrapper').className).toContain('w-full');
   });
 });
+
+describe('MobilePartyroomDisplayBoard · component lifecycle', () => {
+  test('#8 룸 unmount → 다시 mount → expanded=true reset (component-local state)', () => {
+    const { unmount } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    fireEvent.click(screen.getByRole('button', { name: '영상 가리기' }));
+    expect(screen.getByTestId('video-wrapper').className).toContain('w-[80px]');
+
+    unmount();
+
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    expect(screen.getByTestId('video-wrapper').className).toContain('aspect-video');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
@@ -1,35 +1,32 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { FC } from 'react';
+import { FC, useRef, useState } from 'react';
+import type TReactPlayer from 'react-player';
 import { useFetchPartyroomDetailSummary } from '@/features/partyroom/get-summary';
 import { cn } from '@/shared/lib/functions/cn';
 import { useStores } from '@/shared/lib/store/stores.context';
+import useAutoplayGestureGate from './lib/use-autoplay-gesture-gate.hook';
 import ActionButtons from './ui/parts/action-buttons.component';
-
-// 데스크탑 video.component.tsx 와 동일 패턴 — react-player/youtube 를 SSR off 로 동적 import.
-// C3 격리: 데스크탑 module-private const 를 import 하지 않고 자체 mount.
-const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
+import NowPlayingMeta from './ui/parts/now-playing-meta.component';
+import TapToPlayButton from './ui/parts/tap-to-play-button.component';
+import VideoFrame from './ui/parts/video-frame.component';
 
 interface Props {
   partyroomId: number;
 }
 
 /**
- * 모바일 전광판 (§4.2):
- * - sticky top — 헤더 + now-playing + 리액션 inline 한 묶음
- * - YoutubePlayer 1px hidden mount — **오디오 재생** (모바일 청취 핵심)
- * - 리액션 inline (플로팅 X — 채팅·키보드 충돌 회피)
+ * 모바일 전광판 — chunk 3.1 재설계 (spec §4.2 / §6.*).
  *
- * 룸 이름은 store 에 없으므로 `useFetchPartyroomDetailSummary` 로 fetch
- * (데스크탑 룸도 동일 패턴).
+ * 본 컴포넌트 책임:
+ * 1. expanded state owner (룸 mount 시 true, 토글 클릭만 변경).
+ * 2. useAutoplayGestureGate 호출 — VideoFrame overlay 와 NowPlayingRow TapToPlayButton
+ *    양쪽에 동일 gate state 주입 (§4.4 / §6.5.2 single source of truth).
+ * 3. NowPlayingRow (min-h-[44px]) 로 NowPlayingMeta + TapToPlayButton 같은 row wrap
+ *    → TapToPlayButton 의 iOS HIG 44x44 hit-area 확보 (§6.4 reviewer 3차 #2).
  *
- * Header (룸이름·뒤로·⋮ 메뉴) 는 본 컴포넌트 안에서 직접 렌더 — page.tsx 는 모바일
- * 룸에서 글로벌 `<Header />` 미렌더. ⋮ 메뉴 확장은 chunk 3·4.
- *
- * autoplay 정책 / gesture gate / seekToLive 는 chunk 후속 polish 대상 — chunk 2 는
- * 입장 시(=user gesture 직후) 자동재생 케이스만 커버.
+ * 데스크탑 widgets/partyroom-display-board 는 0 수정 (§3 row 9).
  */
 const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
   const router = useRouter();
@@ -38,6 +35,7 @@ const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
   const playback = useCurrentPartyroom((state) => state.playback);
   const currentDj = useCurrentPartyroom((state) => state.currentDj);
   const crews = useCurrentPartyroom((state) => state.crews);
+  // 두번째 arg = chunk 2 의 기존 시그니처 그대로 유지 (suspense/enabled flag, 데스크탑 룸 동일 패턴).
   const { data: detailSummary } = useFetchPartyroomDetailSummary(partyroomId, true);
   const partyroomTitle = detailSummary?.title ?? '';
 
@@ -45,9 +43,20 @@ const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
     ? (crews.find((c) => c.crewId === currentDj.crewId)?.nickname ?? null)
     : null;
 
+  const [expanded, setExpanded] = useState(true);
+  const playerRef = useRef<TReactPlayer | null>(null);
+
+  const videoId = playbackActivated ? (playback?.linkId ?? null) : null;
+  const isPlaying = videoId !== null;
+  const mode: 'A' | 'B' | 'C' = !isPlaying ? 'C' : expanded ? 'A' : 'B';
+
+  const gate = useAutoplayGestureGate({ playerRef, playable: isPlaying, videoId });
+
+  // TapToPlayButton 합성 prop: AutoplayGestureGate visible 조건과 동일 (single source).
+  const tapToPlayVisible = gate.autoplayBlocked && !gate.played;
+
   return (
     <div className={cn('sticky top-0 z-20 w-full bg-black border-b border-gray-800')}>
-      {/* 헤더 row: 뒤로 · 룸 이름 · ⋮ (⋮ 메뉴는 chunk 3·4 에 확장) */}
       <header className='flex items-center justify-between px-4 h-12'>
         <button
           aria-label='뒤로'
@@ -67,39 +76,38 @@ const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
         </button>
       </header>
 
-      {/* now-playing + 리액션 */}
-      <div className='px-4 py-3 space-y-3'>
-        {playbackActivated && playback ? (
-          <>
-            <p className='text-base font-semibold text-white truncate'>{playback.name}</p>
-            {currentDjNickname && <p className='text-xs text-gray-500'>🎧 {currentDjNickname}</p>}
-            <p className='text-xs text-gray-600'>{playback.duration}</p>
-          </>
-        ) : (
-          <p className='text-sm text-gray-500'>지금 재생 중인 곡이 없어요</p>
-        )}
-
-        <div className='flex gap-2'>
-          <ActionButtons />
-        </div>
+      <div className='px-4 pt-3'>
+        <VideoFrame
+          videoId={videoId}
+          expanded={expanded}
+          onToggleExpand={() => setExpanded((v) => !v)}
+          playerRef={playerRef}
+          gate={gate}
+        />
       </div>
 
-      {/* YoutubePlayer = 오디오 mount. 1px hidden 으로 화면 차지 X */}
-      {playbackActivated && playback?.linkId && (
+      {mode !== 'C' && playback && (
         <div
-          aria-hidden
-          className='absolute pointer-events-none w-px h-px overflow-hidden opacity-0 -z-10'
+          data-testid='now-playing-row'
+          className='flex items-center min-h-[44px] px-4 pt-3 gap-3'
         >
-          <YoutubePlayer
-            url={`https://www.youtube.com/watch?v=${playback.linkId}`}
-            playing={playbackActivated}
-            muted={false}
-            volume={1}
-            width='1px'
-            height='1px'
-          />
+          <div className={mode === 'A' ? 'w-full' : 'flex-1 min-w-0'}>
+            <NowPlayingMeta
+              layout={mode === 'A' ? 'column' : 'row'}
+              trackName={playback.name}
+              djNickname={currentDjNickname}
+              duration={playback.duration}
+            />
+          </div>
+          {mode === 'B' && (
+            <TapToPlayButton autoplayBlocked={tapToPlayVisible} onTap={gate.handleGesturePlay} />
+          )}
         </div>
       )}
+
+      <div className='flex gap-2 px-4 py-3'>
+        <ActionButtons />
+      </div>
     </div>
   );
 };

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import BlankPlaceholder from './blank-placeholder.component';
+
+describe('BlankPlaceholder', () => {
+  test('inline 한국어 안내 텍스트 렌더 (spec §6.3, §3 row 11)', () => {
+    render(<BlankPlaceholder />);
+    expect(screen.getByText('지금 재생 중인 곡이 없어요')).toBeTruthy();
+  });
+
+  test('wrapper-fill class (w-full h-full + center) — wrapper aspect 책임은 VideoFrame', () => {
+    const { container } = render(<BlankPlaceholder />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bw-full\b/);
+    expect(root.className).toMatch(/\bh-full\b/);
+    expect(root.className).toMatch(/\bflex\b/);
+    expect(root.className).toMatch(/\bitems-center\b/);
+    expect(root.className).toMatch(/\bjustify-center\b/);
+    expect(root.className).not.toMatch(/\baspect-video\b/);
+    expect(root.className).not.toMatch(/\bbg-black\b/);
+    expect(root.className).not.toMatch(/\brounded\b/);
+  });
+
+  test('data-testid="blank-placeholder" 단언', () => {
+    render(<BlankPlaceholder />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/blank-placeholder.component.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+
+/**
+ * Mode C (비재생) 안내 — inline 한국어 (spec §6.3, §3 row 11).
+ *
+ * **책임 분리**: 16:9 aspect / 검정 배경 / rounded 는 VideoFrame 의 wrapperClass('C')
+ * 가 책임. 본 컴포넌트는 그 wrapper 의 *fill* (w-full h-full) + 중앙 정렬 + 텍스트만.
+ *
+ * Text styling: 기존 chunk 2 inline 의 `text-sm text-gray-500` 패턴 유지 (시각 회귀 0).
+ */
+const BlankPlaceholder: FC = () => {
+  return (
+    <div data-testid='blank-placeholder' className='w-full h-full flex items-center justify-center'>
+      <p className='text-sm text-gray-500'>지금 재생 중인 곡이 없어요</p>
+    </div>
+  );
+};
+
+export default BlankPlaceholder;

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import ExpandToggle from './expand-toggle.component';
+
+describe('ExpandToggle', () => {
+  test('expanded=true 시 aria-label="영상 가리기" + aria-pressed="false" (spec §6.2)', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe('영상 가리기');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('expanded=false 시 aria-label="영상 펼치기" + aria-pressed="true"', () => {
+    render(<ExpandToggle expanded={false} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe('영상 펼치기');
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('클릭 시 onToggle 콜백 1회 호출', () => {
+    const onToggle = vi.fn();
+    render(<ExpandToggle expanded={true} onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  test('44×44 hit-area class — min-h-[44px] + min-w-[44px] (iOS HIG, spec §6.2)', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/\bmin-h-\[44px\]/);
+    expect(btn.className).toMatch(/\bmin-w-\[44px\]/);
+  });
+
+  test('positioning 책임은 parent (VideoFrame) — leaf 본문은 absolute/top-*/right-* 미보유', () => {
+    render(<ExpandToggle expanded={true} onToggle={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).not.toMatch(/\babsolute\b/);
+    expect(btn.className).not.toMatch(/\btop-/);
+    expect(btn.className).not.toMatch(/\bright-/);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/expand-toggle.component.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react';
+
+interface Props {
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * ▾/◂ 토글. controlled (state owner = MobilePartyroomDisplayBoard, spec §4.4).
+ *
+ * a11y (spec §6.2): aria-label expanded → '영상 가리기' / collapsed → '영상 펼치기',
+ * aria-pressed: !expanded, min-h/w 44px.
+ *
+ * **positioning 책임은 parent (Chunk 3 VideoFrame).** 본문에 absolute / top-x / right-x
+ * 등을 두면 leaf 가 부모 layout 에 coupling 됨. 시각 styling 도 최소.
+ */
+const ExpandToggle: FC<Props> = ({ expanded, onToggle }) => {
+  return (
+    <button
+      type='button'
+      aria-label={expanded ? '영상 가리기' : '영상 펼치기'}
+      aria-pressed={!expanded}
+      onClick={onToggle}
+      className='min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-200'
+    >
+      {expanded ? '▾' : '◂'}
+    </button>
+  );
+};
+
+export default ExpandToggle;

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import NowPlayingMeta from './now-playing-meta.component';
+
+describe('NowPlayingMeta', () => {
+  test('layout="column": 트랙명·DJ·duration 3 라인 렌더', () => {
+    render(
+      <NowPlayingMeta
+        layout='column'
+        trackName='Test Track'
+        djNickname='DJ Alpha'
+        duration='3:45'
+      />
+    );
+    expect(screen.getByText('Test Track')).toBeTruthy();
+    expect(screen.getByText(/DJ Alpha/)).toBeTruthy();
+    expect(screen.getByText('3:45')).toBeTruthy();
+  });
+
+  test('layout="row": 3 값 모두 렌더', () => {
+    render(
+      <NowPlayingMeta layout='row' trackName='Test Track' djNickname='DJ Beta' duration='2:10' />
+    );
+    expect(screen.getByText('Test Track')).toBeTruthy();
+    expect(screen.getByText(/DJ Beta/)).toBeTruthy();
+    expect(screen.getByText('2:10')).toBeTruthy();
+  });
+
+  test('djNickname=null 시 DJ 라인 미렌더', () => {
+    render(
+      <NowPlayingMeta layout='column' trackName='Solo Track' djNickname={null} duration='1:00' />
+    );
+    expect(screen.getByText('Solo Track')).toBeTruthy();
+    expect(screen.queryByText(/🎧/)).toBeNull();
+    expect(screen.getByText('1:00')).toBeTruthy();
+  });
+
+  test('layout 분기 root class — column 은 flex-col, row 는 flex-row', () => {
+    const { container, rerender } = render(
+      <NowPlayingMeta layout='column' trackName='T' djNickname={null} duration='0:00' />
+    );
+    expect((container.firstElementChild as HTMLElement).className).toMatch(/\bflex-col\b/);
+    rerender(<NowPlayingMeta layout='row' trackName='T' djNickname={null} duration='0:00' />);
+    expect((container.firstElementChild as HTMLElement).className).toMatch(/\bflex-row\b/);
+  });
+
+  test('row variant 도 parent flex 토큰 (flex-1 / min-w-0 등) 보유 X', () => {
+    const { container } = render(
+      <NowPlayingMeta layout='row' trackName='T' djNickname='D' duration='0:00' />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toMatch(/\bflex-1\b/);
+    expect(root.className).not.toMatch(/\bmin-w-0\b/);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { cn } from '@/shared/lib/functions/cn';
+
+interface Props {
+  layout: 'column' | 'row';
+  trackName: string;
+  djNickname: string | null;
+  /** `M:SS` 또는 `MM:SS` 사전 포맷 문자열. parent 가 책임. */
+  duration: string;
+}
+
+/**
+ * 트랙메타 — Mode A = column, Mode B = row (spec §4.4 / §6.4 prop 정의).
+ *
+ * `layout` prop 의미: 본 컴포넌트 *내부* 의 배치만 결정.
+ * - column = 트랙명 / DJ / duration 세 줄 vertical stack
+ * - row = 트랙명 · DJ · duration 한 줄 horizontal inline
+ *
+ * **외부 배치는 NowPlayingRow (root) 책임**. `flex-1` / `min-w-0` 등 부모 토큰 미보유.
+ */
+const NowPlayingMeta: FC<Props> = ({ layout, trackName, djNickname, duration }) => {
+  return (
+    <div
+      className={cn(
+        'flex',
+        layout === 'column' ? 'flex-col space-y-1' : 'flex-row items-center gap-2'
+      )}
+    >
+      <p className='text-base font-semibold text-white truncate'>{trackName}</p>
+      {djNickname && <p className='text-xs text-gray-500 truncate'>🎧 {djNickname}</p>}
+      <p className='text-xs text-gray-600 shrink-0'>{duration}</p>
+    </div>
+  );
+};
+
+export default NowPlayingMeta;

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import TapToPlayButton from './tap-to-play-button.component';
+
+describe('TapToPlayButton', () => {
+  test('autoplayBlocked=true 시 visible (▶ + aria-label="재생")', () => {
+    render(<TapToPlayButton autoplayBlocked={true} onTap={() => {}} />);
+    expect(screen.getByRole('button', { name: '재생' })).toBeTruthy();
+  });
+
+  test('autoplayBlocked=false 시 미렌더', () => {
+    const { container } = render(<TapToPlayButton autoplayBlocked={false} onTap={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('클릭 시 onTap 콜백 1회', () => {
+    const onTap = vi.fn();
+    render(<TapToPlayButton autoplayBlocked={true} onTap={onTap} />);
+    fireEvent.click(screen.getByRole('button', { name: '재생' }));
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  test('44×44 hit-area', () => {
+    render(<TapToPlayButton autoplayBlocked={true} onTap={() => {}} />);
+    const btn = screen.getByRole('button', { name: '재생' });
+    expect(btn.className).toMatch(/\bmin-h-\[44px\]/);
+    expect(btn.className).toMatch(/\bmin-w-\[44px\]/);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/tap-to-play-button.component.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react';
+
+interface Props {
+  /**
+   * **합성 (pre-computed) prop**: root 에서 `gate.autoplayBlocked && !gate.played`
+   * 를 미리 계산해 내려주는 합성 boolean. 본 컴포넌트는 raw `gate.autoplayBlocked`
+   * 를 받지 않으며 `played` 도 받지 않는다 (spec §6.5.2 single source of truth).
+   */
+  autoplayBlocked: boolean;
+  onTap: () => void;
+}
+
+/**
+ * Mode B 의 release 경로 — autoplay 차단 시 NowPlayingMeta row 옆 sibling 으로 렌더.
+ *
+ * State 공유 보장 (spec §6.5.2): autoplayBlocked + onTap 모두 root 의 동일
+ * useAutoplayGestureGate gate state 에서 내려옴 → AutoplayGestureGate 와 single source.
+ *
+ * **positioning 책임은 parent (NowPlayingRow)**.
+ */
+const TapToPlayButton: FC<Props> = ({ autoplayBlocked, onTap }) => {
+  if (!autoplayBlocked) return null;
+  return (
+    <button
+      type='button'
+      aria-label='재생'
+      onClick={onTap}
+      className='shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded bg-white/90 text-black'
+    >
+      <svg width='20' height='20' viewBox='0 0 24 24' fill='currentColor' aria-hidden>
+        <path d='M8 5v14l11-7z' />
+      </svg>
+    </button>
+  );
+};
+
+export default TapToPlayButton;

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { useRef } from 'react';
+import type TReactPlayer from 'react-player';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import VideoFrame, {
+  COLLAPSED_VIDEO_HEIGHT,
+  COLLAPSED_VIDEO_WIDTH,
+  wrapperClass,
+} from './video-frame.component';
+import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+
+const youtubePlayerCalls: Array<Record<string, unknown>> = [];
+vi.mock('react-player/youtube', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    youtubePlayerCalls.push(props);
+    return <div data-testid='youtube-player-mock' data-url={String(props.url ?? '')} />;
+  },
+}));
+vi.mock('next/dynamic', async () => {
+  const mod = await import('react-player/youtube');
+  return { __esModule: true, default: () => mod.default };
+});
+vi.mock('@/entities/preference', () => ({
+  useUserPreferenceStore: vi.fn((selector: (s: { volume: number; muted: boolean }) => unknown) =>
+    selector({ volume: 1, muted: false })
+  ),
+}));
+
+function makeGate(overrides: Partial<AutoplayGestureGate> = {}): AutoplayGestureGate {
+  return {
+    autoplayBlocked: false,
+    played: false,
+    playerReady: false,
+    handleGesturePlay: vi.fn(),
+    onReady: vi.fn(),
+    onStart: vi.fn(),
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    ...overrides,
+  };
+}
+
+function Harness({
+  videoId,
+  expanded,
+  onToggleExpand,
+  gate,
+}: {
+  videoId: string | null;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  gate: AutoplayGestureGate;
+}) {
+  const playerRef = useRef<TReactPlayer | null>(null);
+  return (
+    <VideoFrame
+      videoId={videoId}
+      expanded={expanded}
+      onToggleExpand={onToggleExpand}
+      playerRef={playerRef}
+      gate={gate}
+    />
+  );
+}
+
+beforeEach(() => {
+  youtubePlayerCalls.length = 0;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// silence unused-import lint warnings until later tasks add tests
+void VideoFrame;
+void Harness;
+void render;
+void screen;
+void fireEvent;
+void COLLAPSED_VIDEO_WIDTH;
+void COLLAPSED_VIDEO_HEIGHT;
+void wrapperClass;
+void makeGate;
+
+describe('VideoFrame · scaffold sanity', () => {
+  test('scaffold loaded', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -236,3 +236,33 @@ describe('VideoFrame · Mode 전환', () => {
     expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
   });
 });
+
+describe('VideoFrame · ToS 가드 (회귀, spec §5)', () => {
+  test.each(['A', 'B', 'C'] as const)(
+    'Mode %s: wrapper className 에 hidden/opacity-0/w-px/h-px/pointer-events-none 토큰 부재',
+    (mode) => {
+      const videoId = mode === 'C' ? null : 'abc';
+      const expanded = mode === 'A' || mode === 'C';
+      render(
+        <Harness
+          videoId={videoId}
+          expanded={expanded}
+          onToggleExpand={() => {}}
+          gate={makeGate()}
+        />
+      );
+      const wrapper = screen.getByTestId('video-wrapper');
+      expect(wrapper.className).not.toMatch(/\bhidden\b/);
+      expect(wrapper.className).not.toMatch(/\bopacity-0\b/);
+      expect(wrapper.className).not.toMatch(/\bw-px\b/);
+      expect(wrapper.className).not.toMatch(/\bh-px\b/);
+      expect(wrapper.className).not.toMatch(/\bpointer-events-none\b/);
+    }
+  );
+
+  test('video-wrapper testid 에 aria-hidden="true" 직접 부착 안 됨', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.getAttribute('aria-hidden')).toBeNull();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -74,14 +74,6 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-// silence unused-import lint warnings until later tasks add tests
-void VideoFrame;
-void Harness;
-void render;
-void screen;
-void fireEvent;
-void makeGate;
-
 describe('VideoFrame · wrapperClass (정적 리터럴 가드, spec §4.5)', () => {
   test('Mode A 리터럴', () => {
     expect(wrapperClass('A')).toBe('aspect-video w-full bg-black rounded');
@@ -95,5 +87,37 @@ describe('VideoFrame · wrapperClass (정적 리터럴 가드, spec §4.5)', () 
   test('JS 상수 ↔ wrapperClass(B) 정적 리터럴 sync — 상수만 바뀌면 fail', () => {
     expect(wrapperClass('B')).toContain(`w-[${COLLAPSED_VIDEO_WIDTH}px]`);
     expect(wrapperClass('B')).toContain(`h-[${COLLAPSED_VIDEO_HEIGHT}px]`);
+  });
+});
+
+describe('VideoFrame · Mode A (재생 + expanded)', () => {
+  test('YoutubePlayer mount + width=100% / height=100% / url 정상', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(youtubePlayerCalls).toHaveLength(1);
+    const props = youtubePlayerCalls[0];
+    expect(props.width).toBe('100%');
+    expect(props.height).toBe('100%');
+    expect(props.url).toBe('https://www.youtube.com/watch?v=abc');
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+  });
+
+  test('wrapper 가 wrapperClass("A") 정적 토큰 보유 + ExpandToggle ▾ (expanded=true)', () => {
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).toContain('w-full');
+    expect(wrapper.className).toContain('bg-black');
+    expect(wrapper.className).toContain('rounded');
+    expect(screen.getByRole('button', { name: '영상 가리기' })).toBeTruthy();
+    expect(screen.queryByTestId('blank-placeholder')).toBeNull();
+  });
+
+  test('autoplayBlocked && !played 시 AutoplayGestureGate overlay 렌더 + 클릭 시 handleGesturePlay 호출', () => {
+    const handleGesturePlay = vi.fn();
+    const gate = makeGate({ autoplayBlocked: true, played: false, handleGesturePlay });
+    render(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={gate} />);
+    const overlay = screen.getByTestId('autoplay-gesture-gate');
+    fireEvent.click(overlay);
+    expect(handleGesturePlay).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -80,13 +80,20 @@ void Harness;
 void render;
 void screen;
 void fireEvent;
-void COLLAPSED_VIDEO_WIDTH;
-void COLLAPSED_VIDEO_HEIGHT;
-void wrapperClass;
 void makeGate;
 
-describe('VideoFrame · scaffold sanity', () => {
-  test('scaffold loaded', () => {
-    expect(true).toBe(true);
+describe('VideoFrame · wrapperClass (정적 리터럴 가드, spec §4.5)', () => {
+  test('Mode A 리터럴', () => {
+    expect(wrapperClass('A')).toBe('aspect-video w-full bg-black rounded');
+  });
+  test('Mode B 리터럴: w-[80px] h-[45px] shrink-0 bg-black rounded — Tailwind JIT 정적 scan 안전', () => {
+    expect(wrapperClass('B')).toBe('w-[80px] h-[45px] shrink-0 bg-black rounded');
+  });
+  test('Mode C 리터럴', () => {
+    expect(wrapperClass('C')).toBe('aspect-video w-full bg-black rounded');
+  });
+  test('JS 상수 ↔ wrapperClass(B) 정적 리터럴 sync — 상수만 바뀌면 fail', () => {
+    expect(wrapperClass('B')).toContain(`w-[${COLLAPSED_VIDEO_WIDTH}px]`);
+    expect(wrapperClass('B')).toContain(`h-[${COLLAPSED_VIDEO_HEIGHT}px]`);
   });
 });

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -146,3 +146,26 @@ describe('VideoFrame · Mode B (재생 + collapsed)', () => {
     expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
   });
 });
+
+describe('VideoFrame · Mode C (비재생, videoId=null)', () => {
+  test('BlankPlaceholder visible + YoutubePlayer 미렌더 + Toggle 미렌더', () => {
+    render(<Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: /영상/ })).toBeNull();
+  });
+
+  test('Props 안전: videoId=null 이면 expanded=true 라도 Mode C 강제', () => {
+    render(<Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('aspect-video');
+    expect(wrapper.className).not.toContain('w-[80px]');
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+  });
+
+  test('Props 안전: videoId=null + expanded=false 도 Mode C 강제', () => {
+    render(<Harness videoId={null} expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -121,3 +121,28 @@ describe('VideoFrame · Mode A (재생 + expanded)', () => {
     expect(handleGesturePlay).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('VideoFrame · Mode B (재생 + collapsed)', () => {
+  test('wrapper 가 wrapperClass("B") 정적 토큰 (80×45) + ExpandToggle ◂', () => {
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    const wrapper = screen.getByTestId('video-wrapper');
+    expect(wrapper.className).toContain('w-[80px]');
+    expect(wrapper.className).toContain('h-[45px]');
+    expect(wrapper.className).toContain('shrink-0');
+    expect(wrapper.className).toContain('bg-black');
+    expect(screen.getByRole('button', { name: '영상 펼치기' })).toBeTruthy();
+  });
+
+  test('YoutubePlayer width=100%/height=100% 그대로 — IFrame remount 회피', () => {
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />);
+    expect(youtubePlayerCalls).toHaveLength(1);
+    expect(youtubePlayerCalls[0].width).toBe('100%');
+    expect(youtubePlayerCalls[0].height).toBe('100%');
+  });
+
+  test('Mode B 에서는 autoplayBlocked 라도 AutoplayGestureGate overlay 미렌더 (Mode A only)', () => {
+    const gate = makeGate({ autoplayBlocked: true, played: false });
+    render(<Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={gate} />);
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.test.tsx
@@ -169,3 +169,70 @@ describe('VideoFrame · Mode C (비재생, videoId=null)', () => {
     expect(youtubePlayerCalls).toHaveLength(0);
   });
 });
+
+describe('VideoFrame · Mode 전환', () => {
+  test('Mode A → B 전환: wrapper DOM element identity 보존 (remount 없음) + class 만 교체', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    const wrapperBefore = screen.getByTestId('video-wrapper');
+    const ytBefore = screen.getByTestId('youtube-player-mock');
+    expect(wrapperBefore.className).toContain('aspect-video');
+
+    rerender(
+      <Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    const wrapperAfter = screen.getByTestId('video-wrapper');
+    const ytAfter = screen.getByTestId('youtube-player-mock');
+    expect(wrapperAfter).toBe(wrapperBefore);
+    expect(ytAfter).toBe(ytBefore);
+    expect(wrapperAfter.className).toContain('w-[80px]');
+    expect(wrapperAfter.className).toContain('h-[45px]');
+    expect(wrapperAfter.className).not.toContain('aspect-video');
+  });
+
+  test('Mode B → C 전환: YoutubePlayer unmount + BlankPlaceholder visible', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+    const callsBefore = youtubePlayerCalls.length;
+
+    rerender(
+      <Harness videoId={null} expanded={false} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls.length).toBe(callsBefore);
+  });
+
+  test('Mode C → A 전환: BlankPlaceholder unmount + YoutubePlayer mount', () => {
+    const { rerender } = render(
+      <Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+    expect(youtubePlayerCalls).toHaveLength(0);
+
+    rerender(<Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />);
+
+    expect(screen.queryByTestId('blank-placeholder')).toBeNull();
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+    expect(youtubePlayerCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('Mode A → C 전환: YoutubePlayer unmount + BlankPlaceholder mount (B→C 대칭, spec §7.1 #12)', () => {
+    const { rerender } = render(
+      <Harness videoId='abc' expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+    expect(screen.getByTestId('youtube-player-mock')).toBeTruthy();
+
+    rerender(
+      <Harness videoId={null} expanded={true} onToggleExpand={() => {}} gate={makeGate()} />
+    );
+
+    expect(screen.queryByTestId('youtube-player-mock')).toBeNull();
+    expect(screen.getByTestId('blank-placeholder')).toBeTruthy();
+  });
+});

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -1,7 +1,15 @@
 'use client';
+import dynamic from 'next/dynamic';
 import { FC, RefObject } from 'react';
 import type TReactPlayer from 'react-player';
+import { YouTubeConfig } from 'react-player/youtube';
+import { useUserPreferenceStore } from '@/entities/preference';
+import { cn } from '@/shared/lib/functions/cn';
+import BlankPlaceholder from './blank-placeholder.component';
+import ExpandToggle from './expand-toggle.component';
 import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+
+const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
 
 export const COLLAPSED_VIDEO_WIDTH = 80;
 export const COLLAPSED_VIDEO_HEIGHT = 45;
@@ -25,8 +33,69 @@ interface Props {
   gate: AutoplayGestureGate;
 }
 
-const VideoFrame: FC<Props> = (_props) => {
-  throw new Error('not implemented');
+const VideoFrame: FC<Props> = ({ videoId, expanded, onToggleExpand, playerRef, gate }) => {
+  const mode: 'A' | 'B' | 'C' = videoId === null ? 'C' : expanded ? 'A' : 'B';
+  const volume = useUserPreferenceStore((s) => s.volume);
+  const muted = useUserPreferenceStore((s) => s.muted);
+
+  const showOverlayGate = mode === 'A' && gate.autoplayBlocked && !gate.played;
+  const showToggle = mode === 'A' || mode === 'B';
+
+  return (
+    <div className='relative'>
+      <div data-testid='video-wrapper' className={cn('relative', wrapperClass(mode))}>
+        {mode === 'C' ? (
+          <BlankPlaceholder />
+        ) : (
+          <YoutubePlayer
+            key={`video-${gate.playerReady}-${gate.played}`}
+            url={`https://www.youtube.com/watch?v=${videoId}`}
+            playing={gate.playerReady}
+            volume={muted ? 0 : volume}
+            muted={muted}
+            width='100%'
+            height='100%'
+            className='bg-black rounded'
+            onReady={(player: TReactPlayer) => {
+              playerRef.current = player;
+              gate.onReady(player);
+            }}
+            onStart={gate.onStart}
+            onPlay={gate.onPlay}
+            onPause={gate.onPause}
+            config={config}
+          />
+        )}
+        {showOverlayGate && (
+          // z-20: autoplay 차단 시 overlay 가 ExpandToggle 을 의도적으로 가린다.
+          // 사용자가 토글 접근 전에 먼저 gesture release 를 해야 함 (UX 잠금).
+          <button
+            type='button'
+            data-testid='autoplay-gesture-gate'
+            aria-label='클릭하여 재생'
+            onClick={gate.handleGesturePlay}
+            className='absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-black/70 cursor-pointer'
+          >
+            <span className='flex items-center justify-center w-16 h-16 rounded-full bg-white/90'>
+              <svg width='28' height='28' viewBox='0 0 24 24' fill='black' aria-hidden>
+                <path d='M8 5v14l11-7z' />
+              </svg>
+            </span>
+            <span className='text-sm text-gray-100'>클릭하여 재생</span>
+          </button>
+        )}
+        {showToggle && (
+          <div className='absolute top-1 right-1 bg-black/40 rounded-full p-1'>
+            <ExpandToggle expanded={expanded} onToggle={onToggleExpand} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default VideoFrame;
+
+const config: YouTubeConfig = {
+  playerVars: { controls: 0, autoplay: 1, modestbranding: 1, rel: 0, autohide: 1 },
+};

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { FC, RefObject } from 'react';
+import type TReactPlayer from 'react-player';
+import type { AutoplayGestureGate } from '../../lib/use-autoplay-gesture-gate.hook';
+
+export const COLLAPSED_VIDEO_WIDTH = 80;
+export const COLLAPSED_VIDEO_HEIGHT = 45;
+
+export function wrapperClass(mode: 'A' | 'B' | 'C'): string {
+  switch (mode) {
+    case 'A':
+      return 'aspect-video w-full bg-black rounded';
+    case 'B':
+      return 'w-[80px] h-[45px] shrink-0 bg-black rounded';
+    case 'C':
+      return 'aspect-video w-full bg-black rounded';
+  }
+}
+
+interface Props {
+  videoId: string | null;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  playerRef: RefObject<TReactPlayer | null>;
+  gate: AutoplayGestureGate;
+}
+
+const VideoFrame: FC<Props> = (_props) => {
+  throw new Error('not implemented');
+};
+
+export default VideoFrame;

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from 'next/dynamic';
-import { FC, RefObject } from 'react';
+import { FC, MutableRefObject } from 'react';
 import type TReactPlayer from 'react-player';
 import { YouTubeConfig } from 'react-player/youtube';
 import { useUserPreferenceStore } from '@/entities/preference';
@@ -29,7 +29,9 @@ interface Props {
   videoId: string | null;
   expanded: boolean;
   onToggleExpand: () => void;
-  playerRef: RefObject<TReactPlayer | null>;
+  // VideoFrame 본문이 onReady 에서 playerRef.current 에 react-player 인스턴스를 할당하므로
+  // MutableRefObject 가 필요. 부모는 useRef<TReactPlayer | null>(null) 로 그대로 생성.
+  playerRef: MutableRefObject<TReactPlayer | null>;
   gate: AutoplayGestureGate;
 }
 


### PR DESCRIPTION
## 배경

chunk 2 의 모바일 디스플레이가 `1px×1px + opacity-0 + pointer-events-none` 로 YouTube IFrame 을 숨김 → **YouTube IFrame Player API 서비스 약관 위반**. prod ship 전 fix 필수 (chunk 3.1 spec §2.2).

## 변경 요약 (5 chunk)

- **Chunk 1**: `useAutoplayGestureGate` hook — autoplay 차단 감지 + gesture release single source. `AUTOPLAY_DETECT_MS` 상수 export. 데스크탑 `video.component.tsx` 의 inline 패턴 추출 (C3 격리, 데스크탑 0 수정).
- **Chunk 2**: 정적 parts 4개 — BlankPlaceholder, ExpandToggle, NowPlayingMeta, TapToPlayButton. 책임 분리 잠금 (wrapper class / positioning / 시각 styling 은 parent 책임).
- **Chunk 3**: `VideoFrame` orchestrator — 3 mode (A 풀폭 / B 80×45 / C 검정 placeholder) + wrapper-based sizing (YoutubePlayer width/height='100%' 고정, key 가 videoId/mode 미포함 → IFrame remount 회피).
- **Chunk 4**: root `MobilePartyroomDisplayBoard` 재설계 — 1px IFrame 본문 폐기 → VideoFrame + NowPlayingRow (NowPlayingMeta + TapToPlayButton). expanded state 토글 클릭 1곳에서만 변경.
- **Chunk 5**: Playwright headed mandatory CI — `display-board.tos.spec.ts` (Mode A/B/C + 토글 DOM identity + chat scroll 보존). branch protection required check 등록 (사용자 단발 GitHub UI 작업).

## ToS 보존 (spec §5)

3-layer 다중 방어:

- **unit**: YoutubePlayer width/height='100%' 단언, wrapper class `hidden`/`opacity-0`/`w-px`/`h-px`/`pointer-events-none` 부재 단언, `data-testid='video-wrapper'` 에 `aria-hidden='true'` 직접 부착 안 됨.
- **integration**: Mode 분기 + expanded 보존 invariants + cross-component single source.
- **Playwright headed (mandatory CI)**: ancestor visibility / computed style / boundingBox / viewport 안 / DOM identity / chat scroll 보존.

## 결정 잠금 (spec §3) — 핵심만

- Mode A/B/C + 우상단 ▾/◂ 토글, collapsed 80×45 (iOS HIG 44×44 hit-area 근접)
- 비재생 시 토글 hide (Mode C), expanded session-local (트랙 변경·Mode C 진입·복귀 모두 보존)
- YoutubePlayer width/height='100%' 고정 + wrapper Tailwind class 만 교체 (remount 0)
- 정적 Tailwind class only
- inline 한국어 (chunk 5 i18n catch-up 시 일괄 이주)
- 데스크탑 `widgets/partyroom-display-board/*` 0 수정 (C3 sibling 사본)

## 테스트

- hook 8 + parts 17 + video-frame 21 + integration 12 = **58 unit/integration**
- e2e (mandatory): 5 케이스 (Mode A / A↔B / B→A / Mode C / chat scroll)

## 체크리스트

- [x] `yarn test` GREEN
- [x] `yarn tsc --noEmit` 0 errors
- [x] `yarn lint` 0 errors
- [x] `yarn playwright test --list` 5 spec 등록
- [ ] **사용자 GitHub UI 작업**: Settings → Branches → `develop` / `release` 의 required check 에 \"Playwright E2E\" 등록 (spec §3 row 15, §10 step 6).
- [ ] **사용자 release 게이트**: chunk 3 (이미 develop 머지됨) 와 본 chunk 3.1 은 **단일 release 묶음으로 prod ship 필수** (spec §10 step 9).

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-29-mobile-display-board-tos-redesign.md` (v4, 16 결정 잠금)
- Plan: `docs/superpowers/plans/2026-05-29-mobile-display-board-tos-redesign.md` (5 chunk, plan-reviewer 5 iter Approved)

## Risk + 후속

- `useAutoplayGestureGate` (mobile) vs 데스크탑 inline 패턴 코드 중복 — 머지 직후 GH 이슈 신규 등록 (spec §9 risk #5).
- Mobile mode A 트랙 변경 시 seekToLive 미주입 — chunk 2 baseline 도 동일 (regression 아님), 별도 후속 PR.

## 관련

- pfplay-web #340 (모바일 반응형 전체 스코프)
- chunk 3 PR #357 (머지됨, develop)