### PR TITLE
fix(e2e/mobile): desktop setup + mobile assertion 분리 — 모바일 lobby 'Be a pfplay host' 부재 회피

### DIFF
--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -1,4 +1,5 @@
-import { expect } from '@playwright/test';
+import path from 'path';
+import { type Browser, type BrowserContext, type Page, devices, expect } from '@playwright/test';
 import {
   CHAT_SCROLL_TOLERANCE_PX,
   COLLAPSED_VIDEO_HEIGHT,
@@ -10,8 +11,8 @@ import {
   mobilePlaylistName,
 } from './display-board.helpers';
 import { test } from '../fixtures/auth.fixtures';
+import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 import {
-  closePartyroom,
   createPartyroom,
   createPlaylistWithTracks,
   enterPartyroomAndWaitUntilReady,
@@ -22,137 +23,176 @@ import {
  * chunk 3.1 spec §5 — ToS 보존 가드 (Playwright headed, mandatory CI).
  *
  * iPhone 13 (390×844) 단일 매트릭스 — 추가 viewport (SE / Pixel) 는 후속 polish.
- * 세션 cleanup: 각 케이스는 createPartyroom 으로 신규 룸 + 끝에 closePartyroom.
+ *
+ * **setup 책임 분리 (chunk 5 reviewer BLOCKING #1 post-merge fix)**:
+ * - partyroom 생성 / DJ 등록 / playlist UI 는 *desktop* 만 노출 (mobile UX 는 join 중심,
+ *   [[project_mobile_responsive_scope_340]]). createPartyroom helper 의 'Be a pfplay
+ *   host' 버튼이 모바일 lobby 에 부재 → 모바일 viewport 에서 setup fail.
+ * - 본 spec 은 `beforeAll` 에서 **desktop context (user1)** 가 partyroom 을 setup 하고
+ *   DJ session 을 keep-alive. 각 테스트는 **mobile context (user2)** 가 partyroom URL 로
+ *   직접 진입해 ToS 가드만 assertion. setup 1회 공유로 5 cases 총 소요 ~2 min.
  */
 
-test('Mode A 진입: IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님', async ({
-  user1Context,
-}) => {
-  test.setTimeout(120_000);
-  const page = await user1Context.newPage();
+const AUTH_DIR = path.join(__dirname, '../.auth');
 
-  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
-  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
-  await createPlaylistWithTracks(page, mobilePlaylistName());
-  await registerAsDj(page);
+async function newDesktopUserContext(browser: Browser): Promise<BrowserContext> {
+  const ctx = await browser.newContext({
+    ...devices['Desktop Chrome'],
+    storageState: path.join(AUTH_DIR, 'a-user1.json'),
+    ignoreHTTPSErrors: true,
+    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+      ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+      : {},
+  });
+  await ctx.addInitScript(ETHEREUM_MOCK_SCRIPT);
+  return ctx;
+}
 
-  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+// ─────────────────────────────────────────────────────────────────────────────
+// Group 1: 재생 활성 (Mode A / 토글 / chat scroll — 4 tests, 1 partyroom 공유)
+// ─────────────────────────────────────────────────────────────────────────────
 
-  await expectIframeToBeOnScreen(page);
-  await expectIframeNotVisuallyHidden(page);
+test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
+  test.describe.configure({ mode: 'serial' });
 
-  await closePartyroom(page);
+  let djContext: BrowserContext;
+  let djPage: Page;
+  let partyroomUrl: string;
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(180_000);
+    djContext = await newDesktopUserContext(browser);
+    djPage = await djContext.newPage();
+    partyroomUrl = await createPartyroom(djPage, mobilePartyroomName());
+    await enterPartyroomAndWaitUntilReady(djPage, partyroomUrl);
+    await createPlaylistWithTracks(djPage, mobilePlaylistName());
+    await registerAsDj(djPage);
+    // djContext alive 유지 — DJ session 끊기면 mobile listener 가 Mode A 진입 X.
+  });
+
+  test.afterAll(async () => {
+    if (djContext) await djContext.close();
+  });
+
+  test('Mode A 진입: IFrame visible + boundingBox ≥ 80×45 + viewport 안 + 시각 hidden 아님', async ({
+    user2Context,
+  }) => {
+    test.setTimeout(60_000);
+    const page = await user2Context.newPage();
+    await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+    await expectIframeToBeOnScreen(page);
+    await expectIframeNotVisuallyHidden(page);
+  });
+
+  test('Mode A → Mode B 토글: wrapper 80×45 정확값 + IFrame 여전히 visible + DOM identity 보존', async ({
+    user2Context,
+  }) => {
+    test.setTimeout(60_000);
+    const page = await user2Context.newPage();
+    await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+    const iframeBefore = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+    expect(iframeBefore).not.toBeNull();
+
+    await page.getByRole('button', { name: '영상 가리기' }).click();
+    await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+
+    const wrapper = page.getByTestId('video-wrapper');
+    const wrapperBox = await wrapper.boundingBox();
+    expect(wrapperBox).not.toBeNull();
+    if (!wrapperBox) return;
+    expect(Math.round(wrapperBox.width)).toBe(COLLAPSED_VIDEO_WIDTH);
+    expect(Math.round(wrapperBox.height)).toBe(COLLAPSED_VIDEO_HEIGHT);
+
+    await expectIframeNotVisuallyHidden(page);
+
+    const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+    expect(iframeAfter).not.toBeNull();
+    const sameElement = await page.evaluate(([a, b]) => a === b, [iframeBefore, iframeAfter]);
+    expect(sameElement).toBe(true);
+  });
+
+  test('Mode B → Mode A 복귀: IFrame 동일 element + 16:9 wrapper 복귀', async ({
+    user2Context,
+  }) => {
+    test.setTimeout(60_000);
+    const page = await user2Context.newPage();
+    await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+    const iframeInitial = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+
+    await page.getByRole('button', { name: '영상 가리기' }).click();
+    await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+    await page.getByRole('button', { name: '영상 펼치기' }).click();
+    await expect(page.getByRole('button', { name: '영상 가리기' })).toBeVisible();
+
+    const wrapper = page.getByTestId('video-wrapper');
+    await expect(wrapper).toHaveClass(/aspect-video/);
+
+    const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
+    const sameElement = await page.evaluate(([a, b]) => a === b, [iframeInitial, iframeAfter]);
+    expect(sameElement).toBe(true);
+  });
+
+  test('sticky-top 높이 변화 시 chat scroll offset ≤ CHAT_SCROLL_TOLERANCE_PX 보존', async ({
+    user2Context,
+  }) => {
+    test.setTimeout(60_000);
+    const page = await user2Context.newPage();
+    await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+
+    const chatTab = page.getByRole('tab', { name: /채팅/ }).first();
+    if (await chatTab.isVisible().catch(() => false)) {
+      await chatTab.click();
+    }
+
+    const chatContainer = page.locator('[data-tab-content="chat"]').first();
+    await expect(chatContainer).toBeVisible();
+
+    await page.waitForTimeout(500);
+
+    const scrollBefore = await chatContainer.evaluate((el) => el.scrollTop);
+
+    await page.getByRole('button', { name: '영상 가리기' }).click();
+    await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+    await page.waitForTimeout(300);
+
+    const scrollAfter = await chatContainer.evaluate((el) => el.scrollTop);
+
+    const delta = Math.abs(scrollAfter - scrollBefore);
+    expect(delta).toBeLessThanOrEqual(CHAT_SCROLL_TOLERANCE_PX);
+  });
 });
 
-test('Mode A → Mode B 토글: wrapper 80×45 정확값 + IFrame 여전히 visible + DOM identity 보존', async ({
-  user1Context,
-}) => {
-  test.setTimeout(120_000);
-  const page = await user1Context.newPage();
+// ─────────────────────────────────────────────────────────────────────────────
+// Group 2: 재생 없음 (Mode C — 1 test, DJ 등록 X 의 별도 partyroom)
+// ─────────────────────────────────────────────────────────────────────────────
 
-  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
-  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
-  await createPlaylistWithTracks(page, mobilePlaylistName());
-  await registerAsDj(page);
-  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+test.describe('재생 없음 — Mode C', () => {
+  test.describe.configure({ mode: 'serial' });
 
-  const iframeBefore = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
-  expect(iframeBefore).not.toBeNull();
+  let setupContext: BrowserContext;
+  let setupPage: Page;
+  let partyroomUrl: string;
 
-  await page.getByRole('button', { name: '영상 가리기' }).click();
-  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(120_000);
+    setupContext = await newDesktopUserContext(browser);
+    setupPage = await setupContext.newPage();
+    partyroomUrl = await createPartyroom(setupPage, mobilePartyroomName());
+    await enterPartyroomAndWaitUntilReady(setupPage, partyroomUrl);
+    // DJ 등록 / playlist 모두 skip — playback 없는 상태로 mobile 이 진입 시 Mode C 트리거.
+  });
 
-  const wrapper = page.getByTestId('video-wrapper');
-  const wrapperBox = await wrapper.boundingBox();
-  expect(wrapperBox).not.toBeNull();
-  if (!wrapperBox) return;
-  expect(Math.round(wrapperBox.width)).toBe(COLLAPSED_VIDEO_WIDTH);
-  expect(Math.round(wrapperBox.height)).toBe(COLLAPSED_VIDEO_HEIGHT);
+  test.afterAll(async () => {
+    if (setupContext) await setupContext.close();
+  });
 
-  await expectIframeNotVisuallyHidden(page);
-
-  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
-  expect(iframeAfter).not.toBeNull();
-  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeBefore, iframeAfter]);
-  expect(sameElement).toBe(true);
-
-  await closePartyroom(page);
-});
-
-test('Mode B → Mode A 복귀: IFrame 동일 element + 16:9 wrapper 복귀', async ({ user1Context }) => {
-  test.setTimeout(120_000);
-  const page = await user1Context.newPage();
-
-  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
-  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
-  await createPlaylistWithTracks(page, mobilePlaylistName());
-  await registerAsDj(page);
-  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
-
-  const iframeInitial = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
-
-  await page.getByRole('button', { name: '영상 가리기' }).click();
-  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
-  await page.getByRole('button', { name: '영상 펼치기' }).click();
-  await expect(page.getByRole('button', { name: '영상 가리기' })).toBeVisible();
-
-  const wrapper = page.getByTestId('video-wrapper');
-  await expect(wrapper).toHaveClass(/aspect-video/);
-
-  const iframeAfter = await page.locator('iframe[src*="youtube.com/embed"]').elementHandle();
-  const sameElement = await page.evaluate(([a, b]) => a === b, [iframeInitial, iframeAfter]);
-  expect(sameElement).toBe(true);
-
-  await closePartyroom(page);
-});
-
-test('Mode C (재생 없음): BlankPlaceholder visible + IFrame 미존재', async ({ user1Context }) => {
-  test.setTimeout(120_000);
-  const page = await user1Context.newPage();
-
-  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
-  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
-
-  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
-
-  await expect(page.getByTestId('blank-placeholder')).toBeVisible();
-  await expect(page.locator('iframe[src*="youtube.com/embed"]')).toHaveCount(0);
-
-  await closePartyroom(page);
-});
-
-test('sticky-top 높이 변화 시 chat scroll offset ≤ CHAT_SCROLL_TOLERANCE_PX 보존', async ({
-  user1Context,
-}) => {
-  test.setTimeout(120_000);
-  const page = await user1Context.newPage();
-
-  const partyroomUrl = await createPartyroom(page, mobilePartyroomName());
-  await enterPartyroomAndWaitUntilReady(page, partyroomUrl);
-  await createPlaylistWithTracks(page, mobilePlaylistName());
-  await registerAsDj(page);
-  await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
-
-  const chatTab = page.getByRole('tab', { name: /채팅/ }).first();
-  if (await chatTab.isVisible().catch(() => false)) {
-    await chatTab.click();
-  }
-
-  const chatContainer = page.locator('[data-tab-content="chat"]').first();
-  await expect(chatContainer).toBeVisible();
-
-  await page.waitForTimeout(500);
-
-  const scrollBefore = await chatContainer.evaluate((el) => el.scrollTop);
-
-  await page.getByRole('button', { name: '영상 가리기' }).click();
-  await expect(page.getByRole('button', { name: '영상 펼치기' })).toBeVisible();
-  await page.waitForTimeout(300);
-
-  const scrollAfter = await chatContainer.evaluate((el) => el.scrollTop);
-
-  const delta = Math.abs(scrollAfter - scrollBefore);
-  expect(delta).toBeLessThanOrEqual(CHAT_SCROLL_TOLERANCE_PX);
-
-  await closePartyroom(page);
+  test('Mode C: BlankPlaceholder visible + IFrame 미존재', async ({ user2Context }) => {
+    test.setTimeout(60_000);
+    const page = await user2Context.newPage();
+    await gotoMobileRoomAndWaitForVideo(page, partyroomUrl);
+    await expect(page.getByTestId('blank-placeholder')).toBeVisible();
+    await expect(page.locator('iframe[src*="youtube.com/embed"]')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## 배경

PR #360 머지 후 run [26621305433](https://github.com/pfplay/pfplay-web/actions/runs/26621305433) 의 **5/5 mobile cases ALL FAIL**:

\`\`\`
Test timeout of 120000ms exceeded.
Error: locator.click: Target page, context or browser has been closed
Call log:
  - waiting for getByRole('button', { name: /be a pfplay host/i })

at createPartyroom (e2e/helpers/partyroom.helpers.ts:182)
\`\`\`

## 원인

\`createPartyroom\` helper 의 \`'Be a pfplay host'\` 버튼은 **desktop UI 만** 노출. 모바일 lobby 는 [[project_mobile_responsive_scope_340]] 의 게이트라인 (공유링크 유입 전환·게스트 맛보기·로그인 게이트) 에 따라 join 중심 — partyroom **생성 UI 부재**.

따라서 mobile project (\`devices['iPhone 13']\` viewport) 에서 \`createPartyroom\` 호출 시 버튼 못 찾고 120s timeout 후 fail.

chunk 5 plan-document-reviewer 가 BLOCKING #1 으로 명시 (\"createPartyroom 가 모바일 viewport 에서 동작하나?\") — 실제 발생 사례.

## 수정

\`e2e/mobile/display-board.tos.spec.ts\` 본문 재구조:

### Group 1: 재생 활성 (4 tests, 1 partyroom 공유)

- \`beforeAll\`: **desktop context** (\`devices['Desktop Chrome']\` + a-user1 storage state) 가 partyroom 생성 + DJ + playlist setup. DJ session alive 유지.
- 각 test: **mobile context** (project 의 iPhone 13 + user2) 가 partyroom URL 직접 진입 → ToS 가드 assertion.
- \`describe.serial\` mode 로 group 별 1회 setup 공유.

### Group 2: 재생 없음 (Mode C, 1 test, 별도 partyroom)

- \`beforeAll\`: desktop context 가 partyroom 생성만 (DJ 등록 X). 빈 partyroom.
- test: mobile context 가 진입 → Mode C (BlankPlaceholder + IFrame 미존재).

## 부수 효과

- 5 cases 총 소요: ~10 min (각각 setup) → **~2 min** (group 별 1회 setup 공유)
- workflow 30 min budget 여유 충분
- 책임 분리 본질에 부합 — partyroom CRUD = desktop, ToS 가드 = mobile

## 체크리스트

- [x] \`yarn tsc --noEmit\` 0 errors
- [x] \`yarn playwright test --list --project=display-board-tos-mobile\` 5 tests 등록 (2 describe groups)
- [ ] CI Playwright E2E GREEN (post-merge)

## 관련 PR / Run

- PR #358 chunk 3.1 (MERGED): \`45e65697\`
- PR #359 webkit→chromium hotfix (MERGED): \`ac9105a\`
- PR #360 workflow timeout 30 min (MERGED): \`440b88a\`
- Run 26619366316: webkit 미설치 (5/5)
- Run 26620171948: workflow timeout cancel
- Run 26621305433: createPartyroom 부재 (5/5, 본 PR 의 fix 대상)