### PR TITLE
fix(e2e/mobile): beforeAll 의 createPartyroom 전 goto('/parties') 추가

### DIFF
--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -63,9 +63,13 @@ test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
     test.setTimeout(180_000);
     djContext = await newDesktopUserContext(browser);
     djPage = await djContext.newPage();
+    // createPartyroom 의 'Be a pfplay host' 는 /parties lobby UI 의 버튼. blank page 에서
+    // 호출하면 못 찾음 → e2e-a 패턴 (goto /parties 먼저, 그 후 createPlaylistWithTracks +
+    // createPartyroom) 그대로 따른다.
+    await djPage.goto('/parties');
+    await createPlaylistWithTracks(djPage, mobilePlaylistName());
     partyroomUrl = await createPartyroom(djPage, mobilePartyroomName());
     await enterPartyroomAndWaitUntilReady(djPage, partyroomUrl);
-    await createPlaylistWithTracks(djPage, mobilePlaylistName());
     await registerAsDj(djPage);
     // djContext alive 유지 — DJ session 끊기면 mobile listener 가 Mode A 진입 X.
   });
@@ -179,6 +183,8 @@ test.describe('재생 없음 — Mode C', () => {
     test.setTimeout(120_000);
     setupContext = await newDesktopUserContext(browser);
     setupPage = await setupContext.newPage();
+    // /parties 로 navigate 후 createPartyroom (lobby UI 의 'Be a pfplay host' 버튼 진입).
+    await setupPage.goto('/parties');
     partyroomUrl = await createPartyroom(setupPage, mobilePartyroomName());
     await enterPartyroomAndWaitUntilReady(setupPage, partyroomUrl);
     // DJ 등록 / playlist 모두 skip — playback 없는 상태로 mobile 이 진입 시 Mode C 트리거.


### PR DESCRIPTION
## 배경

PR #361 머지 후 run [26622738503](https://github.com/pfplay/pfplay-web/actions/runs/26622738503) — **12.3 min · 11 passed · 2 failed**:

\`\`\`
"beforeAll" hook timeout of 180000ms exceeded.
Error: locator.click: Target page, context or browser has been closed
Call log:
  - waiting for getByRole('button', { name: /be a pfplay host/i })
at createPartyroom (e2e/helpers/partyroom.helpers.ts:182)
```

## 원인

PR #361 의 refactor 가 \`beforeAll\` 에서 \`newPage()\` 직후 바로 \`createPartyroom\` 호출. 그러나 \`createPartyroom\` 의 'Be a pfplay host' 버튼은 \`/parties\` lobby 의 UI 요소 — blank page 에서는 못 찾음.

e2e-a 가 동작하는 패턴 (`e2e/e2e-a.partyroom-join-sync.spec.ts:81-87`):

```ts
await page1.goto('/parties');         // 명시적 navigation
await createPlaylistWithTracks(page1, name);   // playlist 먼저
partyroomUrl = await createPartyroom(page1, name);  // 그 다음 partyroom
```

내 refactor 가 \`goto('/parties')\` 누락 + 순서 다름.

## 수정

Group 1 + Group 2 의 \`beforeAll\` 모두:

1. \`await page.goto('/parties')\` 명시
2. e2e-a 와 동일 순서: \`(playlist) → partyroom → enter → DJ\`

## 진전

- Run #1: 0/5 mobile (webkit 미설치)
- Run #2: cancel (workflow timeout)
- Run #3: 0/5 mobile (createPartyroom 부재)
- Run #4: **3/5 mobile pass** (refactor 부분 성공 — Mode B↔A 토글 + chat scroll + 11 desktop e2e GREEN)
- Run #5 (본 PR): goto 추가 → 5/5 mobile pass 예상

## 체크리스트

- [x] tsc 0 errors
- [ ] CI Playwright E2E GREEN (post-merge)

## 관련 PR

- PR #358 chunk 3.1 (MERGED)
- PR #359 webkit→chromium (MERGED)
- PR #360 workflow timeout 30 min (MERGED)
- PR #361 desktop setup refactor (MERGED)