### PR TITLE
[모바일 반응형 chunk 5] lobby 카드 데스크탑 catch-up

### DIFF
--- a/docs/superpowers/plans/2026-05-30-mobile-lobby-card-catchup.md
+++ b/docs/superpowers/plans/2026-05-30-mobile-lobby-card-catchup.md
@@ -1,0 +1,616 @@
+# 모바일 lobby 카드 데스크탑 catch-up (chunk 5) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `MobilePartyroomCard` 를 데스크탑 `PartyroomCard` 와 동일한 BackdropBlur 단일 카드 패턴으로 rewrite. shared 컴포넌트 (`BackdropBlurContainer`, `Typography`, `Crews`) 차용 + `MainStageLabel` sub-컴포넌트로 i18n 의존 격리.
+
+**Architecture:** 단일 파일 rewrite 가 핵심. spec §4.2 의 코드 명세를 ground truth 로 사용. TDD 는 컴포넌트 단위 (case 6개 일괄 red → rewrite → all green). list 컴포넌트는 isMain prop 전달 한 줄 변경.
+
+**Tech Stack:** Next.js 14 (App Router), TypeScript ^5.5, vitest ^4.0, @testing-library/react, tailwindcss 3.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md`
+**Issue:** pfplay-web#377
+**Branch:** `feature/mobile-responsive-chunk5` (origin/development 동기화 후 분기, spec 4 commits ahead)
+
+---
+
+## Chunk 1: 단위 test 6 케이스 갱신 + 카드 rewrite (TDD)
+
+### Phase 0: Pre-flight
+
+**Files:** 없음 (확인만)
+
+- [ ] **Step 0.1: 브랜치 / 상태 확인**
+
+Run:
+
+```bash
+cd "C:/Users/Eisen/Desktop/Labs/[projects] pfplay/pfplay-web"
+git status
+git log --oneline -5
+git branch --show-current
+```
+
+Expected:
+
+- branch = `feature/mobile-responsive-chunk5`
+- HEAD log 에 `docs(mobile/chunk-5)` commit 4건 (101a3ca / 96d8ca2 / 7cdcedf / 12ef856)
+- working tree clean
+
+- [ ] **Step 0.2: PFPersonFilled import 가능성 사전 확인 (dry-run)**
+
+Spec §4.8 Mock 정리 마지막 bullet 의 advisory — Crews 컴포넌트가 `PFPersonFilled` 를 import 한다. vitest 가 svg 컴포넌트를 그대로 처리할 수 있는지 확인.
+
+Run:
+
+```bash
+yarn vitest run src/features/partyroom/list/ui/crews.component 2>&1 | head -30
+```
+
+Expected: "No test files found" (Crews 는 test 가 없음). 단 import 자체가 에러 없이 해결되는지 확인 → 에러 메시지 있으면 PFPersonFilled mock 추가 필요. 보통 SvgComponent 는 transformer 로 처리되므로 mock 불필요할 가능성 높음.
+
+Confirm:
+
+```bash
+ls src/shared/ui/icons/ | head -20
+```
+
+Expected: PFPersonFilled 가 svg/tsx 파일로 존재 (e.g. `PFPersonFilled.tsx` 또는 index re-export).
+
+판정:
+
+- import 에러 없으면 → Phase 1 의 mock 정의에서 PFPersonFilled mock 생략
+- import 에러 있으면 → Phase 1 Step 1.1 의 mock 정의에 `vi.mock('@/shared/ui/icons', ...)` 추가
+
+---
+
+### Phase 1: 단위 test 6 케이스 갱신 (red)
+
+**Files:**
+
+- Modify: `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx`
+
+- [ ] **Step 1.1: test 파일 6 케이스 갱신**
+
+기존 3 케이스 (case 1·2·3) 중 case 3 (placeholder 동작) 만 단언 변경. case 4·5·6 추가. i18n mock 은 vi.mock 으로 파일 상단 전역 적용 (케이스 1·2·3·4 는 MainStageLabel 미마운트라 영향 없음, 케이스 5·6 만 mock 키 참조).
+
+Replace `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` 전체:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { StageType } from '@/shared/api/http/types/@enums';
+import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
+import MobilePartyroomCard from './partyroom-card.component';
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} alt={props.alt ?? ''} />,
+}));
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, onClick }: any) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+// MainStageLabel 분기 (isMain=true 케이스) 전용 mock.
+// 케이스 1·2·3·4 는 MainStageLabel 미마운트라 useI18n 호출 X — mock 영향 받지 않음을 단언으로 검증.
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    lobby: {
+      para: {
+        pfplay_main_stage: 'PFPlay Main Stage',
+      },
+    },
+  }),
+}));
+
+const baseSummary: PartyroomSummary = {
+  partyroomId: 1,
+  stageType: StageType.GENERAL,
+  title: '토요일밤 파티',
+  introduction: '같이 들어요',
+  crewCount: 12,
+  playbackActivated: true,
+  playback: { name: 'Song Title', thumbnailImage: '/thumb.png', duration: '3:30' },
+  primaryIcons: [{ avatarIconUri: '/avatar.png' }],
+};
+
+describe('MobilePartyroomCard', () => {
+  test('제목·인원·now-playing 을 표시한다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    expect(screen.getByText('토요일밤 파티')).toBeTruthy();
+    expect(screen.getByText(/12/)).toBeTruthy();
+    expect(screen.getByText('Song Title')).toBeTruthy();
+  });
+
+  test('카드 전체가 /parties/{id}?source=list 로 이동한다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/parties/1?source=list');
+  });
+
+  test('playbackActivated=false 일 때 now-playing 영역이 렌더되지 않는다', () => {
+    render(
+      <MobilePartyroomCard
+        roomId={baseSummary.partyroomId}
+        summary={{ ...baseSummary, playbackActivated: false, playback: undefined }}
+      />
+    );
+    // v1 placeholder "재생 중인 곡이 없어요" 는 삭제됨 (BackdropBlur fallback 이미지로 대체)
+    expect(screen.queryByText(/재생 중인 곡이 없어요/)).toBeNull();
+    // now-playing 곡 썸네일 영역 부재
+    expect(screen.queryByAltText('playback thumbnail')).toBeNull();
+  });
+
+  test('primaryIcons 개수만큼 아바타가 렌더된다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    // Crews 컴포넌트가 primaryIcons.slice(0, 3) 으로 alt='party crew' 의 <Image /> 렌더
+    expect(screen.getAllByAltText('party crew').length).toBe(1);
+  });
+
+  test('isMain=true 일 때 "PFPlay Main Stage" 라벨이 표시된다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} isMain />);
+    expect(screen.getByText('PFPlay Main Stage')).toBeTruthy();
+  });
+
+  test('isMain 이 falsy 일 때 "PFPlay Main Stage" 라벨이 표시되지 않는다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    expect(screen.queryByText('PFPlay Main Stage')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 1.2: test 실행하여 red 확인**
+
+Run:
+
+```bash
+yarn vitest run src/features-mobile/partyroom/list/partyroom-card.component.test.tsx 2>&1 | tail -40
+```
+
+Expected:
+
+- 6 case 중 다음이 fail:
+  - **case 3** (placeholder 단언 변경): v1 코드의 "재생 중인 곡이 없어요" placeholder 가 아직 존재 → `screen.queryByText(/재생 중인 곡이 없어요/)` 가 truthy → fail
+  - **case 4** (아바타): v1 코드는 emoji 만 → `getAllByAltText('party crew')` 0건 → fail
+  - **case 5** (Main 라벨 표시): v1 코드는 `isMain` prop 자체가 없음 → 라벨 미렌더 → fail
+- case 1·2·6 은 통과 가능 (case 6 은 라벨 미표시가 v1 의 default 동작).
+
+이 fail pattern 이 다음 step 의 정답 시그널.
+
+- [ ] **Step 1.3: commit (red baseline)**
+
+```bash
+git add src/features-mobile/partyroom/list/partyroom-card.component.test.tsx
+git -c user.email="livinglikekrillin@gmail.com" -c user.name="정주영" commit -m "test(mobile/chunk-5): 카드 단위 test 6 케이스 갱신 (red, #377)
+
+- case 3: 'playback=false' placeholder 단언 → 미렌더 단언으로 변경
+- case 4 신규: primaryIcons 개수만큼 아바타 렌더
+- case 5 신규: isMain=true 일 때 'PFPlay Main Stage' 라벨 표시
+- case 6 신규: isMain falsy 일 때 라벨 미표시
+- i18n mock 추가 (case 5·6 의 MainStageLabel 분기용)
+
+case 3·4·5 가 v1 코드에서 fail (예상된 red baseline).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Phase 2: 카드 컴포넌트 rewrite (green)
+
+**Files:**
+
+- Replace: `src/features-mobile/partyroom/list/partyroom-card.component.tsx`
+
+- [ ] **Step 2.1: 카드 컴포넌트를 spec §4.2 명세로 rewrite**
+
+Replace `src/features-mobile/partyroom/list/partyroom-card.component.tsx` 전체:
+
+```tsx
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { FC } from 'react';
+import Crews from '@/features/partyroom/list/ui/crews.component';
+import { getPartyroomCardBackdropProps } from '@/features/partyroom/list/ui/partyroom-card-backdrop';
+import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { BackdropBlurContainer } from '@/shared/ui/components/backdrop-blur-container';
+import { Typography } from '@/shared/ui/components/typography';
+
+interface Props {
+  roomId: number;
+  summary: PartyroomSummary;
+  onClose?: () => void;
+  /** Main 카드일 때 true → "PFPlay Main Stage" 라벨 표시 */
+  isMain?: boolean;
+}
+
+/**
+ * Main 라벨 sub-컴포넌트.
+ *
+ * isMain=true 분기에서만 마운트 → `useI18n` 호출이 라벨 케이스에 한정.
+ * 일반 카드 (isMain=false) 는 이 컴포넌트를 마운트하지 않으므로 i18n provider 의존 X.
+ * (기존 v1 카드 단위 test 들이 i18n mock 없이 통과하는 invariant 보존.)
+ */
+const MainStageLabel: FC = () => {
+  const t = useI18n();
+  return (
+    <Typography type='caption2' className='text-gray-300 uppercase tracking-wide'>
+      {t.lobby.para.pfplay_main_stage}
+    </Typography>
+  );
+};
+
+/**
+ * 모바일 로비 1컬럼 카드 (chunk 5 = 데스크탑 baseline catch-up).
+ *
+ * - 데스크탑 PartyroomCard 와 동일한 BackdropBlur 단일 카드 패턴, 모바일 폼팩터로 축소.
+ * - shared 컴포넌트 (BackdropBlurContainer, Typography, Crews) 차용.
+ * - PFInfoOutline 은 모바일에서 의도적으로 제외 (정보 기능 없는 정적 아이콘).
+ * - isMain=true 일 때 title2 위 caption2 chip 으로 "PFPlay Main Stage" 라벨 (MainStageLabel sub-컴포넌트로 분리).
+ */
+const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) => {
+  return (
+    <BackdropBlurContainer
+      src={summary.playback?.thumbnailImage}
+      {...getPartyroomCardBackdropProps(summary.playback?.thumbnailImage)}
+    >
+      <Link
+        href={`/parties/${roomId}?source=list`}
+        onClick={onClose}
+        className='h-full flexCol justify-between gap-10 py-5 px-5 backdrop-blur-sm bg-backdrop-black/80'
+      >
+        <div className='flexCol gap-1.5'>
+          {isMain && <MainStageLabel />}
+          <Typography type='title2' className='text-gray-50'>
+            {summary.title}
+          </Typography>
+        </div>
+
+        <div className='gap-3 flexCol max-w-full'>
+          {summary.playback && (
+            <div className='flex-1 max-w-full min-w-0 flexRowCenter gap-3 rounded'>
+              <div className='w-[64px] h-[36px] bg-gray-700 shrink-0'>
+                <Image
+                  priority
+                  src={summary.playback.thumbnailImage}
+                  alt='playback thumbnail'
+                  width={64}
+                  height={36}
+                  className='w-full h-full object-contain select-none'
+                />
+              </div>
+              <Typography
+                type='caption1'
+                overflow='ellipsis'
+                className='flex-1 text-gray-50 select-none'
+              >
+                {summary.playback.name}
+              </Typography>
+            </div>
+          )}
+          <div className='bg-gray-600 h-[1px]' />
+          <Crews
+            count={summary.crewCount}
+            icons={summary.primaryIcons.map((a) => a.avatarIconUri)}
+          />
+        </div>
+      </Link>
+    </BackdropBlurContainer>
+  );
+};
+
+export default MobilePartyroomCard;
+```
+
+- [ ] **Step 2.2: 카드 단위 test 6 케이스 GREEN 확인**
+
+Run:
+
+```bash
+yarn vitest run src/features-mobile/partyroom/list/partyroom-card.component.test.tsx 2>&1 | tail -20
+```
+
+Expected: `Tests  6 passed (6)` / `Test Files  1 passed (1)`.
+
+만약 case 1 의 `screen.getByText(/12/)` 가 fail 한다면 Crews 컴포넌트의 count 렌더 형식 확인 — Crews 는 Typography body3 로 숫자만 표시 (suffix 없음). v1 의 "👥 12명" → 변경된 "12" → `getByText(/12/)` 로 정규식이라 통과해야 함.
+
+만약 case 4 의 `getAllByAltText('party crew')` 가 fail 한다면:
+
+- Crews 컴포넌트 line 26 `alt={'party crew'}` 확인
+- mock `next/image` 가 `alt` prop 을 제대로 forward 하는지 확인 (현 mock 정의 `alt={props.alt ?? ''}` 적용됨)
+
+PFPersonFilled 미해결 import 에러 발생 시 Phase 0 Step 0.2 의 판정대로 mock 추가:
+
+```tsx
+vi.mock('@/shared/ui/icons', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/ui/icons')>('@/shared/ui/icons');
+  return {
+    ...actual,
+    PFPersonFilled: (props: any) => <svg data-testid='pf-person-filled' {...props} />,
+  };
+});
+```
+
+- [ ] **Step 2.3: typecheck clean**
+
+Run:
+
+```bash
+yarn typecheck 2>&1 | tail -10
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 2.4: lint clean (해당 파일)**
+
+Run:
+
+```bash
+yarn lint --max-warnings 0 src/features-mobile/partyroom/list/partyroom-card.component.tsx 2>&1 | tail -10
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 2.5: commit (green)**
+
+```bash
+git add src/features-mobile/partyroom/list/partyroom-card.component.tsx
+git -c user.email="livinglikekrillin@gmail.com" -c user.name="정주영" commit -m "feat(mobile/chunk-5): 카드 rewrite (BackdropBlur 단일, Crews, Typography, MainStageLabel) (#377)
+
+데스크탑 PartyroomCard 와 동일한 BackdropBlur 단일 카드 패턴으로
+rewrite. 모바일 폼팩터로 spacing 축소 (px-5/py-5/gap-10).
+
+- BackdropBlurContainer + 80% 불투명 오버레이 (데스크탑 검증된 가독성)
+- Crews 아바타 (PFPersonFilled + count + 아바타 최대 3개)
+- Typography 토큰 (title2 / caption1 / caption2)
+- MainStageLabel sub-컴포넌트 분리 — useI18n 호출이 라벨 케이스에 한정
+- PFInfoOutline 제외 (정보 기능 없는 정적 아이콘, 깔때기 lens redundant)
+- 사용자 가시 동작 변화: 'playback=false' placeholder 텍스트 제거
+  → BackdropBlur fallback 이미지로 대체
+
+6 unit tests GREEN.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Phase 3: list 컴포넌트 isMain prop 전달
+
+**Files:**
+
+- Modify: `src/features-mobile/partyroom/list/partyroom-list.component.tsx`
+
+- [ ] **Step 3.1: list 컴포넌트의 Main 카드 prepend 부분 수정**
+
+기존 list (spread + map) 를 **명시적 분리 prepend** 로 변경. Main 카드에 `isMain` prop 전달.
+
+Replace return 블록 (line 24~42):
+
+```tsx
+const MobilePartyroomList: FC = () => {
+  const { data: mainRoom } = useSuspenseFetchMainPartyroom();
+  const { data: generalRooms } = useFetchGeneralPartyrooms();
+
+  if (!mainRoom && (!generalRooms || generalRooms.length === 0)) {
+    return (
+      <div className='w-full py-12 text-center text-sm text-gray-500'>
+        지금 열려 있는 파티가 없어요.
+      </div>
+    );
+  }
+
+  return (
+    <ul className='flexCol gap-4 w-full'>
+      {mainRoom && (
+        <li key={mainRoom.partyroomId}>
+          <MobilePartyroomCard roomId={mainRoom.partyroomId} summary={mainRoom} isMain />
+        </li>
+      )}
+      {generalRooms?.map((summary) => (
+        <li key={summary.partyroomId}>
+          <MobilePartyroomCard roomId={summary.partyroomId} summary={summary} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+```
+
+**주의**: 기존 빈 상태 ("지금 열려 있는 파티가 없어요") 표시 조건이 `rooms.length === 0` 이었는데, 분리 후 `!mainRoom && (!generalRooms || generalRooms.length === 0)` 으로 정정 — 의미 동일.
+
+상단 import / 컴포넌트 주석 (line 1~19) 은 유지. 단 line 12 주석의 "맨 앞 prepend" 표현 그대로 valid.
+
+- [ ] **Step 3.2: typecheck clean**
+
+Run:
+
+```bash
+yarn typecheck 2>&1 | tail -10
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3.3: 회귀 unit test (전체) clean**
+
+Run:
+
+```bash
+yarn vitest run src/features-mobile 2>&1 | tail -10
+```
+
+Expected: 전체 features-mobile 단위 test 모두 GREEN.
+
+- [ ] **Step 3.4: commit**
+
+```bash
+git add src/features-mobile/partyroom/list/partyroom-list.component.tsx
+git -c user.email="livinglikekrillin@gmail.com" -c user.name="정주영" commit -m "feat(mobile/chunk-5): list 의 Main 카드에 isMain prop 전달 (#377)
+
+mainRoom prepend 와 generalRooms map 을 명시적으로 분리. isMain 판정
+로직이 컴포넌트 위치(idx)가 아닌 데이터 소스에 직접 매핑됨 — generalRooms
+정렬 변경에 fragile 한 idx 기반 대안 회피.
+
+빈 상태 표시 조건 의미 동일하게 정정 (rooms.length === 0
+  → !mainRoom && (!generalRooms || generalRooms.length === 0)).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Phase 4: e2e 영향 점검
+
+**Files:** 없음 (조사만, 발견 시 follow-up commit)
+
+- [ ] **Step 4.1: e2e 영향 grep**
+
+Run:
+
+```bash
+rg "재생 중인 곡이 없어요|MobilePartyroomCard|partyroom-card\.component" e2e/ 2>&1
+```
+
+Expected: 모바일 lobby 카드 텍스트 단언이나 컴포넌트 직접 참조 0건이 이상적. 발견 시 항목 정리:
+
+| 파일:line      | 단언 | 영향 |
+| -------------- | ---- | ---- |
+| (발견 시 채움) |      |      |
+
+- [ ] **Step 4.2: 발견된 영향 수정 (있을 때만)**
+
+영향 spec 에서 placeholder 텍스트 단언이 있으면:
+
+- 단언 제거 또는 새 동작 (now-playing 영역 부재) 단언으로 교체
+- BackdropBlur 카드 구조 단언 (예: 카드 배경에 `bg-backdrop-black/80` 클래스 존재) 추가 검토
+
+수정 후:
+
+```bash
+git add e2e/<영향파일>
+git -c user.email="livinglikekrillin@gmail.com" -c user.name="정주영" commit -m "test(e2e/mobile): chunk 5 카드 rewrite 영향 단언 갱신 (#377)
+
+<구체적 변경 설명>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+발견 없으면 skip + 별도 commit 불필요.
+
+---
+
+### Phase 5: 로컬 실측 (user surface)
+
+**Files:** 없음
+
+> **User memory `reference_pfplay_web_local_dev_http_webpack`**: 로컬 검증은 `npx next dev` (http+webpack). `yarn dev` (--experimental-https --turbo) 는 금지 — https/webpack mixed-content 또는 Turbopack /parties/[id] SSR 워커 크래시.
+
+- [ ] **Step 5.1: 로컬 dev 서버 띄우기 (user 가 직접 실행)**
+
+본 step 은 agent 가 background 로 띄울 수 있으나 사용자가 브라우저에서 실측해야 valid. User 에게 surface:
+
+```
+로컬 dev 검증 부탁드립니다:
+
+  cd "C:/Users/Eisen/Desktop/Labs/[projects] pfplay/pfplay-web"
+  npx next dev
+
+브라우저 http://localhost:3000/parties (또는 lobby 경로) 진입:
+
+[모바일 viewport 검증]
+- DevTools 모바일 뷰 (예: iPhone 13)
+- lobby 카드가 BackdropBlur 배경 + 80% 어두운 오버레이로 렌더되는가
+- 카드 우하단에 PFInfoOutline 아이콘이 없는가 (제외 확인)
+- Crews 영역에 아바타 (최대 3개) + count 가 표시되는가
+- Main 카드 (맨 위) 에 "PFPlay Main Stage" 라벨 (작은 chip) 이 보이는가
+- 일반 카드에는 라벨이 없는가
+- playbackActivated=false 인 룸이 있다면 "재생 중인 곡이 없어요" 텍스트가 없는가
+
+[데스크탑 viewport 검증]
+- 데스크탑 뷰포트에서 lobby 카드 (MainPartyroomCard + PartyroomCard) 디자인이 변경 없이 유지되는가
+```
+
+User 가 결과 confirm 한 후 다음 step.
+
+- [ ] **Step 5.2: 발견 회귀 / 시각 이슈 대응 (있을 때만)**
+
+발견 시 spec / plan 으로 회귀해서 수정 + 추가 commit.
+
+---
+
+### Phase 6: PR 준비
+
+**Files:** PR description (GitHub)
+
+- [ ] **Step 6.1: 브랜치 push**
+
+Run:
+
+```bash
+git push -u origin feature/mobile-responsive-chunk5
+```
+
+Expected: 새 브랜치 origin push 성공.
+
+- [ ] **Step 6.2: PR 생성 (한국어, closes #377)**
+
+User memory `feedback_korean_issue_commit_pr`: PR body 한국어. memory `feedback_commit_consolidation_before_push`: push 직전 commit 정돈 (단 micro commit 보존 합의 가능).
+
+본 plan 의 commit 수 ≤ 5 (test red / 카드 rewrite / list / [선택] e2e / [선택] docs). squash 없이 누적 머지 가능 (memory `feedback_main_squash_merge` — 소량이면 squash 도 OK).
+
+Run:
+
+```bash
+gh pr create --title "[모바일 반응형 chunk 5] lobby 카드 데스크탑 catch-up" --body "$(cat <<'EOF'
+closes #377
+
+## 요약
+
+`MobilePartyroomCard` 를 데스크탑 `PartyroomCard` 와 동일한 **BackdropBlur 단일 카드 패턴** 으로 rewrite. shared 컴포넌트 (`BackdropBlurContainer`, `Typography`, `Crews`) 차용 + `MainStageLabel` sub-컴포넌트로 i18n 의존 격리.
+
+## 변경
+
+- `src/features-mobile/partyroom/list/partyroom-card.component.tsx` rewrite (BackdropBlur 단일 패턴, Typography 토큰, Crews 차용, MainStageLabel sub-컴포넌트)
+- `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` 케이스 6개 (기존 3 유지/수정 + 신규 3)
+- `src/features-mobile/partyroom/list/partyroom-list.component.tsx` Main 카드에 `isMain` prop 전달
+
+영향 파일 = **3개**. 데스크탑 카드 무영향.
+
+## 사용자 가시 동작 변화 (1건)
+
+- `playbackActivated=false` 일 때 "재생 중인 곡이 없어요" placeholder 텍스트 제거 → BackdropBlur fallback 이미지 `/images/Background/Partyroom.png` 로 대체 (데스크탑 카드와 동일 동작)
+
+## 결정 잠금 (spec)
+
+| # | 결정 | 답 |
+| --- | --- | --- |
+| Q1 | 1차 목적 | 전환 깔때기 강화 (#340 정합) |
+| Q2 | 카드 구조 | A. BackdropBlur 단일 |
+| Q3 | Main 카드 | a. 일반 카드 + Main 라벨 |
+| Q4 | PFInfoOutline | 제외 |
+| Q5 | 스코프 | `MobilePartyroomCard` 1개 파일 |
+| Q6 | 구현 | A2. shared 컴포넌트 차용 rewrite |
+
+## 검증
+
+- [x] 단위 test 6 케이스 GREEN
+- [x] typecheck 0 오류
+- [x] lint clean
+- [x] 로컬 `npx next dev` 모바일/데스크탑 viewport 실측
+- [x] e2e 영향 점검 (모바일 lobby 카드 텍스트 단언 검색)
+
+## 설계 문서
+
+`docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --base development
+```

--- a/docs/superpowers/plans/2026-05-30-mobile-lobby-card-catchup.md
+++ b/docs/superpowers/plans/2026-05-30-mobile-lobby-card-catchup.md
@@ -34,7 +34,7 @@ git branch --show-current
 Expected:
 
 - branch = `feature/mobile-responsive-chunk5`
-- HEAD log 에 `docs(mobile/chunk-5)` commit 4건 (101a3ca / 96d8ca2 / 7cdcedf / 12ef856)
+- HEAD log 에 `docs(mobile/chunk-5)` commit ≥ 5건 (101a3ca spec 초안 / 96d8ca2 spec iter1 / 7cdcedf spec iter2 / 12ef856 issue 링크 / 380549f plan; 본 plan 자체 commit 포함). 실측 시 commit 누락이 아니라 추가만 있으면 OK
 - working tree clean
 
 - [ ] **Step 0.2: PFPersonFilled import 가능성 사전 확인 (dry-run)**

--- a/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
+++ b/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
@@ -59,7 +59,8 @@ chunk 5 의 **1차 목적은 전환 깔때기 강화**다. 모바일 반응형 �
 ### 3.2 Main 라벨 a 선택 — trade-off 정리
 
 - ✅ BackdropBlur 통일 디자인 + 작은 라벨 chip 으로 공식 룸 신호
-- ✅ 신규 컴포넌트 불필요 (`MobilePartyroomCard` 의 `isMain` prop 분기로 처리)
+- ✅ 1컬럼 리듬 유지
+- ⚠️ **의식적 trade-off**: 데스크탑 `MainPartyroomCard` 는 큰 hero (`detail1` 보조 카피 `welcome_party` 까지) 로 일반 카드보다 풍부하지만, 모바일은 `caption2` chip 1줄만 → **Main 카드의 데스크탑↔모바일 격차가 일반 카드 격차보다 오히려 커진다**. 1컬럼 폼팩터에서 hero 가 약하다는 chunk 2 의 framing 을 일관되게 적용한 결과 (Q3 b 거절 근거와 동일). 후속 chunk 에서 Main 전용 모바일 hero 가 재논의될 가능성 열어둠.
 - ❌ 대안 b (별도 hero) — 1컬럼 리듬 깨짐 + 신규 컴포넌트
 - ❌ 대안 c (라벨 없이 유지) — Main 정체성 손실
 
@@ -121,16 +122,30 @@ interface Props {
 }
 
 /**
+ * Main 라벨 sub-컴포넌트.
+ *
+ * isMain=true 분기에서만 마운트 → `useI18n` 호출이 라벨 케이스에 한정.
+ * 일반 카드 (isMain=false) 는 이 컴포넌트를 마운트하지 않으므로 i18n provider 의존 X.
+ * (기존 v1 카드 단위 test 들이 i18n mock 없이 통과하는 invariant 보존.)
+ */
+const MainStageLabel: FC = () => {
+  const t = useI18n();
+  return (
+    <Typography type='caption2' className='text-gray-300 uppercase tracking-wide'>
+      {t.lobby.para.pfplay_main_stage}
+    </Typography>
+  );
+};
+
+/**
  * 모바일 로비 1컬럼 카드 (chunk 5 = 데스크탑 baseline catch-up).
  *
  * - 데스크탑 PartyroomCard 와 동일한 BackdropBlur 단일 카드 패턴, 모바일 폼팩터로 축소.
  * - shared 컴포넌트 (BackdropBlurContainer, Typography, Crews) 차용.
  * - PFInfoOutline 은 모바일에서 의도적으로 제외 (정보 기능 없는 정적 아이콘).
- * - isMain=true 일 때 title2 위 caption2 chip 으로 "PFPlay Main Stage" 라벨.
+ * - isMain=true 일 때 title2 위 caption2 chip 으로 "PFPlay Main Stage" 라벨 (MainStageLabel sub-컴포넌트로 분리).
  */
 const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) => {
-  const t = useI18n();
-
   return (
     <BackdropBlurContainer
       src={summary.playback?.thumbnailImage}
@@ -142,11 +157,7 @@ const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) =>
         className='h-full flexCol justify-between gap-10 py-5 px-5 backdrop-blur-sm bg-backdrop-black/80'
       >
         <div className='flexCol gap-1.5'>
-          {isMain && (
-            <Typography type='caption2' className='text-gray-300 uppercase tracking-wide'>
-              {t.lobby.para.pfplay_main_stage}
-            </Typography>
-          )}
+          {isMain && <MainStageLabel />}
           <Typography type='title2' className='text-gray-50'>
             {summary.title}
           </Typography>
@@ -204,26 +215,7 @@ export default MobilePartyroomCard;
 
 ### 4.4 컴포넌트 명세 — `MobilePartyroomList` (Main 카드 isMain 전달)
 
-```tsx
-// 변경 핵심:
-const rooms = [...(mainRoom ? [mainRoom] : []), ...(generalRooms ?? [])];
-
-return (
-  <ul className='flexCol gap-4 w-full'>
-    {rooms.map((summary, idx) => (
-      <li key={summary.partyroomId}>
-        <MobilePartyroomCard
-          roomId={summary.partyroomId}
-          summary={summary}
-          isMain={idx === 0 && !!mainRoom}
-        />
-      </li>
-    ))}
-  </ul>
-);
-```
-
-또는 더 명시적으로 Main 을 별도 prepend (현재 v1 구조 유지):
+Main 카드와 일반 카드를 **명시적으로 분리해서 prepend**. `isMain` 판정 로직이 컴포넌트가 아닌 데이터 소스 (mainRoom vs generalRooms) 에 직접 매핑됨.
 
 ```tsx
 return (
@@ -242,7 +234,7 @@ return (
 );
 ```
 
-**선택: 후자 (명시적 prepend)** — `isMain` 판정 로직이 컴포넌트가 아닌 데이터 소스 (mainRoom vs generalRooms) 에 명확히 매핑됨. idx 기반은 generalRooms 정렬 변경에 fragile.
+**거절된 대안 (idx 기반)**: ❌ `rooms.map((s, idx) => <Card isMain={idx === 0 && !!mainRoom} />)` 형태. generalRooms 정렬 변경에 fragile + isMain 판정이 list 위치에 결합됨. 채택하지 않음.
 
 ### 4.5 Crews 컴포넌트 cross-import 결정
 
@@ -251,6 +243,7 @@ return (
 - `Crews` 는 stateless presentation 컴포넌트, hooks/store 의존 없음
 - shared 로 hoist 하려면 데스크탑 코드도 함께 수정해야 함 — chunk 5 스코프 초과
 - 후속 chunk 에서 다른 모바일 화면이 `Crews` 를 쓰게 되면 그 시점에 hoist 재검토 (YAGNI)
+- **lint enforcement 확인**: `eslint.config.js` 에 `features-mobile → features` import 차단 룰 없음 (no `boundaries` / `no-restricted-paths` 설정). lint red 우려 없음
 
 대안: 로컬에 동일 컴포넌트를 복제 — 코드 중복, 사용자 메모리 `feedback_elegant_no_code_dirtying` (코드 더럽힘 회피) 위반.
 
@@ -262,13 +255,13 @@ return (
 
 ### 4.7 Error Handling
 
-| 케이스                         | 처리                                                                                                                            | 비고                                                                                                                                                          |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `playbackActivated=false`      | now-playing 블록 전체 미렌더 (`{summary.playback && ...}`)                                                                      | 현재 v1 의 "재생 중인 곡이 없어요" placeholder 는 **삭제** — BackdropBlur 카드는 빈 슬롯 보이지 않는 게 더 깔끔. BackdropBlur 자체는 fallback 이미지로 채워짐 |
-| `playback.thumbnailImage` 부재 | `BackdropBlurContainer` 가 `getPartyroomCardBackdropProps` fallback (`/images/Background/Partyroom.png`) 처리 — 데스크탑과 동일 | shared 컴포넌트 자체 처리                                                                                                                                     |
-| `primaryIcons` 빈 배열         | `Crews` 가 `icons.slice(0, 3)` 으로 안전 처리, count 만 표시                                                                    | `PartyroomSummary` 주석 "최소한 호스트 1명에 대한 정보는 있음" — 빈 배열 실제 발생 X                                                                          |
-| `crewCount=0`                  | `Crews` 가 `count ? count : 0` 처리                                                                                             | 기존 동일                                                                                                                                                     |
-| 긴 제목                        | `Typography type='title2'` 가 자동 truncate (titleTypes)                                                                        | 데스크탑과 동일                                                                                                                                               |
+| 케이스                         | 처리                                                                                                                                                                                     | 비고                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `playbackActivated=false`      | now-playing 블록 전체 미렌더 (`{summary.playback && ...}`)                                                                                                                               | 현재 v1 의 "재생 중인 곡이 없어요" placeholder 는 **삭제** (사용자 가시 동작 변화 — PR body 명시 필요). BackdropBlur 자체는 fallback 이미지 `/images/Background/Partyroom.png` 로 채워지므로 빈 카드 X. 데스크탑 카드 동일 동작이라 분위기 손상 우려 검증됨. 깔때기 lens 통과: "재생 중 곡 없음" 표시 사라짐 = inactive 신호 약화 ≠ active 신호 약화 → 전환 깔때기에는 중립 |
+| `playback.thumbnailImage` 부재 | `BackdropBlurContainer` 가 `getPartyroomCardBackdropProps` fallback 처리 — fallbackSrc=`/images/Background/Partyroom.png`, imageClassName=`object-[24%_60%] scale-110` (데스크탑과 동일) | shared 컴포넌트 자체 처리                                                                                                                                                                                                                                                                                                                                                   |
+| `primaryIcons` 빈 배열         | `Crews` 가 `icons.slice(0, 3)` 으로 안전 처리, count 만 표시                                                                                                                             | `PartyroomSummary` 주석 "최소한 호스트 1명에 대한 정보는 있음" — 빈 배열 실제 발생 X                                                                                                                                                                                                                                                                                        |
+| `crewCount=0`                  | `Crews` 가 `count ? count : 0` 처리                                                                                                                                                      | 기존 동일                                                                                                                                                                                                                                                                                                                                                                   |
+| 긴 제목                        | `Typography type='title2'` 가 자동 truncate (titleTypes)                                                                                                                                 | 데스크탑과 동일                                                                                                                                                                                                                                                                                                                                                             |
 
 ### 4.8 Testing
 
@@ -276,12 +269,19 @@ return (
 
 기존 3 케이스 유지 + 다음 수정/추가:
 
-1. **제목·인원·now-playing 표시** (기존) — 통과 예상 (raw text → Typography 변경은 텍스트 매칭 무영향)
-2. **카드 전체가 `/parties/{id}?source=list` 로 이동** (기존) — 그대로 통과
-3. **`playbackActivated=false` 케이스** — 수정: "재생 중인 곡이 없어요" placeholder 단언 제거, now-playing 영역이 **렌더되지 않음** 단언으로 변경 (썸네일 영역 부재)
-4. **신규: 아바타가 `primaryIcons` 개수만큼 렌더** — `screen.getAllByAltText('party crew').length === 1` (mock primaryIcons 1개 기준)
-5. **신규: `isMain=true` 일 때 "PFPlay Main Stage" 라벨 표시** — i18n provider mock 필요, `screen.getByText(/PFPlay Main Stage/i)` (또는 i18n 키의 ko 값) 단언
-6. **신규: `isMain` 이 falsy 일 때 라벨 미표시** — `screen.queryByText(...)` 단언
+1. **제목·인원·now-playing 표시** (기존) — 통과 예상 (raw text → Typography 변경은 텍스트 매칭 무영향, `isMain` 미지정 → `MainStageLabel` 미마운트 → i18n provider mock 불필요)
+2. **카드 전체가 `/parties/{id}?source=list` 로 이동** (기존) — 그대로 통과 (i18n mock 불필요)
+3. **`playbackActivated=false` 케이스** — 수정: "재생 중인 곡이 없어요" placeholder 단언 제거, now-playing 영역이 **렌더되지 않음** 단언으로 변경 (예: `screen.queryByAltText('playback thumbnail')` 가 null). i18n mock 불필요
+4. **신규: 아바타가 `primaryIcons` 개수만큼 렌더** — `screen.getAllByAltText('party crew').length === 1` (mock primaryIcons 1개 기준). i18n mock 불필요
+5. **신규: `isMain=true` 일 때 "PFPlay Main Stage" 라벨 표시** — **i18n mock 필요** (`vi.mock('@/shared/lib/localization/i18n.context', () => ({ useI18n: () => ({ lobby: { para: { pfplay_main_stage: 'PFPlay Main Stage' } } }) }))` 패턴, 참조: `src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.test.tsx`). `screen.getByText('PFPlay Main Stage')` 단언
+6. **신규: `isMain` 이 falsy 일 때 라벨 미표시** — `screen.queryByText('PFPlay Main Stage')` 가 null. 동일 i18n mock 적용된 상태에서 prop 차이만 검증
+
+**Mock 정리**:
+
+- `next/image` — 기존 mock 유지 (Crews 안 `<Image priority />` 까지 커버)
+- `next/link` — 기존 mock 유지
+- `@/shared/lib/localization/i18n.context` — **케이스 5·6 전용**. 파일 상단 `vi.mock(...)` 하나로 전역 stub. 케이스 1·2·3·4 는 `<MainStageLabel />` 미마운트라 mock 미사용. 케이스 1·2·3·4 가 mock 영향받지 않는지 (의도치 않은 dependency leak) 확인하는 게 본 spec 의 invariant
+- `@/shared/ui/icons` (PFPersonFilled, Crews 안에서 import) — Vitest 가 svg/icon 컴포넌트를 그대로 처리 가능하면 mock 불필요. 처음 test 실행 시 unresolved import 발생하면 `vi.mock` 추가. plan 단계에서 dry-run 으로 확인 (mock 추가 여부는 implementation 가 결정)
 
 #### 통합 / E2E
 
@@ -297,23 +297,24 @@ return (
 - [ ] `yarn lint` clean
 - [ ] 로컬 `npx next dev` (http+webpack, 메모리 `reference_pfplay_web_local_dev_http_webpack` 준수) 실측 — 데스크탑 viewport `~/parties` 무영향, 모바일 viewport BackdropBlur·Crews·Main 라벨 렌더 확인
 - [ ] e2e suite (모바일 lobby 관련) 영향 점검 + 회귀 확인
-- [ ] PR 본문 한국어, closes #(issue)
+- [ ] PR 본문 한국어, closes #(issue). **PR body 에 사용자 가시 동작 변화 1건 명시: "playbackActivated=false 일 때 '재생 중인 곡이 없어요' placeholder 텍스트 제거 (BackdropBlur fallback 이미지로 대체)"**
 
 ## 6. 위험·완화
 
-| 위험                                                                   | 영향            | 완화                                                                                     |
-| ---------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- |
-| 어두운 썸네일 + 밝은 BackdropBlur 텍스트 가독성 저하                   | 사용성 ↓        | 데스크탑 검증된 `bg-backdrop-black/80` 80% 불투명 오버레이 그대로 차용                   |
-| `Crews` cross-import (`features-mobile` → `features`) 로 layering 오염 | 아키텍처 일관성 | stateless presentation 한정 + 후속 chunk 에서 다른 모바일 사용처 발생 시 shared 로 hoist |
-| 모바일 e2e spec 의 텍스트 단언 실패                                    | CI red          | spec 작성 시 사전 grep, 영향 spec 의 단언 텍스트 재확인                                  |
-| Main 라벨 i18n 키 미렌더 (provider mock 부재)                          | test red        | 단위 test 에 `I18nProvider` mock 추가 (데스크탑 `MainPartyroomCard` test 패턴 참조)      |
+| 위험                                                                                     | 영향                     | 완화                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 어두운 썸네일 + 밝은 BackdropBlur 텍스트 가독성 저하                                     | 사용성 ↓                 | 데스크탑 검증된 `bg-backdrop-black/80` 80% 불투명 오버레이 그대로 차용                                                                                                                                                                                                    |
+| `Crews` cross-import (`features-mobile` → `features`) 로 layering 오염                   | 아키텍처 일관성          | stateless presentation 한정 + 후속 chunk 에서 다른 모바일 사용처 발생 시 shared 로 hoist                                                                                                                                                                                  |
+| 모바일 e2e spec 의 텍스트 단언 실패                                                      | CI red                   | spec 작성 시 사전 grep, 영향 spec 의 단언 텍스트 재확인                                                                                                                                                                                                                   |
+| Main 라벨 i18n 키 미렌더 (provider mock 부재)                                            | test red                 | 케이스 5·6 에 한정해 `vi.mock('@/shared/lib/localization/i18n.context', () => ({ useI18n: () => ({ ... }) }))` 패턴 적용. 참조: `src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.test.tsx`. (데스크탑 카드 ui/ 하위에는 test 파일 자체 없음 — 0건 확인됨) |
+| `MainStageLabel` sub-컴포넌트 분리 안 했을 때 기존 케이스 1~4 가 i18n provider mock 강제 | test red (4 케이스 일괄) | `MainStageLabel` 분리로 useI18n 호출이 라벨 케이스에만 한정 — §4.2 코드 명세로 lock                                                                                                                                                                                       |
 
 ## 7. 변경 요약
 
-| 파일                                                                   | 변경                                                                          |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `src/features-mobile/partyroom/list/partyroom-card.component.tsx`      | rewrite (BackdropBlur 단일 패턴, Typography 토큰, Crews 차용, Main 라벨 분기) |
-| `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` | 케이스 6개 (기존 3 유지 + placeholder 케이스 수정 + 신규 3)                   |
-| `src/features-mobile/partyroom/list/partyroom-list.component.tsx`      | Main 카드 prepend 시 `isMain` prop 전달                                       |
+| 파일                                                                   | 변경                                                                                                              |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `src/features-mobile/partyroom/list/partyroom-card.component.tsx`      | rewrite (BackdropBlur 단일 패턴, Typography 토큰, Crews 차용, `MainStageLabel` sub-컴포넌트 분리, Main 라벨 분기) |
+| `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` | 케이스 6개 (기존 3 유지/수정 + 신규 3 — 5·6 에 한해 i18n mock)                                                    |
+| `src/features-mobile/partyroom/list/partyroom-list.component.tsx`      | Main 카드 prepend 시 `isMain` prop 전달                                                                           |
 
-영향 파일 = **3개**, 신규 컴포넌트 = **0**, 신규 i18n 키 = **0**, 백엔드 API 변경 = **0**.
+영향 파일 = **3개**, 신규 file-level 컴포넌트 = **0** (sub-컴포넌트 `MainStageLabel` 은 카드 파일 내부에 colocate), 신규 i18n 키 = **0**, 백엔드 API 변경 = **0**.

--- a/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
+++ b/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
@@ -1,6 +1,6 @@
 # 모바일 lobby 카드 데스크탑 catch-up (chunk 5) — Design
 
-- **Issue**: TBD (spec 승인 후 등록)
+- **Issue**: #377
 - **Date**: 2026-05-30
 - **Branch**: `feature/mobile-responsive-chunk5`
 - **시리즈**: 모바일 반응형 chunk 1~4 + #372 (env zod) 완료, chunk 5 진입

--- a/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
+++ b/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
@@ -1,0 +1,319 @@
+# 모바일 lobby 카드 데스크탑 catch-up (chunk 5) — Design
+
+- **Issue**: TBD (spec 승인 후 등록)
+- **Date**: 2026-05-30
+- **Branch**: `feature/mobile-responsive-chunk5`
+- **시리즈**: 모바일 반응형 chunk 1~4 + #372 (env zod) 완료, chunk 5 진입
+- **관련 메모리**: `project_mobile_chunk5_next_session_entry`, `project_mobile_lobby_card_chunk5_backlog`, `project_mobile_responsive_scope_340.md`
+
+## 1. 배경 (Why)
+
+chunk 2 에서 진입한 모바일 lobby 1컬럼 카드는 의도된 **v1 minimal** 이었다. 데스크탑 `PartyroomCard` 의 BackdropBlur·Crews 아바타·Typography 토큰·PFInfoOutline 4 가지 시각 자산이 모두 빠져 있다. chunk 5 는 그 격차를 좁힌다.
+
+chunk 5 의 **1차 목적은 전환 깔때기 강화**다. 모바일 반응형 전환의 1차 목표가 "공유 링크 / 소셜 유입자의 입장 전환율 증가" (이슈 #340 framing) 이므로, lobby 첫 화면의 카드가 "지금 사람들이 모여서 듣고 있는 활성 파티" 분위기를 빠르게 전달하는 것이 활성화 신호로 가장 강력하다. 시각적 일관성 (데스크탑↔모바일 디자인 시스템 통일) 은 부수 효과로 따라온다.
+
+### 현재 격차 (v1 vs 데스크탑 baseline)
+
+| 항목          | 데스크탑 baseline                                                                                             | 현재 모바일 v1                                                              | 데이터/컴포넌트 가용                                                |
+| ------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 카드 구조     | `BackdropBlurContainer` (썸네일 cover scale-105 + `backdrop-blur-sm bg-backdrop-black/80` 오버레이) 단일 카드 | 평면 `bg-gray-900` + 상단 `aspect-video` 썸네일 슬롯 + 하단 정보 블록 (2단) | shared 재사용 가능                                                  |
+| 아바타        | `Crews` (`PFPersonFilled` + count + 아바타 최대 3개)                                                          | `👥` emoji + 카운트만                                                       | `primaryIcons` API 응답 포함, mock 에도 존재하나 컴포넌트가 무시 중 |
+| Typography    | `type='title2'` / `caption1` / `body3` 디자인 토큰                                                            | raw `<h3>`, raw `<p>`                                                       | shared 재사용 가능                                                  |
+| PFInfoOutline | 우하단 24×24 (정적 아이콘, `role='presentation'`)                                                             | 없음                                                                        | shared icon                                                         |
+
+## 2. 목표 (What)
+
+1. `MobilePartyroomCard` 를 **BackdropBlur 단일 카드** 패턴으로 rewrite — 데스크탑 `PartyroomCard` 와 동일 패밀리
+2. shared 컴포넌트 (`BackdropBlurContainer`, `Typography`, `Crews`) 차용. 모바일 폼팩터 specific 한 spacing/sizing 만 `MobilePartyroomCard` 가 자체 결정
+3. Main 카드 (현재 일반 카드 디자인으로 prepend) 에 "PFPlay Main Stage" 라벨만 추가하여 공식 룸 정체성 전달
+4. 기존 단위 test 업데이트 + 신규 케이스 (아바타 렌더·Main 라벨 분기)
+
+비목표 (out of scope):
+
+- 데스크탑 `PartyroomCard` / `MainPartyroomCard` 수정 (무영향)
+- `PFInfoOutline` 모바일 포함 — 깔때기 lens 에서 정보 기능 부재로 redundant (의도적 제외, §3.4)
+- `Crews` 컴포넌트를 `features/` → `shared/` hoist — chunk 5 스코프 초과, YAGNI
+- 모바일 hero 카드 별도 디자인 (`MobileMainPartyroomCard` 신규) — 1컬럼 리듬 깨짐, YAGNI
+- 다른 모바일 화면 (헤더·플레이리스트·displayBoard 등) 의 시각 자산
+- Main 라벨의 다국어 추가 키 — 기존 `t.lobby.para.pfplay_main_stage` 재사용
+
+## 3. 결정 잠금 (clarifying questions 결과)
+
+| #   | 결정           | 답                                                            | 근거                                                                              |
+| --- | -------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Q1  | 1차 목적       | 전환 깔때기 강화                                              | 이슈 #340 모바일 반응형 1차 목표 정합                                             |
+| Q2  | 카드 구조      | A. BackdropBlur 단일 카드 (데스크탑 패턴 모바일 폼팩터 축소)  | 분위기 신호 가장 강함 + 데스크탑 검증된 가독성 패턴                               |
+| Q3  | Main 카드 처리 | a. 일반 카드 + Main 라벨 추가                                 | 1컬럼 리듬 유지 + 공식 룸 정체성 전달 + 코드 재사용                               |
+| Q4  | PFInfoOutline  | 제외                                                          | 정적 아이콘 (정보 기능 없음) + 좁은 카드 시각 노이즈 + 깔때기 lens 에서 가치 약함 |
+| Q5  | 스코프         | `MobilePartyroomCard` 1개 파일                                | `MobilePartyroomList` 외 다른 사용처 없음 (grep 확인)                             |
+| Q6  | 구현 접근      | A2. `MobilePartyroomCard` 를 shared 컴포넌트 차용해서 rewrite | `features-mobile` ↔ `features` 분리 유지, 변경 격리                              |
+
+### 3.1 카드 구조 A 선택 — trade-off 정리
+
+- ✅ 활성 파티 분위기 신호 가장 강함 (목적 정합)
+- ✅ 데스크탑과 디자인 시스템 통일
+- ⚠️ 어두운 썸네일에서 텍스트 가독성 우려 → 데스크탑 카드에서 이미 검증된 패턴 (`bg-backdrop-black/80` 80% 불투명 오버레이) 으로 신뢰 가능
+- ❌ 대안 B (2단 유지) — 분위기 신호 약, 데스크탑과 카드 패밀리 분리
+- ❌ 대안 C (하이브리드 hero+패널) — 신규 패턴, 데스크탑 baseline 과도 다름, YAGNI
+
+### 3.2 Main 라벨 a 선택 — trade-off 정리
+
+- ✅ BackdropBlur 통일 디자인 + 작은 라벨 chip 으로 공식 룸 신호
+- ✅ 신규 컴포넌트 불필요 (`MobilePartyroomCard` 의 `isMain` prop 분기로 처리)
+- ❌ 대안 b (별도 hero) — 1컬럼 리듬 깨짐 + 신규 컴포넌트
+- ❌ 대안 c (라벨 없이 유지) — Main 정체성 손실
+
+### 3.3 구현 A2 선택 — trade-off 정리
+
+- ✅ shared 컴포넌트만 차용, `features-mobile` ↔ `features` 분리 유지
+- ✅ 변경 격리 (한 파일 + 테스트)
+- ✅ 데스크탑 무영향
+- ❌ 대안 A1 (데스크탑 카드 직접 import) — className 충돌 + 분기 prop 필요, 결국 fork 와 비슷한 복잡도
+- ❌ 대안 A3 (responsive 통합) — chunk 5 스코프 초과 + 회귀 위험
+
+### 3.4 PFInfoOutline 제외 근거 (확장)
+
+데스크탑 `PartyroomCard` 의 `PFInfoOutline` 은 현재 코드상 `role='presentation'` + 클릭 핸들러 없음 → **정적 아이콘**. 카드 전체가 `Link` 이므로 어차피 탭 시 룸 진입. 실제 정보 표시 affordance 가 아니다.
+
+모바일 전환 깔때기 lens 에서:
+
+- 모바일 탭 진입은 직관 — 별도 affordance 신호 redundant
+- 좁은 카드 공간에 추가 아이콘은 시각 노이즈
+- 정보 기능 없는 정적 아이콘 → cost > benefit
+
+미래에 PFInfoOutline 이 실제 정보 affordance (예: 룸 미리보기 모달) 로 진화하면 그 시점에 모바일 포함 재검토. 지금은 제외.
+
+## 4. 설계 (How)
+
+### 4.1 Architecture
+
+```
+src/features-mobile/partyroom/list/
+├── partyroom-card.component.tsx          # rewrite (BackdropBlur 단일 패턴)
+├── partyroom-card.component.test.tsx     # 업데이트 (아바타·Typography·Main 라벨 케이스)
+├── partyroom-list.component.tsx          # 변경: Main 카드에 isMain prop 전달
+└── index.ts                              # 변경 없음
+```
+
+영향 파일 = **3개**. 데스크탑 `PartyroomCard` / `MainPartyroomCard` 무영향.
+
+### 4.2 컴포넌트 명세 — `MobilePartyroomCard`
+
+```tsx
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { FC } from 'react';
+import Crews from '@/features/partyroom/list/ui/crews.component';
+import { getPartyroomCardBackdropProps } from '@/features/partyroom/list/ui/partyroom-card-backdrop';
+import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { BackdropBlurContainer } from '@/shared/ui/components/backdrop-blur-container';
+import { Typography } from '@/shared/ui/components/typography';
+
+interface Props {
+  roomId: number;
+  summary: PartyroomSummary;
+  onClose?: () => void;
+  /** Main 카드일 때 true → "PFPlay Main Stage" 라벨 표시 */
+  isMain?: boolean;
+}
+
+/**
+ * 모바일 로비 1컬럼 카드 (chunk 5 = 데스크탑 baseline catch-up).
+ *
+ * - 데스크탑 PartyroomCard 와 동일한 BackdropBlur 단일 카드 패턴, 모바일 폼팩터로 축소.
+ * - shared 컴포넌트 (BackdropBlurContainer, Typography, Crews) 차용.
+ * - PFInfoOutline 은 모바일에서 의도적으로 제외 (정보 기능 없는 정적 아이콘).
+ * - isMain=true 일 때 title2 위 caption2 chip 으로 "PFPlay Main Stage" 라벨.
+ */
+const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) => {
+  const t = useI18n();
+
+  return (
+    <BackdropBlurContainer
+      src={summary.playback?.thumbnailImage}
+      {...getPartyroomCardBackdropProps(summary.playback?.thumbnailImage)}
+    >
+      <Link
+        href={`/parties/${roomId}?source=list`}
+        onClick={onClose}
+        className='h-full flexCol justify-between gap-10 py-5 px-5 backdrop-blur-sm bg-backdrop-black/80'
+      >
+        <div className='flexCol gap-1.5'>
+          {isMain && (
+            <Typography type='caption2' className='text-gray-300 uppercase tracking-wide'>
+              {t.lobby.para.pfplay_main_stage}
+            </Typography>
+          )}
+          <Typography type='title2' className='text-gray-50'>
+            {summary.title}
+          </Typography>
+        </div>
+
+        <div className='gap-3 flexCol max-w-full'>
+          {summary.playback && (
+            <div className='flex-1 max-w-full min-w-0 flexRowCenter gap-3 rounded'>
+              <div className='w-[64px] h-[36px] bg-gray-700 shrink-0'>
+                <Image
+                  priority
+                  src={summary.playback.thumbnailImage}
+                  alt='playback thumbnail'
+                  width={64}
+                  height={36}
+                  className='w-full h-full object-contain select-none'
+                />
+              </div>
+              <Typography
+                type='caption1'
+                overflow='ellipsis'
+                className='flex-1 text-gray-50 select-none'
+              >
+                {summary.playback.name}
+              </Typography>
+            </div>
+          )}
+          <div className='bg-gray-600 h-[1px]' />
+          <Crews
+            count={summary.crewCount}
+            icons={summary.primaryIcons.map((a) => a.avatarIconUri)}
+          />
+        </div>
+      </Link>
+    </BackdropBlurContainer>
+  );
+};
+
+export default MobilePartyroomCard;
+```
+
+### 4.3 데스크탑과의 spacing 차이 (의도된 모바일 폼팩터 조정)
+
+| 항목                  | 데스크탑                                      | 모바일                                               | 근거                                                             |
+| --------------------- | --------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------- |
+| 좌우 패딩             | `px-7` (28px)                                 | `px-5` (20px)                                        | 모바일 폭 좁음                                                   |
+| 상하 패딩             | `py-6` (24px)                                 | `py-5` (20px)                                        | 카드 세로 컴팩트                                                 |
+| 상하단 블록 gap       | `gap-[61px]`                                  | `gap-10` (40px)                                      | 카드 세로 축소                                                   |
+| now-playing 썸네일    | 80×44                                         | 64×36                                                | 모바일 폭 좁음                                                   |
+| now-playing inner gap | `gap-[12px]`                                  | `gap-3` (12px)                                       | 동일                                                             |
+| 하단 블록 inner gap   | `gap-4`                                       | `gap-3` (12px)                                       | 컴팩트                                                           |
+| 하단 영역 alignment   | `justify-between` (Crews 좌·PFInfoOutline 우) | (justify-between 제거)                               | PFInfoOutline 제외로 Crews 단독 좌정렬                           |
+| Typography 토큰       | title2 / caption1 / body3                     | **동일**                                             | 모바일 1컬럼 카드 폭이 데스크탑 카드와 유사 → 사이즈 다운 불필요 |
+| **Main 라벨**         | (별도 `MainPartyroomCard` 가 처리)            | `caption2` chip (gray-300, uppercase, tracking-wide) | 일반 카드 디자인 위 라벨 추가만으로 정체성                       |
+
+### 4.4 컴포넌트 명세 — `MobilePartyroomList` (Main 카드 isMain 전달)
+
+```tsx
+// 변경 핵심:
+const rooms = [...(mainRoom ? [mainRoom] : []), ...(generalRooms ?? [])];
+
+return (
+  <ul className='flexCol gap-4 w-full'>
+    {rooms.map((summary, idx) => (
+      <li key={summary.partyroomId}>
+        <MobilePartyroomCard
+          roomId={summary.partyroomId}
+          summary={summary}
+          isMain={idx === 0 && !!mainRoom}
+        />
+      </li>
+    ))}
+  </ul>
+);
+```
+
+또는 더 명시적으로 Main 을 별도 prepend (현재 v1 구조 유지):
+
+```tsx
+return (
+  <ul className='flexCol gap-4 w-full'>
+    {mainRoom && (
+      <li key={mainRoom.partyroomId}>
+        <MobilePartyroomCard roomId={mainRoom.partyroomId} summary={mainRoom} isMain />
+      </li>
+    )}
+    {generalRooms?.map((summary) => (
+      <li key={summary.partyroomId}>
+        <MobilePartyroomCard roomId={summary.partyroomId} summary={summary} />
+      </li>
+    ))}
+  </ul>
+);
+```
+
+**선택: 후자 (명시적 prepend)** — `isMain` 판정 로직이 컴포넌트가 아닌 데이터 소스 (mainRoom vs generalRooms) 에 명확히 매핑됨. idx 기반은 generalRooms 정렬 변경에 fragile.
+
+### 4.5 Crews 컴포넌트 cross-import 결정
+
+`Crews` 와 `getPartyroomCardBackdropProps` 는 `features/partyroom/list/ui/` 에 있다. `features-mobile/` 에서 `features/` 를 import 하는 것은 일반적으로 layered architecture 에서 회피하지만, 본 작업에서는 다음 이유로 cross-import 채택:
+
+- `Crews` 는 stateless presentation 컴포넌트, hooks/store 의존 없음
+- shared 로 hoist 하려면 데스크탑 코드도 함께 수정해야 함 — chunk 5 스코프 초과
+- 후속 chunk 에서 다른 모바일 화면이 `Crews` 를 쓰게 되면 그 시점에 hoist 재검토 (YAGNI)
+
+대안: 로컬에 동일 컴포넌트를 복제 — 코드 중복, 사용자 메모리 `feedback_elegant_no_code_dirtying` (코드 더럽힘 회피) 위반.
+
+### 4.6 Data Flow
+
+변경 없음. `useFetchGeneralPartyrooms` + `useSuspenseFetchMainPartyroom` 은 같은 `/api/v1/partyrooms` getList 응답을 query key 공유로 단일 fetch + 다른 select. `PartyroomSummary.primaryIcons` 는 이미 응답 포함 (백엔드 API 변경 0).
+
+기존 v1 test mock 에도 `primaryIcons: [{ avatarIconUri: '/avatar.png' }]` 가 있어 단지 컴포넌트가 무시 중 → 카드만 고치면 실데이터 자동 연결.
+
+### 4.7 Error Handling
+
+| 케이스                         | 처리                                                                                                                            | 비고                                                                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `playbackActivated=false`      | now-playing 블록 전체 미렌더 (`{summary.playback && ...}`)                                                                      | 현재 v1 의 "재생 중인 곡이 없어요" placeholder 는 **삭제** — BackdropBlur 카드는 빈 슬롯 보이지 않는 게 더 깔끔. BackdropBlur 자체는 fallback 이미지로 채워짐 |
+| `playback.thumbnailImage` 부재 | `BackdropBlurContainer` 가 `getPartyroomCardBackdropProps` fallback (`/images/Background/Partyroom.png`) 처리 — 데스크탑과 동일 | shared 컴포넌트 자체 처리                                                                                                                                     |
+| `primaryIcons` 빈 배열         | `Crews` 가 `icons.slice(0, 3)` 으로 안전 처리, count 만 표시                                                                    | `PartyroomSummary` 주석 "최소한 호스트 1명에 대한 정보는 있음" — 빈 배열 실제 발생 X                                                                          |
+| `crewCount=0`                  | `Crews` 가 `count ? count : 0` 처리                                                                                             | 기존 동일                                                                                                                                                     |
+| 긴 제목                        | `Typography type='title2'` 가 자동 truncate (titleTypes)                                                                        | 데스크탑과 동일                                                                                                                                               |
+
+### 4.8 Testing
+
+#### 단위 — `partyroom-card.component.test.tsx`
+
+기존 3 케이스 유지 + 다음 수정/추가:
+
+1. **제목·인원·now-playing 표시** (기존) — 통과 예상 (raw text → Typography 변경은 텍스트 매칭 무영향)
+2. **카드 전체가 `/parties/{id}?source=list` 로 이동** (기존) — 그대로 통과
+3. **`playbackActivated=false` 케이스** — 수정: "재생 중인 곡이 없어요" placeholder 단언 제거, now-playing 영역이 **렌더되지 않음** 단언으로 변경 (썸네일 영역 부재)
+4. **신규: 아바타가 `primaryIcons` 개수만큼 렌더** — `screen.getAllByAltText('party crew').length === 1` (mock primaryIcons 1개 기준)
+5. **신규: `isMain=true` 일 때 "PFPlay Main Stage" 라벨 표시** — i18n provider mock 필요, `screen.getByText(/PFPlay Main Stage/i)` (또는 i18n 키의 ko 값) 단언
+6. **신규: `isMain` 이 falsy 일 때 라벨 미표시** — `screen.queryByText(...)` 단언
+
+#### 통합 / E2E
+
+- 기존 `MobilePartyroomList` 단위 test 가 있으면 Main 카드에 `isMain` prop 전달 케이스 추가. 없으면 카드 단위 test 로 충분 (YAGNI)
+- 기존 모바일 lobby e2e 가 카드 텍스트 (`getByText`) 로 단언하는 부분 점검 필요 — 텍스트 컨텐츠 자체는 변경 없으므로 영향 없을 가능성 높음
+- 시각 회귀 (BackdropBlur 적용 후 카드 배경) 는 e2e 화면 캡처가 있는 spec 만 영향 — 사전 grep 필요
+
+## 5. 검증 / 종료 기준 (Done)
+
+- [ ] `MobilePartyroomCard` rewrite + 단위 test 6 케이스 GREEN
+- [ ] `MobilePartyroomList` 의 Main 카드 `isMain` prop 전달 검증
+- [ ] `yarn typecheck` 0 오류
+- [ ] `yarn lint` clean
+- [ ] 로컬 `npx next dev` (http+webpack, 메모리 `reference_pfplay_web_local_dev_http_webpack` 준수) 실측 — 데스크탑 viewport `~/parties` 무영향, 모바일 viewport BackdropBlur·Crews·Main 라벨 렌더 확인
+- [ ] e2e suite (모바일 lobby 관련) 영향 점검 + 회귀 확인
+- [ ] PR 본문 한국어, closes #(issue)
+
+## 6. 위험·완화
+
+| 위험                                                                   | 영향            | 완화                                                                                     |
+| ---------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- |
+| 어두운 썸네일 + 밝은 BackdropBlur 텍스트 가독성 저하                   | 사용성 ↓        | 데스크탑 검증된 `bg-backdrop-black/80` 80% 불투명 오버레이 그대로 차용                   |
+| `Crews` cross-import (`features-mobile` → `features`) 로 layering 오염 | 아키텍처 일관성 | stateless presentation 한정 + 후속 chunk 에서 다른 모바일 사용처 발생 시 shared 로 hoist |
+| 모바일 e2e spec 의 텍스트 단언 실패                                    | CI red          | spec 작성 시 사전 grep, 영향 spec 의 단언 텍스트 재확인                                  |
+| Main 라벨 i18n 키 미렌더 (provider mock 부재)                          | test red        | 단위 test 에 `I18nProvider` mock 추가 (데스크탑 `MainPartyroomCard` test 패턴 참조)      |
+
+## 7. 변경 요약
+
+| 파일                                                                   | 변경                                                                          |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `src/features-mobile/partyroom/list/partyroom-card.component.tsx`      | rewrite (BackdropBlur 단일 패턴, Typography 토큰, Crews 차용, Main 라벨 분기) |
+| `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` | 케이스 6개 (기존 3 유지 + placeholder 케이스 수정 + 신규 3)                   |
+| `src/features-mobile/partyroom/list/partyroom-list.component.tsx`      | Main 카드 prepend 시 `isMain` prop 전달                                       |
+
+영향 파일 = **3개**, 신규 컴포넌트 = **0**, 신규 i18n 키 = **0**, 백엔드 API 변경 = **0**.

--- a/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
+++ b/docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md
@@ -201,17 +201,17 @@ export default MobilePartyroomCard;
 
 ### 4.3 데스크탑과의 spacing 차이 (의도된 모바일 폼팩터 조정)
 
-| 항목                  | 데스크탑                                      | 모바일                                               | 근거                                                             |
-| --------------------- | --------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------- |
-| 좌우 패딩             | `px-7` (28px)                                 | `px-5` (20px)                                        | 모바일 폭 좁음                                                   |
-| 상하 패딩             | `py-6` (24px)                                 | `py-5` (20px)                                        | 카드 세로 컴팩트                                                 |
-| 상하단 블록 gap       | `gap-[61px]`                                  | `gap-10` (40px)                                      | 카드 세로 축소                                                   |
-| now-playing 썸네일    | 80×44                                         | 64×36                                                | 모바일 폭 좁음                                                   |
-| now-playing inner gap | `gap-[12px]`                                  | `gap-3` (12px)                                       | 동일                                                             |
-| 하단 블록 inner gap   | `gap-4`                                       | `gap-3` (12px)                                       | 컴팩트                                                           |
-| 하단 영역 alignment   | `justify-between` (Crews 좌·PFInfoOutline 우) | (justify-between 제거)                               | PFInfoOutline 제외로 Crews 단독 좌정렬                           |
-| Typography 토큰       | title2 / caption1 / body3                     | **동일**                                             | 모바일 1컬럼 카드 폭이 데스크탑 카드와 유사 → 사이즈 다운 불필요 |
-| **Main 라벨**         | (별도 `MainPartyroomCard` 가 처리)            | `caption2` chip (gray-300, uppercase, tracking-wide) | 일반 카드 디자인 위 라벨 추가만으로 정체성                       |
+| 항목                  | 데스크탑                                                                     | 모바일                                                                                                           | 근거                                                             |
+| --------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 좌우 패딩             | `px-7` (28px)                                                                | `px-5` (20px)                                                                                                    | 모바일 폭 좁음                                                   |
+| 상하 패딩             | `py-6` (24px)                                                                | `py-5` (20px)                                                                                                    | 카드 세로 컴팩트                                                 |
+| 상하단 블록 gap       | `gap-[61px]`                                                                 | `gap-10` (40px)                                                                                                  | 카드 세로 축소                                                   |
+| now-playing 썸네일    | 80×44                                                                        | 64×36                                                                                                            | 모바일 폭 좁음                                                   |
+| now-playing inner gap | `gap-[12px]`                                                                 | `gap-3` (12px)                                                                                                   | 동일                                                             |
+| 하단 블록 inner gap   | `gap-4`                                                                      | `gap-3` (12px)                                                                                                   | 컴팩트                                                           |
+| 하단 영역 alignment   | `justify-between` (Crews 좌·PFInfoOutline 우)                                | (justify-between 제거)                                                                                           | PFInfoOutline 제외로 Crews 단독 좌정렬                           |
+| Typography 토큰       | title2 (제목) / caption1 (now-playing 곡명) / body3 (Crews count, inherited) | **동일** (모바일이 직접 사용: title2 + caption1 + caption2 (Main 라벨). body3 는 Crews 내부 hardcoded inherited) | 모바일 1컬럼 카드 폭이 데스크탑 카드와 유사 → 사이즈 다운 불필요 |
+| **Main 라벨**         | (별도 `MainPartyroomCard` 가 처리)                                           | `caption2` chip (gray-300, uppercase, tracking-wide)                                                             | 일반 카드 디자인 위 라벨 추가만으로 정체성                       |
 
 ### 4.4 컴포넌트 명세 — `MobilePartyroomList` (Main 카드 isMain 전달)
 

--- a/src/features-mobile/partyroom/list/partyroom-card.component.test.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-card.component.test.tsx
@@ -17,6 +17,18 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// MainStageLabel 분기 (isMain=true 케이스) 전용 mock.
+// 케이스 1·2·3·4 는 MainStageLabel 미마운트라 useI18n 호출 X — mock 영향 받지 않음을 단언으로 검증.
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    lobby: {
+      para: {
+        pfplay_main_stage: 'PFPlay Main Stage',
+      },
+    },
+  }),
+}));
+
 const baseSummary: PartyroomSummary = {
   partyroomId: 1,
   stageType: StageType.GENERAL,
@@ -29,25 +41,41 @@ const baseSummary: PartyroomSummary = {
 };
 
 describe('MobilePartyroomCard', () => {
-  test('룸 제목·인원·now-playing 을 표시한다', () => {
+  test('제목·인원·now-playing 을 표시한다', () => {
     render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
     expect(screen.getByText('토요일밤 파티')).toBeTruthy();
     expect(screen.getByText(/12/)).toBeTruthy();
     expect(screen.getByText('Song Title')).toBeTruthy();
   });
 
-  test('카드 전체가 /parties/{id}?source=list 로 이동한다 (데스크탑 카드 패턴과 동일)', () => {
+  test('카드 전체가 /parties/{id}?source=list 로 이동한다', () => {
     render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
     expect(screen.getByRole('link').getAttribute('href')).toBe('/parties/1?source=list');
   });
 
-  test('playbackActivated=false 일 때 now-playing 영역에 placeholder 를 표시한다', () => {
+  test('playbackActivated=false 일 때 now-playing 영역이 렌더되지 않는다', () => {
     render(
       <MobilePartyroomCard
         roomId={baseSummary.partyroomId}
         summary={{ ...baseSummary, playbackActivated: false, playback: undefined }}
       />
     );
-    expect(screen.getByText(/재생 중인 곡이 없어요/)).toBeTruthy();
+    expect(screen.queryByText(/재생 중인 곡이 없어요/)).toBeNull();
+    expect(screen.queryByAltText('playback thumbnail')).toBeNull();
+  });
+
+  test('primaryIcons 개수만큼 아바타가 렌더된다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    expect(screen.getAllByAltText('party crew').length).toBe(1);
+  });
+
+  test('isMain=true 일 때 "PFPlay Main Stage" 라벨이 표시된다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} isMain />);
+    expect(screen.getByText('PFPlay Main Stage')).toBeTruthy();
+  });
+
+  test('isMain 이 falsy 일 때 "PFPlay Main Stage" 라벨이 표시되지 않는다', () => {
+    render(<MobilePartyroomCard roomId={baseSummary.partyroomId} summary={baseSummary} />);
+    expect(screen.queryByText('PFPlay Main Stage')).toBeNull();
   });
 });

--- a/src/features-mobile/partyroom/list/partyroom-card.component.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-card.component.tsx
@@ -83,10 +83,14 @@ const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) =>
             </div>
           )}
           <div className='bg-gray-600 h-[1px]' />
-          <Crews
-            count={summary.crewCount}
-            icons={summary.primaryIcons.map((a) => a.avatarIconUri)}
-          />
+          {/* Crews 의 outer wrapper 가 flexRowCenter (= justify-center) 라 부모 flexCol 의 stretch 와 결합 시 카드 가운데로 모인다.
+              self-start 로 fit-content + 좌측 정렬 강제 — 데스크탑 카드는 부모 justify-between 으로 다른 경로로 좌측 고정되므로 무영향. */}
+          <div className='self-start'>
+            <Crews
+              count={summary.crewCount}
+              icons={summary.primaryIcons.map((a) => a.avatarIconUri)}
+            />
+          </div>
         </div>
       </Link>
     </BackdropBlurContainer>

--- a/src/features-mobile/partyroom/list/partyroom-card.component.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-card.component.tsx
@@ -3,56 +3,93 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { FC } from 'react';
+import Crews from '@/features/partyroom/list/ui/crews.component';
+import { getPartyroomCardBackdropProps } from '@/features/partyroom/list/ui/partyroom-card-backdrop';
 import { PartyroomSummary } from '@/shared/api/http/types/partyrooms';
-import { cn } from '@/shared/lib/functions/cn';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { BackdropBlurContainer } from '@/shared/ui/components/backdrop-blur-container';
+import { Typography } from '@/shared/ui/components/typography';
 
 interface Props {
   roomId: number;
   summary: PartyroomSummary;
   onClose?: () => void;
+  /** Main 카드일 때 true → "PFPlay Main Stage" 라벨 표시 */
+  isMain?: boolean;
 }
 
 /**
- * 모바일 로비 1컬럼 카드 (§4.4).
+ * Main 라벨 sub-컴포넌트.
  *
- * - 풀폭 + 썸네일(now-playing) + 룸 제목 + 인원 + now-playing 1줄
- * - Link href: `/parties/${roomId}?source=list` (데스크탑 카드와 동일 attribution 패턴)
- * - DJ 닉네임은 list 엔드포인트가 제공하지 않음 → 표시 X (룸 진입 후 확인)
+ * isMain=true 분기에서만 마운트 → `useI18n` 호출이 라벨 케이스에 한정.
+ * 일반 카드 (isMain=false) 는 이 컴포넌트를 마운트하지 않으므로 i18n provider 의존 X.
+ * (기존 v1 카드 단위 test 들이 i18n mock 없이 통과하는 invariant 보존.)
  */
-const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose }) => {
+const MainStageLabel: FC = () => {
+  const t = useI18n();
   return (
-    <Link
-      href={`/parties/${roomId}?source=list`}
-      onClick={onClose}
-      className={cn(
-        'block w-full rounded-xl overflow-hidden bg-gray-900',
-        'transition-colors hover:bg-gray-800 active:bg-gray-800'
-      )}
+    <Typography type='caption2' className='text-gray-300 uppercase tracking-wide'>
+      {t.lobby.para.pfplay_main_stage}
+    </Typography>
+  );
+};
+
+/**
+ * 모바일 로비 1컬럼 카드 (chunk 5 = 데스크탑 baseline catch-up).
+ *
+ * - 데스크탑 PartyroomCard 와 동일한 BackdropBlur 단일 카드 패턴, 모바일 폼팩터로 축소.
+ * - shared 컴포넌트 (BackdropBlurContainer, Typography, Crews) 차용.
+ * - PFInfoOutline 은 모바일에서 의도적으로 제외 (정보 기능 없는 정적 아이콘).
+ * - isMain=true 일 때 title2 위 caption2 chip 으로 "PFPlay Main Stage" 라벨 (MainStageLabel sub-컴포넌트로 분리).
+ */
+const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) => {
+  return (
+    <BackdropBlurContainer
+      src={summary.playback?.thumbnailImage}
+      {...getPartyroomCardBackdropProps(summary.playback?.thumbnailImage)}
     >
-      <div className='relative w-full aspect-video bg-gray-800'>
-        {summary.playback?.thumbnailImage ? (
-          <Image
-            src={summary.playback.thumbnailImage}
-            alt={summary.playback.name}
-            fill
-            className='object-cover'
+      <Link
+        href={`/parties/${roomId}?source=list`}
+        onClick={onClose}
+        className='h-full flexCol justify-between gap-10 py-5 px-5 backdrop-blur-sm bg-backdrop-black/80'
+      >
+        <div className='flexCol gap-1.5'>
+          {isMain && <MainStageLabel />}
+          <Typography type='title2' className='text-gray-50'>
+            {summary.title}
+          </Typography>
+        </div>
+
+        <div className='gap-3 flexCol max-w-full'>
+          {summary.playback && (
+            <div className='flex-1 max-w-full min-w-0 flexRowCenter gap-3 rounded'>
+              <div className='w-[64px] h-[36px] bg-gray-700 shrink-0'>
+                <Image
+                  priority
+                  src={summary.playback.thumbnailImage}
+                  alt='playback thumbnail'
+                  width={64}
+                  height={36}
+                  className='w-full h-full object-contain select-none'
+                />
+              </div>
+              <Typography
+                type='caption1'
+                overflow='ellipsis'
+                className='flex-1 text-gray-50 select-none'
+              >
+                {summary.playback.name}
+              </Typography>
+            </div>
+          )}
+          <div className='bg-gray-600 h-[1px]' />
+          <Crews
+            count={summary.crewCount}
+            icons={summary.primaryIcons.map((a) => a.avatarIconUri)}
           />
-        ) : (
-          <div className='w-full h-full flex items-center justify-center text-gray-600 text-xs'>
-            준비 중
-          </div>
-        )}
-      </div>
-      <div className='p-4 space-y-1.5'>
-        <h3 className='text-base font-semibold text-white truncate'>{summary.title}</h3>
-        <p className='text-xs text-gray-400'>👥 {summary.crewCount}명</p>
-        {summary.playbackActivated && summary.playback ? (
-          <p className='text-xs text-gray-500 truncate'>{summary.playback.name}</p>
-        ) : (
-          <p className='text-xs text-gray-600'>재생 중인 곡이 없어요</p>
-        )}
-      </div>
-    </Link>
+        </div>
+      </Link>
+    </BackdropBlurContainer>
   );
 };
 

--- a/src/features-mobile/partyroom/list/partyroom-list.component.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-list.component.tsx
@@ -21,9 +21,7 @@ const MobilePartyroomList: FC = () => {
   const { data: mainRoom } = useSuspenseFetchMainPartyroom();
   const { data: generalRooms } = useFetchGeneralPartyrooms();
 
-  const rooms = [...(mainRoom ? [mainRoom] : []), ...(generalRooms ?? [])];
-
-  if (rooms.length === 0) {
+  if (!mainRoom && (!generalRooms || generalRooms.length === 0)) {
     return (
       <div className='w-full py-12 text-center text-sm text-gray-500'>
         지금 열려 있는 파티가 없어요.
@@ -33,7 +31,12 @@ const MobilePartyroomList: FC = () => {
 
   return (
     <ul className='flexCol gap-4 w-full'>
-      {rooms.map((summary) => (
+      {mainRoom && (
+        <li key={mainRoom.partyroomId}>
+          <MobilePartyroomCard roomId={mainRoom.partyroomId} summary={mainRoom} isMain />
+        </li>
+      )}
+      {generalRooms?.map((summary) => (
         <li key={summary.partyroomId}>
           <MobilePartyroomCard roomId={summary.partyroomId} summary={summary} />
         </li>


### PR DESCRIPTION
closes #377

## 요약

`MobilePartyroomCard` 를 데스크탑 `PartyroomCard` 와 동일한 **BackdropBlur 단일 카드 패턴** 으로 rewrite. shared 컴포넌트 (`BackdropBlurContainer`, `Typography`, `Crews`) 차용 + `MainStageLabel` sub-컴포넌트로 i18n 의존 격리 (일반 카드 unit test 의 i18n provider mock 강제 invariant 보존).

## 변경

- `src/features-mobile/partyroom/list/partyroom-card.component.tsx` rewrite (BackdropBlur 단일 패턴, Typography 토큰, Crews 차용, MainStageLabel sub-컴포넌트)
- `src/features-mobile/partyroom/list/partyroom-card.component.test.tsx` 케이스 6개 (기존 3 유지/수정 + 신규 3)
- `src/features-mobile/partyroom/list/partyroom-list.component.tsx` Main 카드에 `isMain` prop 전달 (mainRoom prepend + generalRooms map 명시적 분리, idx 기반 거절안 회피)

영향 파일 = **3개**. 데스크탑 카드 무영향.

## 사용자 가시 동작 변화 (1건)

- `playbackActivated=false` 일 때 "재생 중인 곡이 없어요" placeholder 텍스트 제거 → BackdropBlur fallback 이미지 `/images/Background/Partyroom.png` 로 대체 (데스크탑 카드와 동일 동작)

## 결정 잠금 (spec)

| # | 결정 | 답 |
| --- | --- | --- |
| Q1 | 1차 목적 | 전환 깔때기 강화 (#340 정합) |
| Q2 | 카드 구조 | A. BackdropBlur 단일 |
| Q3 | Main 카드 | a. 일반 카드 + Main 라벨 |
| Q4 | PFInfoOutline | 제외 |
| Q5 | 스코프 | `MobilePartyroomCard` 1개 파일 |
| Q6 | 구현 | A2. shared 컴포넌트 차용 rewrite |

## 검증

- [x] 단위 test 6 케이스 GREEN
- [x] typecheck 0 오류
- [x] 본 변경 파일 한정 lint clean
- [x] e2e 영향 점검: 모바일 lobby 카드 텍스트 단언 / DOM 단언 0 hit (변경 영향 없음)
- [ ] **로컬 실측은 환경 (띄어쓰기 경로) 이슈로 skip — Vercel preview deploy 로 대체 검증 부탁드립니다** (모바일 viewport: BackdropBlur 배경 + Crews 아바타 + Main 라벨 + 일반 카드 라벨 부재 + placeholder 텍스트 제거 확인 / 데스크탑 viewport: 카드 무영향 확인)
- [ ] e2e CI (preview 자동 실행) GREEN 확인

## 설계 문서

- Spec: `docs/superpowers/specs/2026-05-30-mobile-lobby-card-catchup-design.md`
- Plan: `docs/superpowers/plans/2026-05-30-mobile-lobby-card-catchup.md`

spec review iter 2 + plan review iter 1 모두 ✅ Approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
