### PR TITLE
fix(mobile/chunk-3·4): widget baseline 정합 sweep (재생 seek + 게스트 CTA dialog)

### DIFF
--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -39,17 +39,35 @@ vi.mock('./ui/parts/action-buttons.component', () => ({
 
 type StoreState = {
   playbackActivated: boolean;
-  playback: { name: string; duration: string; linkId: string } | null;
+  // PartyroomPlayback 형식 정합: id/thumbnailImage 는 모바일 widget 이 사용 안 하지만,
+  // endTime 은 seekToLive 가 getInitialSeek(endTime - now) 으로 사용하므로 필수.
+  playback: {
+    name: string;
+    duration: string;
+    linkId: string;
+    endTime: number;
+    id?: number;
+    thumbnailImage?: string;
+  } | null;
   currentDj: { crewId: number } | null;
   crews: Array<{ crewId: number; nickname: string }>;
 };
 
+// 미래 시각 → getInitialSeek 가 양수 elapsed 반환하지만 mock seekTo 는 호출만 추적.
+const FUTURE_END_TIME = Date.now() + 60_000;
+
 let storeState: StoreState = {
   playbackActivated: true,
-  playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+  playback: { name: 'Track 1', duration: '3:30', linkId: 'abc', endTime: FUTURE_END_TIME },
   currentDj: { crewId: 1 },
   crews: [{ crewId: 1, nickname: 'DJ A' }],
 };
+
+// react-player onReady 콜백에 넘기는 mock player.
+// seekToLive 가 playerRef.current?.seekTo 를 호출하므로 vi.fn 으로 stub 필요 (회귀 fix #382 invariant).
+function makeMockPlayer() {
+  return { seekTo: vi.fn() } as unknown;
+}
 
 vi.mock('@/shared/lib/store/stores.context', () => ({
   useStores: () => ({
@@ -63,7 +81,7 @@ function setStoreState(patch: Partial<StoreState>) {
 function resetStoreState() {
   storeState = {
     playbackActivated: true,
-    playback: { name: 'Track 1', duration: '3:30', linkId: 'abc' },
+    playback: { name: 'Track 1', duration: '3:30', linkId: 'abc', endTime: FUTURE_END_TIME },
     currentDj: { crewId: 1 },
     crews: [{ crewId: 1, nickname: 'DJ A' }],
   };
@@ -189,7 +207,7 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
 
     const firstYt = youtubePlayerCalls[0];
     act(() => {
-      (firstYt.onReady as (p: unknown) => void)({} as unknown);
+      (firstYt.onReady as (p: unknown) => void)(makeMockPlayer());
       (firstYt.onPlay as () => void)();
     });
 
@@ -198,7 +216,7 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
 
     const newYt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
     act(() => {
-      (newYt.onReady as (p: unknown) => void)({} as unknown);
+      (newYt.onReady as (p: unknown) => void)(makeMockPlayer());
     });
     act(() => {
       vi.advanceTimersByTime(1500);
@@ -221,7 +239,7 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
 
     const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
     act(() => {
-      (yt.onReady as (p: unknown) => void)({} as unknown);
+      (yt.onReady as (p: unknown) => void)(makeMockPlayer());
     });
     act(() => {
       vi.advanceTimersByTime(1500);
@@ -239,7 +257,7 @@ describe('MobilePartyroomDisplayBoard · cross-component single source', () => {
 
     const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
     act(() => {
-      (yt.onReady as (p: unknown) => void)({} as unknown);
+      (yt.onReady as (p: unknown) => void)(makeMockPlayer());
     });
     act(() => {
       vi.advanceTimersByTime(1500);
@@ -258,7 +276,7 @@ describe('MobilePartyroomDisplayBoard · cross-component single source', () => {
 
     const yt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
     act(() => {
-      (yt.onReady as (p: unknown) => void)({} as unknown);
+      (yt.onReady as (p: unknown) => void)(makeMockPlayer());
     });
     act(() => {
       vi.advanceTimersByTime(1500);

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
@@ -83,6 +83,7 @@ const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
           onToggleExpand={() => setExpanded((v) => !v)}
           playerRef={playerRef}
           gate={gate}
+          playback={playback}
         />
       </div>
 

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -3,7 +3,9 @@ import dynamic from 'next/dynamic';
 import { FC, MutableRefObject } from 'react';
 import type TReactPlayer from 'react-player';
 import { YouTubeConfig } from 'react-player/youtube';
+import * as Playback from '@/entities/current-partyroom/model/playback.model';
 import { useUserPreferenceStore } from '@/entities/preference';
+import { PartyroomPlayback } from '@/shared/api/http/types/partyrooms';
 import { cn } from '@/shared/lib/functions/cn';
 import BlankPlaceholder from './blank-placeholder.component';
 import ExpandToggle from './expand-toggle.component';
@@ -33,12 +35,32 @@ interface Props {
   // MutableRefObject 가 필요. 부모는 useRef<TReactPlayer | null>(null) 로 그대로 생성.
   playerRef: MutableRefObject<TReactPlayer | null>;
   gate: AutoplayGestureGate;
+  /**
+   * playback.endTime/duration 기반 라이브 위치 seek 에 사용.
+   * 데스크탑 widgets/partyroom-display-board/ui/parts/video.component.tsx 의 seekToLive 와 동일 정책.
+   * null/undefined 면 seek 안 함 (모드 C 거나 데이터 미도착).
+   */
+  playback?: PartyroomPlayback | null;
 }
 
-const VideoFrame: FC<Props> = ({ videoId, expanded, onToggleExpand, playerRef, gate }) => {
+const VideoFrame: FC<Props> = ({
+  videoId,
+  expanded,
+  onToggleExpand,
+  playerRef,
+  gate,
+  playback,
+}) => {
   const mode: 'A' | 'B' | 'C' = videoId === null ? 'C' : expanded ? 'A' : 'B';
   const volume = useUserPreferenceStore((s) => s.volume);
   const muted = useUserPreferenceStore((s) => s.muted);
+
+  // 현재 트랙의 라이브 위치로 seek. player onReady · 트랙 변경 onStart 양쪽에서 호출.
+  // 데스크탑 PartyroomDisplayBoard 의 seekToLive 와 정확히 동일 패턴.
+  const seekToLive = () => {
+    if (!playback) return;
+    playerRef.current?.seekTo(Playback.getInitialSeek(playback), 'seconds');
+  };
 
   const showOverlayGate = mode === 'A' && gate.autoplayBlocked && !gate.played;
   const showToggle = mode === 'A' || mode === 'B';
@@ -60,9 +82,13 @@ const VideoFrame: FC<Props> = ({ videoId, expanded, onToggleExpand, playerRef, g
             className='bg-black rounded'
             onReady={(player: TReactPlayer) => {
               playerRef.current = player;
+              seekToLive();
               gate.onReady(player);
             }}
-            onStart={gate.onStart}
+            onStart={() => {
+              seekToLive();
+              gate.onStart();
+            }}
             onPlay={gate.onPlay}
             onPause={gate.onPause}
             config={config}

--- a/src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.test.tsx
+++ b/src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.test.tsx
@@ -3,9 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import GuestCta from './guest-cta.component';
 
-const pushMock = vi.fn();
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock }),
+// 데스크탑 PartyroomCreateCard 와 동일 mock 패턴 — informSocialType 함수만 vi.fn 으로 stub.
+// 회귀 fix (#383) 이전 mock 은 next/navigation 의 useRouter 였음 (router.push('/sign-in') →
+// 룸 unmount + backend exit 의 원인).
+const informMock = vi.fn();
+vi.mock('@/features/sign-in/by-social', () => ({
+  useInformSocialType: () => informMock,
 }));
 
 vi.mock('@/shared/lib/localization/i18n.context', () => ({
@@ -26,9 +29,9 @@ describe('GuestCta', () => {
     expect(screen.getByText(/음악을 직접 틀어보세요/)).toBeInTheDocument();
   });
 
-  test('클릭 → router.push(/sign-in)', async () => {
+  test('클릭 → informSocialType() 호출 (dialog 표시, 룸 unmount 회피)', async () => {
     render(<GuestCta />);
     await userEvent.click(screen.getByTestId('guest-cta'));
-    expect(pushMock).toHaveBeenCalledWith('/sign-in');
+    expect(informMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.tsx
+++ b/src/widgets-mobile/partyroom-queue-panel/ui/guest-cta.component.tsx
@@ -1,17 +1,24 @@
 'use client';
-import { useRouter } from 'next/navigation';
 import { FC } from 'react';
+import { useInformSocialType } from '@/features/sign-in/by-social';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Typography } from '@/shared/ui/components/typography';
 
+/**
+ * 게스트가 DJ 대기열 탭에서 sign-up 으로 진입하는 CTA.
+ *
+ * **회귀 fix (#383)**: 기존 `router.push('/sign-in')` 은 페이지 이동이라 룸 unmount + backend exit 발생.
+ * 데스크탑 `features/partyroom/create/ui/card.component.tsx` 와 동일하게 `useInformSocialType()` (sign-in dialog)
+ * 패턴으로 변경 — dialog 가 룸 위에 떠서 사용자가 로그인 완료해도 룸은 유지.
+ */
 const GuestCta: FC = () => {
   const t = useI18n();
-  const router = useRouter();
+  const informSocialType = useInformSocialType();
   return (
     <button
       type='button'
       data-testid='guest-cta'
-      onClick={() => router.push('/sign-in')}
+      onClick={() => informSocialType()}
       className='shrink-0 m-4 p-4 border border-gray-700 rounded text-center hover:bg-gray-900'
     >
       <Typography type='body3'>{t.partyroom.queue.guest_cta_title}</Typography>

--- a/src/widgets-mobile/partyroom-queue-panel/ui/queue-panel.component.test.tsx
+++ b/src/widgets-mobile/partyroom-queue-panel/ui/queue-panel.component.test.tsx
@@ -3,6 +3,12 @@ import { describe, expect, test, vi } from 'vitest';
 import { AuthorityTier, QueueStatus } from '@/shared/api/http/types/@enums';
 import QueuePanel from './queue-panel.component';
 
+// GuestCta 가 useInformSocialType 호출 (회귀 fix #383 으로 dialog 패턴 적용).
+// 이 hook 이 react-query QueryClient 의존이라 test 환경에서 throw → 게스트 분기 케이스 보호.
+vi.mock('@/features/sign-in/by-social', () => ({
+  useInformSocialType: () => vi.fn(),
+}));
+
 vi.mock('@/shared/lib/localization/i18n.context', () => ({
   useI18n: () => ({
     partyroom: {


### PR DESCRIPTION
closes #382, closes #383

## 요약

모바일 chunk 3·4 작업 시 데스크탑 baseline 안 따른 회귀 2건을 같은 sweep PR 으로 fix.

## 변경 (commit 별 분리)

### `2542cdf` — VideoFrame 라이브 위치 seek 누락 (#382, chunk 3 회귀)
- VideoFrame 에 `playback?: PartyroomPlayback` prop 추가
- `onReady` / `onStart` 양쪽에서 `seekTo(getInitialSeek(playback), 'seconds')`
- 호출자 `partyroom-display-board.component` 가 store playback selector 전달
- test mock: storeState 에 endTime + `makeMockPlayer()` factory (seekTo: vi.fn())

### `818e6d0` — GuestCta dialog 패턴 fix (#383, chunk 4 회귀)
- `useRouter().push('/sign-in')` → `useInformSocialType()` 호출
- 데스크탑 `features/partyroom/create/ui/card.component` 동일 패턴
- 게스트 CTA 클릭 시 sign-in dialog 가 룸 위에 표시 → 로그인 완료해도 룸 유지 (이전: 룸 unmount + backend exit + 메인화면 강제 이동)
- guest-cta test mock 갱신

### `ac505ec` — queue-panel test mock 후속
- queue-panel test 가 게스트 분기에서 GuestCta 마운트 → useInformSocialType → react-query QueryClient 부재 throw fix
- vi.mock 1줄 추가로 격리

## 검증

- [x] typecheck 0 errors
- [x] 영향 widget 단위 test 60/60 GREEN
- [x] husky pre-push (typecheck + test) 통과
- [ ] 로컬 실측 (사용자): 룸 입장 시 라이브 위치 재생 / 게스트 CTA 클릭 시 dialog 표시 + 룸 유지
- [ ] Vercel preview e2e

## 관련

- 이슈 #382 (chunk 3 회귀)
- 이슈 #383 (chunk 4 회귀, #379 와 동일 chunk 4 baseline 정합 누락 family)
- pfplay-web #377 (chunk 5 모바일 lobby 카드) 실측 중 발견. 본 PR 별도 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)