### PR TITLE
ci(playwright): workflow timeout 20→30 min (chunk 3.1 mobile budget 확보)

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -41,7 +41,10 @@ jobs:
     needs: deploy
     if: ${{ needs.deploy.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # chunk 3.1 mobile project (5 cases × ~90s setup + assertions) 추가로 총 16 tests
+    # 순차 실행 (workers:1) 시 budget 부족 → 30 min 으로 상향.
+    # 이전 baseline: ~10 min (PR #357 chunk 3 머지 시). chunk 3.1 의 5 mobile setup overhead 누적.
+    timeout-minutes: 30
     environment: Preview – pfplay-web
     env:
       E2E_BASE_URL: https://stg.pfplay.xyz


### PR DESCRIPTION
## 배경

PR #359 hotfix 머지 후 development push run [26620171948](https://github.com/pfplay/pfplay-web/actions/runs/26620171948) 이 **22:59 만에 workflow timeout 으로 cancel**.

## 분석

- workflow \`timeout-minutes: 20\` 설정
- 총 16 tests · workers:1 순차 실행
- e2e-a / e2e-d 로그 보임 (~05:41-05:43), 이후 **16+ min silence** (mobile project 5 cases + e2e-b/c 가 로그 없이 진행)
- chunk 3.1 의 5 mobile cases 가 각 \`createPartyroom + playlist + DJ + IFrame 시청\` setup 으로 ~90s/case → 5 × 90s ≈ 7.5 min 추가 overhead
- 이전 baseline: PR #357 (chunk 3 머지) ~10 min · PR #358 (chunk 3.1, webkit fail 빠른 실패) 14 min · 본 run timeout 23 min

## 수정

\`\`\`yaml
timeout-minutes: 30   # 20에서 상향
\`\`\`

추가 주석으로 budget 산정 근거 명시 (이전 baseline + 5 mobile setup overhead).

## 후속 polish 가능성 (별도 PR)

본 PR 은 timeout 만 단순 상향. mobile project 의 setup 공유 refactor 는 별도 polish:

- 5 cases 가 모두 동일 \`createPartyroom + playlist + DJ\` 함 → 1 partyroom session 안에 Mode A/B/C 전환 검증 1 case 로 묶을 수 있음 (~5 min 회수 가능)
- spec §7.4 의 추가 viewport 매트릭스 (iPhone SE / Pixel 7) 추가 시 본 timeout 도 재검토 필요

## 체크리스트

- [x] yaml diff minimal
- [ ] CI Playwright E2E GREEN (post-merge)

## 관련

- PR #358 (chunk 3.1, MERGED): \`45e65697\`
- PR #359 (webkit→chromium hotfix, MERGED): \`ac9105a\`
- timeout cancel run: https://github.com/pfplay/pfplay-web/actions/runs/26620171948