### PR TITLE
fix(mobile/queue-panel): 게스트일 때 playlists 호출 skip

### DIFF
--- a/src/widgets-mobile/partyroom-queue-panel/ui/queue-panel.component.tsx
+++ b/src/widgets-mobile/partyroom-queue-panel/ui/queue-panel.component.tsx
@@ -21,10 +21,13 @@ interface Props {
 const QueuePanelContent: FC<Props> = ({ partyroomId }) => {
   const { data: me } = useFetchMe();
   const isGuest = me?.authorityTier === AuthorityTier.GT;
+  // 게스트(GT)는 playlists 사용처(register/change DJ slot)에 도달하지 않으므로 호출 자체를 skip.
+  // me 가 아직 fetch 안 된 시점도 enabled=false 로 안전 — 데스크탑 playlist-action.provider 와 동일 패턴.
+  const isMember = !!me && me.authorityTier !== AuthorityTier.GT;
   const { data: djingQueue } = useFetchDjingQueue({ partyroomId });
   const { useCurrentPartyroom } = useStores();
   const myCrewId = useCurrentPartyroom((s) => s.me?.crewId);
-  const { data: playlists = [] } = useFetchPlaylists();
+  const { data: playlists = [] } = useFetchPlaylists({ enabled: isMember });
 
   const djs = djingQueue?.djs ?? [];
   const playback = djingQueue?.playback;


### PR DESCRIPTION
closes #379

## 요약

모바일 queue panel 이 게스트(GT) 일 때도 `useFetchPlaylists` 를 호출하여 403 모달이 뜨는 회귀 fix. 데스크탑 `playlist-action.provider` 와 동일한 `enabled: isMember` 패턴 적용.

## 변경

`src/widgets-mobile/partyroom-queue-panel/ui/queue-panel.component.tsx` 1줄 변경 + 의도 주석.

```diff
const isGuest = me?.authorityTier === AuthorityTier.GT;
+ const isMember = !!me && me.authorityTier !== AuthorityTier.GT;
...
- const { data: playlists = [] } = useFetchPlaylists();
+ const { data: playlists = [] } = useFetchPlaylists({ enabled: isMember });
```

## 회귀 정보

- Introduction commit: `94376fa` (PR #370 모바일 반응형 chunk 4)
- 같은 컴포넌트가 `if (isGuest)` 분기로 게스트엔 GuestCta 렌더 — playlists 사용 자체가 X, 호출 발사는 무의미

## 검증

- [x] typecheck 0 errors
- [x] queue-panel widget unit test 18/18 GREEN
- [ ] 로컬 실측: 게스트로 룸 입장 시 403 모달 X 확인
- [ ] Vercel preview e2e

## 관련

- 이슈 #379
- pfplay-web #377 (chunk 5 모바일 lobby 카드) 실측 중 발견 — 별도 영역이라 별개 PR 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)