### PR TITLE
fix(e2e/mobile): afterAll closePartyroom — backend '1 user 1 host' 제약 회피

### DIFF
--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -13,6 +13,7 @@ import {
 import { test } from '../fixtures/auth.fixtures';
 import { ETHEREUM_MOCK_SCRIPT } from '../fixtures/ethereum-mock';
 import {
+  closePartyroom,
   createPartyroom,
   createPlaylistWithTracks,
   enterPartyroomAndWaitUntilReady,
@@ -86,6 +87,12 @@ test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
   });
 
   test.afterAll(async () => {
+    // backend partyroom termination 필수 — backend 가 'user 1 host' 제약을 가진다.
+    // afterAll 에서 partyroom 정리 안 하면 user1 이 host 로 락된 채 다음 describe 의
+    // beforeAll 의 createPartyroom 이 403 으로 fail (Mode C beforeAll lock-out).
+    if (djPage && !djPage.isClosed() && partyroomUrl) {
+      await closePartyroom(djPage, partyroomUrl).catch(() => null);
+    }
     if (djContext) await djContext.close();
   });
 
@@ -211,6 +218,9 @@ test.describe('재생 없음 — Mode C', () => {
   });
 
   test.afterAll(async () => {
+    if (setupPage && !setupPage.isClosed() && partyroomUrl) {
+      await closePartyroom(setupPage, partyroomUrl).catch(() => null);
+    }
     if (setupContext) await setupContext.close();
   });
 


### PR DESCRIPTION
## 배경

PR #363 머지 후 run [26625070847](https://github.com/pfplay/pfplay-web/actions/runs/26625070847) — 11/13 PASS, **2 mobile fail** (3.8 min).

디버그 로그가 핵심 잡음:
\`\`\`
[Group 1 beforeAll][7451ms] createPartyroom
[Group 1 beforeAll][8104ms] browser console.error: Failed to load resource: 403 ()
[Group 1 beforeAll][8105ms] browser console.error: AxiosError
\`\`\`

## Root Cause (확정 — 로컬 docker MySQL 직접 query 로 검증)

backend 가 **'user 가 동시에 1 partyroom 의 host 만 가능'** 제약. 로컬 \`partyroom\` 테이블 query:
\`\`\`
partyroom_id  title          host_id              status
2             MTOSmpqmx365   848109072896668860   ACTIVE
\`\`\`

user1 이 이전 test 의 stale partyroom 의 host 로 락 → 새 createPartyroom POST 403.

내 \`afterAll\` 이 \`djContext.close()\` 만 호출하고 backend partyroom termination 안 함 → 다음 describe (Mode C) 의 beforeAll 시 user1 이 여전히 host 락 상태 → 403.

## 로컬 검증

- 수정 전 (PR #363): 6/7 (Mode C fail)
- 수정 후 (본 PR): **7/7 PASS** (1.1 min)
  - 로그: \`partyroom created: http://localhost:3000/parties/5\` → Group 1 partyroom cleanup 후 Mode C 가 새 partyroom 정상 생성
  - \`E2E_BASE_URL=http://localhost:3000 NEXT_PUBLIC_API_HOST_NAME=http://localhost:8080/api/ npx playwright test --project=display-board-tos-mobile\`

## 수정

\`\`\`ts
test.afterAll(async () => {
  // backend partyroom termination 필수 — '1 user 1 host' 제약
  if (djPage && !djPage.isClosed() && partyroomUrl) {
    await closePartyroom(djPage, partyroomUrl).catch(() => null);
  }
  if (djContext) await djContext.close();
});
\`\`\`

- Group 1 + Mode C 두 \`afterAll\` 모두 \`closePartyroom\` API call (DELETE \`/v1/partyrooms/{id}\`)
- \`.catch(() => null)\` cleanup 실패 시 silently 흡수
- closePartyroom helper 는 이미 \`partyroom.helpers.ts:178\` 에 존재 (e2e-a 등이 동일 패턴)

## ⚠️ stg backend 누적 stale 가능성

과거 5번 CI fail run 들이 user1 (a-user1) 으로 partyroom 만들고 cleanup 안 됨 → stg backend 에 stale partyrooms 누적. 본 PR fix 는 **future-leak 방지**. 첫 CI run 도 fail 시 stg DB 수동 cleanup 필요할 수 있음 (host=me 검색 endpoint 부재로 코드 cleanup 한계).

## 진전

| Run | PR | 결과 |
|-----|-----|-----|
| #1 | #358 | webkit 미설치 0/5 |
| #2 | #359 | timeout cancel |
| #3 | #360 | createPartyroom 부재 0/5 |
| #4 | #361 | desktop setup 3/5 |
| #5 | #362 | goto 추가 후 2/5 fail (playlist name truncation) |
| #6 | #363 | 11 passed / 2 fail (backend 403) |
| #7 | **본 PR** | **로컬 7/7 GREEN** — CI 결과 대기 |

## 체크리스트

- [x] tsc 0 errors
- [x] 로컬 \`npx playwright test --project=display-board-tos-mobile\` 7/7 PASS
- [ ] CI Playwright E2E GREEN (stg backend stale 영향 가능)