### PR TITLE
fix(e2e/mobile): base36 짧은 이름 + Mode C timeout + 디버그 로그

### DIFF
--- a/e2e/mobile/display-board.helpers.ts
+++ b/e2e/mobile/display-board.helpers.ts
@@ -4,8 +4,11 @@ export const CHAT_SCROLL_TOLERANCE_PX = 10;
 export const COLLAPSED_VIDEO_WIDTH = 80;
 export const COLLAPSED_VIDEO_HEIGHT = 45;
 
-export const mobilePartyroomName = () => `MOBILE-TOS-${Date.now()}`;
-export const mobilePlaylistName = () => `mobile-tos-pl-${Date.now()}`;
+/** 케이스마다 고유한 partyroom / playlist 이름. e2e-a 패턴 (Date.now().toString(36)) 으로
+ *  base36 짧은 문자열 사용 — UI 의 긴 이름 truncation/ellipsis 시 `new RegExp(name)`
+ *  매칭 실패 회피 (run #5 의 Group 1 Mode A beforeAll fail 원인). */
+export const mobilePartyroomName = () => `MTOS${Date.now().toString(36)}`;
+export const mobilePlaylistName = () => `MTOSpl${Date.now().toString(36)}`;
 
 export async function gotoMobileRoomAndWaitForVideo(page: Page, partyroomUrl: string) {
   await page.goto(partyroomUrl);

--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -61,16 +61,27 @@ test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
 
   test.beforeAll(async ({ browser }) => {
     test.setTimeout(180_000);
+    const t0 = Date.now();
+    const log = (m: string) => console.log(`[Group 1 beforeAll][${Date.now() - t0}ms] ${m}`);
     djContext = await newDesktopUserContext(browser);
     djPage = await djContext.newPage();
+    djPage.on('console', (msg) => {
+      if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
+    });
     // createPartyroom 의 'Be a pfplay host' 는 /parties lobby UI 의 버튼. blank page 에서
     // 호출하면 못 찾음 → e2e-a 패턴 (goto /parties 먼저, 그 후 createPlaylistWithTracks +
     // createPartyroom) 그대로 따른다.
+    log('goto /parties');
     await djPage.goto('/parties');
+    log('createPlaylistWithTracks');
     await createPlaylistWithTracks(djPage, mobilePlaylistName());
+    log('createPartyroom');
     partyroomUrl = await createPartyroom(djPage, mobilePartyroomName());
+    log(`partyroom created: ${partyroomUrl}`);
     await enterPartyroomAndWaitUntilReady(djPage, partyroomUrl);
+    log('ready');
     await registerAsDj(djPage);
+    log('DJ registered');
     // djContext alive 유지 — DJ session 끊기면 mobile listener 가 Mode A 진입 X.
   });
 
@@ -180,13 +191,22 @@ test.describe('재생 없음 — Mode C', () => {
   let partyroomUrl: string;
 
   test.beforeAll(async ({ browser }) => {
-    test.setTimeout(120_000);
+    // Group 1 (180s) 와 통일 — cold-start 여파로 120s 가 부족했음 (run #5).
+    test.setTimeout(180_000);
+    const t0 = Date.now();
+    const log = (m: string) => console.log(`[Mode C beforeAll][${Date.now() - t0}ms] ${m}`);
     setupContext = await newDesktopUserContext(browser);
     setupPage = await setupContext.newPage();
-    // /parties 로 navigate 후 createPartyroom (lobby UI 의 'Be a pfplay host' 버튼 진입).
+    setupPage.on('console', (msg) => {
+      if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
+    });
+    log('goto /parties');
     await setupPage.goto('/parties');
+    log('createPartyroom');
     partyroomUrl = await createPartyroom(setupPage, mobilePartyroomName());
+    log(`partyroom created: ${partyroomUrl}`);
     await enterPartyroomAndWaitUntilReady(setupPage, partyroomUrl);
+    log('ready');
     // DJ 등록 / playlist 모두 skip — playback 없는 상태로 mobile 이 진입 시 Mode C 트리거.
   });
 


### PR DESCRIPTION
## 배경

PR #362 머지 후 run [26623940093](https://github.com/pfplay/pfplay-web/actions/runs/26623940093) — 11/13 PASS, 2 mobile fail (12.2 min).

## 두 가지 다른 원인

### Group 1 Mode A beforeAll

\`createPlaylistWithTracks\` 가 \`new RegExp(playlistName)\` 으로 playlist 버튼 클릭. playlist 이름 \`mobile-tos-pl-1780039649340\` (13자 Date.now 십진) — UI 의 긴 이름 truncation/ellipsis 와 match 충돌.

e2e-a 패턴 (\`Date.now().toString(36)\`) 으로 base36 짧은 문자열 (~8자) 사용:
- \`mobile-tos-pl-1780039649340\` (27자) → \`MTOSpllwqrhvfk\` (14자)

### Mode C beforeAll

cold-start 여파로 \`'create party'\` click 시점에 120s timeout 도달. Group 1 (180s) 와 통일 → 180s.

## 추가 — 디버그 로그

두 beforeAll 에 phase 별 console.log + browser console.error mirroring 추가. 다음 fail 시 stage 별 시간 + 브라우저 에러 즉시 진단 가능.

## 변경

- \`e2e/mobile/display-board.helpers.ts\`: mobilePartyroomName/PlaylistName base36
- \`e2e/mobile/display-board.tos.spec.ts\`:
  - Group 1 beforeAll: 디버그 로그 (goto / createPlaylist / createPartyroom / enter / DJ)
  - Mode C beforeAll: timeout 120→180s + 디버그 로그

## 체크리스트

- [x] tsc 0 errors
- [ ] CI Playwright E2E GREEN (post-merge)

## 관련

- chunk 3.1 PR #358 (MERGED) / PR #359~#362 (모두 hotfix MERGED)
- 본 PR = 5번째 hotfix iter