### PR TITLE
fix(e2e/mobile): defensive cleanup + error tracing 4종 + CI artifact 확장

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -100,5 +100,10 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          # playwright-report: HTML 리포트. test-results: trace.zip / video.webm / screenshot
+          # (config 의 trace='on-first-retry' / video='on-first-retry' 가 retry 시 자동 캡쳐).
+          # 화면 모달 / DOM 스냅샷 / 액션 history 디버그 → `npx playwright show-trace` 로 재생.
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 7

--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -52,6 +52,47 @@ async function newDesktopUserContext(browser: Browser): Promise<BrowserContext> 
 const API_BASE = process.env.NEXT_PUBLIC_API_HOST_NAME ?? 'https://dev-api.pfplay.xyz/api/';
 
 /**
+ * 화면 모달 / JS 에러 추적 강화. 디버그 로그에 4종 source 의 에러를 통합:
+ *
+ * - `page.on('pageerror')`: uncaught JS exception (window.onerror, React error boundary, Next dev overlay 의 빨간 화면)
+ * - `page.on('dialog')`: window.alert / confirm / prompt 모달 — 등장 시 dismiss + 본문 기록
+ * - `page.on('console')`: console.error / console.warn (기존)
+ * - Next.js dev overlay DOM 주기 스캔: `nextjs-portal` / `[data-nextjs-dialog]` selector 의 textContent
+ *
+ * Playwright config 의 trace/video 는 retry 시 자동 캡쳐 (test-results/).
+ * CI workflow 의 artifact path 도 test-results/ 포함으로 확장 필요 (별도 변경).
+ */
+function attachErrorTracing(page: Page, log: (m: string) => void) {
+  page.on('pageerror', (err) => {
+    log(`pageerror: ${err.message}\n${err.stack ?? ''}`);
+  });
+  page.on('dialog', async (dialog) => {
+    log(`dialog ${dialog.type()}: ${dialog.message()}`);
+    await dialog.dismiss().catch(() => null);
+  });
+  page.on('console', (msg) => {
+    const t = msg.type();
+    if (t === 'error' || t === 'warning') {
+      log(`browser console.${t}: ${msg.text()}`);
+    }
+  });
+  // Next.js dev overlay 주기 스캔 (3s 간격) — 빠른 fail 시점에 overlay 잡힘
+  const interval = setInterval(async () => {
+    try {
+      const overlay = page.locator('nextjs-portal, [data-nextjs-dialog]').first();
+      if (await overlay.isVisible({ timeout: 100 }).catch(() => false)) {
+        const text = await overlay.textContent({ timeout: 500 }).catch(() => null);
+        if (text) log(`next-overlay: ${text.replace(/\s+/g, ' ').slice(0, 500)}`);
+      }
+    } catch {
+      // page closed during scan — clear interval
+      clearInterval(interval);
+    }
+  }, 3000);
+  page.on('close', () => clearInterval(interval));
+}
+
+/**
  * Defensive cleanup — 과거 비정상 종료 (workflow timeout, SIGKILL 등) 로 누적된
  * mobile test partyrooms 정리. backend '1 user 1 host' 제약 회피.
  *
@@ -95,9 +136,7 @@ test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
     const log = (m: string) => console.log(`[Group 1 beforeAll][${Date.now() - t0}ms] ${m}`);
     djContext = await newDesktopUserContext(browser);
     djPage = await djContext.newPage();
-    djPage.on('console', (msg) => {
-      if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
-    });
+    attachErrorTracing(djPage, log);
     // ⚠️ 과거 비정상 종료로 누적된 mobile test partyrooms 정리 — backend '1 user 1 host' 제약 회피
     log('defensive cleanup');
     await cleanupMobileTestPartyrooms(djContext);
@@ -237,9 +276,7 @@ test.describe('재생 없음 — Mode C', () => {
     const log = (m: string) => console.log(`[Mode C beforeAll][${Date.now() - t0}ms] ${m}`);
     setupContext = await newDesktopUserContext(browser);
     setupPage = await setupContext.newPage();
-    setupPage.on('console', (msg) => {
-      if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
-    });
+    attachErrorTracing(setupPage, log);
     log('defensive cleanup');
     await cleanupMobileTestPartyrooms(setupContext);
     log('cleanup done');

--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -49,6 +49,35 @@ async function newDesktopUserContext(browser: Browser): Promise<BrowserContext> 
   return ctx;
 }
 
+const API_BASE = process.env.NEXT_PUBLIC_API_HOST_NAME ?? 'https://dev-api.pfplay.xyz/api/';
+
+/**
+ * Defensive cleanup — 과거 비정상 종료 (workflow timeout, SIGKILL 등) 로 누적된
+ * mobile test partyrooms 정리. backend '1 user 1 host' 제약 회피.
+ *
+ * 동작:
+ * 1. GET /v1/partyrooms → ACTIVE 전체 list
+ * 2. title prefix 'MTOS' 또는 'MOBILE-TOS-' 인 row 만 필터 (mobile test 명명)
+ * 3. 각각 DELETE 시도 — 권한 없거나 이미 정리됐으면 silently 흡수
+ *
+ * title prefix 가 일반 사용자 명명과 겹칠 가능성 0 (테스트 전용 접두사).
+ */
+async function cleanupMobileTestPartyrooms(ctx: BrowserContext): Promise<void> {
+  try {
+    const response = await ctx.request.get(new URL('v1/partyrooms', API_BASE).toString());
+    if (!response.ok()) return;
+    const list = (await response.json()) as Array<{ partyroomId: number; title: string }>;
+    const stale = list.filter((p) => /^(MTOS|MOBILE-TOS-)/.test(p.title));
+    for (const p of stale) {
+      await ctx.request
+        .delete(new URL(`v1/partyrooms/${p.partyroomId}`, API_BASE).toString())
+        .catch(() => null);
+    }
+  } catch {
+    // cleanup 실패는 test 결과 가리지 않음
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Group 1: 재생 활성 (Mode A / 토글 / chat scroll — 4 tests, 1 partyroom 공유)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -69,6 +98,10 @@ test.describe('재생 활성 — Mode A/B 토글 + chat scroll', () => {
     djPage.on('console', (msg) => {
       if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
     });
+    // ⚠️ 과거 비정상 종료로 누적된 mobile test partyrooms 정리 — backend '1 user 1 host' 제약 회피
+    log('defensive cleanup');
+    await cleanupMobileTestPartyrooms(djContext);
+    log('cleanup done');
     // createPartyroom 의 'Be a pfplay host' 는 /parties lobby UI 의 버튼. blank page 에서
     // 호출하면 못 찾음 → e2e-a 패턴 (goto /parties 먼저, 그 후 createPlaylistWithTracks +
     // createPartyroom) 그대로 따른다.
@@ -207,6 +240,9 @@ test.describe('재생 없음 — Mode C', () => {
     setupPage.on('console', (msg) => {
       if (msg.type() === 'error') log(`browser console.error: ${msg.text()}`);
     });
+    log('defensive cleanup');
+    await cleanupMobileTestPartyrooms(setupContext);
+    log('cleanup done');
     log('goto /parties');
     await setupPage.goto('/parties');
     log('createPartyroom');


### PR DESCRIPTION
## 배경 + 두 개의 fix 동봉

PR #364 (afterAll closePartyroom) 머지 후 run [26626603184](https://github.com/pfplay/pfplay-web/actions/runs/26626603184) — 11/13 PASS, **2 mobile fail** (3.8 min). future-leak 차단됐지만 **stg 누적 stale 영향** 그대로.

### Fix 1: Defensive cleanup at beforeAll

cleanupMobileTestPartyrooms 헬퍼:
1. GET /v1/partyrooms list
2. title 'MTOS' 또는 'MOBILE-TOS-' prefix 필터 (mobile test 명명, 일반 사용자 명명과 충돌 0)
3. 각각 DELETE 시도 — 권한 없거나 정리됐으면 silently 흡수

두 beforeAll 시작 시 호출. stg 누적 stale 자동 정리 + 미래 비정상 종료 대비.

### Fix 2: 화면 모달 / JS 에러 추적 강화 (사용자 요청)

attachErrorTracing(page, log) — 4 source 통합:
- page.on('pageerror'): uncaught JS exception (React error boundary / Next dev overlay 의 빨간 화면)
- page.on('dialog'): alert/confirm/prompt 모달 — dismiss + 본문 기록
- page.on('console'): error + warning
- Next.js dev overlay DOM 주기 스캔 (3s): nextjs-portal / [data-nextjs-dialog]

CI workflow artifact path 에 test-results/ 추가:
- trace.zip / video.webm / screenshot 다운로드 가능
- 'npx playwright show-trace' 로 재생

## 로컬 검증

E2E_BASE_URL=http://localhost:3000 NEXT_PUBLIC_API_HOST_NAME=http://localhost:8080/api/ npx playwright test --project=display-board-tos-mobile:

- **7/7 PASS** (1.1 min)
- defensive cleanup 동작 확인 (insert 한 stale 정리)
- pageerror tracing 동작 — **사용자가 본 화면 모달 정체 잡힘**:
  - @headlessui/react Dialog cleanup 시 stack trace
  - src/shared/ui/components/dialog/dialog.component.tsx:24 의 DialogProvider 라이프사이클
  - afterAll context.close 시점 발생
  - prod 영향 0 (Next dev overlay 만 노출)

## 진전

| Run | PR | 결과 |
|-----|-----|-----|
| #1 | #358 | webkit 미설치 0/5 |
| #2 | #359 | timeout cancel |
| #3 | #360 | createPartyroom 부재 0/5 |
| #4 | #361 | desktop setup 3/5 |
| #5 | #362 | goto 추가 2/5 |
| #6 | #363 | 11 passed / 2 fail (403 backend) |
| #7 | #364 | 11 passed / 2 fail (stg 누적 stale) |
| #8 | **본 PR** | **로컬 7/7 GREEN — stg 누적 자동 정리 예상** |

## 체크리스트

- [x] tsc 0 errors
- [x] 로컬 7/7 PASS
- [ ] CI Playwright E2E GREEN