### PR TITLE
fix(player): 같은 곡 회전 시 재생 정지 fix — playback.id 변경 명시적 reload

### DIFF
--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from 'next/dynamic';
-import { FC, MutableRefObject } from 'react';
+import { FC, MutableRefObject, useEffect } from 'react';
 import type TReactPlayer from 'react-player';
 import { YouTubeConfig } from 'react-player/youtube';
 import * as Playback from '@/entities/current-partyroom/model/playback.model';
@@ -61,6 +61,26 @@ const VideoFrame: FC<Props> = ({
     if (!playback) return;
     playerRef.current?.seekTo(Playback.getInitialSeek(playback), 'seconds');
   };
+
+  // playback.id 변경 (트랙 변경 OR 같은 곡 회전) 감지 → 명시적 IFrame reload (#384).
+  // react-player 는 url prop 이 동일하면 (같은 linkId 회전 케이스) IFrame 에 reload 명령을 안 보낸다.
+  // 결과: 곡 ended state 그대로 유지 → DJ 1명+곡 1개 시나리오에서 재생 정지.
+  // 데스크탑 widgets/partyroom-display-board/.../video.component 와 정확히 동일 패턴.
+  const playbackId = playback?.id;
+  useEffect(() => {
+    if (!playbackId || !videoId || !playerRef.current) return;
+    const internal = playerRef.current.getInternalPlayer() as
+      | { loadVideoById?: (id: string, start?: number) => void; playVideo?: () => void }
+      | undefined;
+    const startSeconds = playback ? Playback.getInitialSeek(playback) : 0;
+    if (internal?.loadVideoById) {
+      internal.loadVideoById(videoId, startSeconds);
+    } else {
+      playerRef.current.seekTo(startSeconds, 'seconds');
+      internal?.playVideo?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playbackId]);
 
   const showOverlayGate = mode === 'A' && gate.autoplayBlocked && !gate.played;
   const showToggle = mode === 'A' || mode === 'B';

--- a/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
@@ -119,6 +119,28 @@ export default function Video({
     seekToLive();
   };
 
+  // playback.id 변경 (트랙 변경 OR 같은 곡 회전) 감지 → 명시적 IFrame reload (#384).
+  // react-player 는 url prop 이 동일하면 (같은 linkId 회전 케이스) IFrame 에 reload 명령을 안 보낸다.
+  // 결과: 곡 ended state 그대로 유지 → DJ 1명+곡 1개 시나리오에서 재생 정지.
+  // playback.id 는 backend 가 회전마다 갱신하므로 신뢰 가능한 reload 트리거.
+  // YouTube IFrame API 의 loadVideoById(videoId, startSeconds) 가 같은 영상도 정상 reload.
+  const playbackId = playback?.id;
+  useEffect(() => {
+    if (!playbackId || !videoId || !playerRef.current) return;
+    const internal = playerRef.current.getInternalPlayer() as
+      | { loadVideoById?: (id: string, start?: number) => void; playVideo?: () => void }
+      | undefined;
+    const startSeconds = Playback.getInitialSeek(playback as PartyroomPlayback);
+    if (internal?.loadVideoById) {
+      internal.loadVideoById(videoId, startSeconds);
+    } else {
+      // loadVideoById 없는 환경 (비 YouTube 임베드 등) 폴백.
+      playerRef.current.seekTo(startSeconds, 'seconds');
+      internal?.playVideo?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playbackId]);
+
   const onPlay = () => {
     setPlayed(true);
     setAutoplayBlocked(false);


### PR DESCRIPTION
closes #384

## 요약

DJ 1명+곡 1개 시나리오에서 곡 ended 후 같은 곡이 다시 시작되지 않던 baseline 버그 fix. 데스크탑·모바일 동일 (chunk 시리즈와 무관).

## Root cause

react-player wrapper 가 `url` prop 동일하면 (같은 linkId 회전) IFrame Player 에 reload 명령 안 보냄 → IFrame 이 ended state 유지 → 정지.

YouTube IFrame API 자체는 `loadVideoById` 호출 시 같은 영상도 reload 가능 — 단지 명시적 호출이 없어 정지.

사용자 가설 ("임베디드 플레이어가 같은 영상 재생을 거부하는가") 검증 결과: **No**. frontend 가 명시적 reload 안 하는 게 원인.

## Fix

playback.id 변경 감지 `useEffect` 에서 YouTube IFrame `loadVideoById(videoId, startSeconds)` 명시적 호출.

- 트랙 변경 (linkId 다름) 시: react-player 가 자체 reload (기존 동작) + useEffect 가 동일 위치로 추가 reload (안전성 ↑)
- 같은 곡 회전 (linkId 동일, id 다름) 시: useEffect 가 명시적 reload — 회귀 fix
- react-player remount 회피 유지 (#335 background autoplay 차단 fix 영향 0)
- fallback: `loadVideoById` 없는 환경에서는 `seekTo(0) + playVideo()`

## 변경

- `src/widgets/partyroom-display-board/ui/parts/video.component.tsx` (데스크탑) — useEffect 추가
- `src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx` (모바일) — useEffect 추가 + useEffect import 추가

본 PR 의 base = `fix/mobile-widget-baseline-sweep` (PR #385). 모바일 fix 가 #385 의 video-frame seek 위에 build. #385 머지 후 본 PR base 가 자동 development 로 정착.

## 검증

- [x] typecheck 0 errors
- [x] display-board widget 단위 test 108/108 GREEN (데스크탑 + 모바일)
- [x] husky pre-push 통과
- [ ] 로컬 실측 (사용자): DJ 1명+곡 1개 시나리오에서 곡 ended 후 같은 곡 자동 재시작 확인 (데스크탑/모바일 모두)
- [ ] Vercel preview e2e

## 관련

- 이슈 #384
- pfplay-web #377 (chunk 5 모바일 lobby 카드) 실측 중 사용자 보고
- PR #385 (widget baseline sweep) 위 build — 머지 순서: #385 → 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)