### PR TITLE
fix(playwright): display-board-tos-mobile chromium 으로 강제 — CI WebKit 미설치 실패 해소

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -91,7 +91,11 @@ export default defineConfig({
     {
       name: 'display-board-tos-mobile',
       testMatch: /mobile\/display-board\.tos\.spec\.ts/,
-      use: { ...devices['iPhone 13'] },
+      // iPhone 13 viewport (390×844) + 모바일 UA 보존, browserName 만 chromium 으로 override.
+      // CI workflow 의 `npx playwright install --with-deps chromium` 이 chromium 만 설치하므로
+      // 기본 `browserName='webkit'` 가 launch 실패함 (`webkit-2272/pw_run.sh` not found).
+      // ToS 가드의 본질은 viewport/IFrame DOM 단언이라 engine 영향 미미 — 다른 e2e-a~d project 와 동일 browser 사용.
+      use: { ...devices['iPhone 13'], browserName: 'chromium' },
       dependencies: ['auth-a'],
     },
   ],


### PR DESCRIPTION
## 배경

PR #358 (chunk 3.1) 머지 후 development push 의 Playwright E2E run 26619366316 에서 신규 \`display-board-tos-mobile\` project 5/5 cases ALL FAIL:

\`\`\`
Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/webkit-2272/pw_run.sh
\`\`\`

## 원인

\`playwright.config.ts\` 의 신규 project 가 \`devices['iPhone 13']\` 를 사용. iPhone 13 device profile 의 기본 \`browserName\` 은 **webkit**. 그러나 CI workflow (\`.github/workflows/vercel-preview-e2e.yml\`) 의 install step:

\`\`\`yaml
- run: npx playwright install --with-deps chromium
\`\`\`

은 **chromium 만 설치**. WebKit 미설치 → launch 실패. 5/5 ALL fail.

## 수정

\`playwright.config.ts\` 의 \`display-board-tos-mobile\` project 의 \`use\` 에 \`browserName: 'chromium'\` override 추가:

\`\`\`ts
use: { ...devices['iPhone 13'], browserName: 'chromium' },
\`\`\`

- iPhone 13 viewport (390×844) + 모바일 UA **보존**
- browserName 만 chromium 으로 교체 (다른 e2e-a~d project 와 동일)
- CI workflow 변경 0 (install step 손대지 않음)

## ToS 가드 본질 영향 없음

chunk 3.1 의 ToS 가드는 viewport / IFrame DOM 단언 (boundingBox / computed style / DOM identity / class 토큰 부재) 이 본질. browser engine 자체는 가드 대상이 아님. chromium 으로 실행해도 동일 가드 효과.

추가 viewport 매트릭스 (iPhone SE / Pixel 7) 는 spec §7.4 의 후속 polish — 본 hotfix 와 별개.

## 체크리스트

- [x] \`yarn tsc --noEmit\` 0 errors
- [x] \`yarn playwright test --list --project=display-board-tos-mobile\` 5 spec 등록
- [ ] CI Playwright E2E GREEN (post-merge)

## 관련

- PR #358 (chunk 3.1, MERGED): \`45e65697\`
- 실패 run: https://github.com/pfplay/pfplay-web/actions/runs/26619366316