### PR TITLE
fix(ci): e2e helper API host stg-api 명시 — 9-iter hotfix 의 진짜 root cause

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -95,6 +95,11 @@ jobs:
       - run: yarn test:e2e
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # e2e helper 의 closePartyroom 등이 직접 backend API 호출하는데, env 명시
+          # 안 하면 fallback 'dev-api.pfplay.xyz' 사용. stg-api 가 아닌 dev backend
+          # 로 DELETE → stg partyroom 의 id 못 찾음 → silent 흡수 → stale 누적.
+          # stg frontend 가 호출하는 stg-api 와 일치시킴.
+          NEXT_PUBLIC_API_HOST_NAME: https://stg-api.pfplay.xyz/api/
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## 진단 결과 (사용자가 끝까지 추적)

`e2e/helpers/partyroom.helpers.ts:178-` 의 closePartyroom:
\`\`\`ts
const API_BASE_URL = process.env.NEXT_PUBLIC_API_HOST_NAME ?? 'https://dev-api.pfplay.xyz/api/';
await page.request.delete(new URL(\`v1/partyrooms/\${id}\`, API_BASE_URL).toString())
  .catch(() => null);  // ← silent fail
\`\`\`

CI workflow 에 \`NEXT_PUBLIC_API_HOST_NAME\` env 미명시 → fallback \`dev-api.pfplay.xyz\` 사용 → stg 의 partyroom 호출이 **dev backend 로 감** → 404 silent 흡수 → **stg partyroom 누적 ACTIVE**.

증거:
- stg backend logs: \`DELETE /api/v1/partyrooms/14X\` 흔적 0 (= dev 로 갔다)
- stg backend logs: presence cron 의 PENDING_EXIT → OFFLINE 만 보임 (user exit 자동, partyroom termination 안 됨)
- 로컬 검증 (env=localhost:8080): partyroom 모두 TERMINATED 정상
- 142~149 stg ACTIVE 잔존 (host_id 매번 다름 = 매 run 새 user 라 별도 충돌 표면화)

## 9개월간 묻혀있던 silent leak

본 leak 는 **chunk 3.1 회귀가 아닌 e2e infra 의 오래된 sigent leak**:

- e2e-a/b/c/d 의 closePartyroom 도 항상 silent fail (모르고 사용)
- 매 run 마다 새 backend user (auth setup 새 user 생성) → 다른 run 의 stale partyroom 충돌 0
- 각 e2e (a/b/c/d) 가 별도 auth 사용 → 서로 영향 0
- → 표면화 안 됨

chunk 3.1 mobile project 가 **auth-a 를 공유** = 같은 run 의 같은 user → e2e-a 가 만든 stale partyroom 의 host 도 mobile 의 user 와 같음 → \`findNonTerminatedHostRoom(X)\` hit → ALREADY_HOST 403.

## 수정

\`\`\`yaml
- run: yarn test:e2e
  env:
    NEXT_PUBLIC_API_HOST_NAME: https://stg-api.pfplay.xyz/api/
\`\`\`

stg frontend 가 호출하는 stg-api 와 일치.

## 부수 효과

- **모든 e2e (a/b/c/d/mobile)** 의 backend stale 누적 0 → 미래 안정성 강화
- chunk 3.1 mandatory CI GREEN 예상
- pfplay-platform PR #276/#277 (tier 비대칭 fix) 도 이번 fix 와 함께 진짜 동작

## 회고

- 9 iter (#358 ~ #366) frontend hotfix + 2 backend PR (#276, #277) — 표면 증상에 대한 처치
- 진짜 본질 = 1 yaml env 추가
- 사용자가 일관 추적으로 발견 (지원 아끼지 않은 진단 SQL/SSH chain)

## 체크리스트

- [x] tsc clean
- [ ] CI Playwright E2E GREEN (post-merge)