### PR TITLE
fix(e2e/mobile): defensive cleanup filter 확장 — e2e-a/b/c/d prefix 포함

### DIFF
--- a/e2e/mobile/display-board.tos.spec.ts
+++ b/e2e/mobile/display-board.tos.spec.ts
@@ -94,21 +94,28 @@ function attachErrorTracing(page: Page, log: (m: string) => void) {
 
 /**
  * Defensive cleanup — 과거 비정상 종료 (workflow timeout, SIGKILL 등) 로 누적된
- * mobile test partyrooms 정리. backend '1 user 1 host' 제약 회피.
+ * e2e test partyrooms 정리. backend '1 user 1 host' 제약 회피.
  *
  * 동작:
  * 1. GET /v1/partyrooms → ACTIVE 전체 list
- * 2. title prefix 'MTOS' 또는 'MOBILE-TOS-' 인 row 만 필터 (mobile test 명명)
- * 3. 각각 DELETE 시도 — 권한 없거나 이미 정리됐으면 silently 흡수
+ * 2. title prefix e2e 6종 ('E2EA'/'E2EB'/'E2EC'/'E2ED'/'MTOS'/'MOBILE-TOS-') 필터
+ * 3. 각각 DELETE 시도 — 권한 없거나 정리됐으면 silently 흡수
  *
- * title prefix 가 일반 사용자 명명과 겹칠 가능성 0 (테스트 전용 접두사).
+ * mobile project 가 a-user1 storage state 를 e2e-a 와 공유 — e2e-a/b/c/d 가
+ * afterAll 의 closePartyroom 실패 시 (네트워크 / 권한 / 비정상 종료) 누적되는
+ * 해당 user host stale 도 함께 정리해야 mobile beforeAll 의 createPartyroom 이
+ * 'ALREADY_HOST' 403 으로 fail 안 함.
+ *
+ * title prefix 일반 사용자 명명과 겹칠 가능성 0 (테스트 전용 접두사).
  */
+const E2E_PARTYROOM_TITLE_PATTERN = /^(E2EA|E2EB|E2EC|E2ED|MTOS|MOBILE-TOS-)/;
+
 async function cleanupMobileTestPartyrooms(ctx: BrowserContext): Promise<void> {
   try {
     const response = await ctx.request.get(new URL('v1/partyrooms', API_BASE).toString());
     if (!response.ok()) return;
     const list = (await response.json()) as Array<{ partyroomId: number; title: string }>;
-    const stale = list.filter((p) => /^(MTOS|MOBILE-TOS-)/.test(p.title));
+    const stale = list.filter((p) => E2E_PARTYROOM_TITLE_PATTERN.test(p.title));
     for (const p of stale) {
       await ctx.request
         .delete(new URL(`v1/partyrooms/${p.partyroomId}`, API_BASE).toString())


### PR DESCRIPTION
## 배경

PR #365 의 defensive cleanup filter 가 `MTOS` / `MOBILE-TOS-` (mobile test prefix) 만 잡음. 같은 \`a-user1\` storage state 를 공유하는 \`e2e-a/b/c/d\` 의 partyroom title (`E2EA` / `E2EB` / `E2EC` / `E2ED`) 은 매치 안 됨.

\`e2e-a/b/c/d\` 의 afterAll closePartyroom 가 실패한 run (네트워크 / 권한 / 비정상 종료) 의 누적분이 mobile beforeAll 시점에 잔존 → user1 host 락 → ALREADY_HOST 403.

## 증상

최근 E2E run [26633066504](https://github.com/pfplay/pfplay-web/actions/runs/26633066504): **2 failed (Mode A + Mode C beforeAll)** / 10 passed / 1 flaky.

디버그 로그:
\`\`\`
[Group 1 beforeAll][100ms] defensive cleanup
[Group 1 beforeAll][751ms] cleanup done       ← 0건 처리 의심 (즉시 완료)
[Group 1 beforeAll][8176ms] createPartyroom
[Group 1 beforeAll][8777ms] console.error: 403
\`\`\`

cleanup 자체는 동작하나 filter 가 `E2EA/B/C/D` prefix 안 잡아서 142~145 (e2e-a~d 가 만든 partyrooms) skip.

## 수정

filter 정규식 확장:
\`\`\`ts
const E2E_PARTYROOM_TITLE_PATTERN = /^(E2EA|E2EB|E2EC|E2ED|MTOS|MOBILE-TOS-)/;
\`\`\`

- e2e 6종 prefix 전체 매치
- 일반 사용자 명명 영향 0 (모두 e2e 전용 접두사)

## 진단 path (사용자 SQL 검증 병행)

backend fix (PR pfplay-platform #276/#277, release 머지 + stg deploy success) 가 실제 stg-api 에 적용됐는지는 별개 검증 진행 중:

\`\`\`sql
SELECT partyroom_id, title, host_id, status FROM partyroom WHERE partyroom_id BETWEEN 142 AND 145;
\`\`\`

- **모두 TERMINATED**: e2e-a~d 의 closePartyroom 정상 = backend fix 적용 OK. 본 PR (filter 확장) + SQL 일괄 cleanup 으로 GREEN 예상
- **ACTIVE 잔존**: backend fix stg 적용 안 됨. release branch empty commit push 로 deploy 재트리거 필요 (본 PR 과 별개)

## 체크리스트

- [x] tsc 0 errors
- [ ] CI Playwright E2E GREEN (사용자 SQL UPDATE 누적 정리 후)

## 관련 PR

- PR #358 chunk 3.1 (MERGED)
- PR #359~#365 frontend e2e hotfix
- pfplay-platform PR #276/#277 backend tier 비대칭 fix (MERGED, release deploy success)