### PR TITLE
fix(player): 같은 곡 회전 시 재생 정지 fix — playback.id 변경 명시적 reload (resurrect #386)

### DIFF
--- a/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/video-frame.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from 'next/dynamic';
-import { FC, MutableRefObject } from 'react';
+import { FC, MutableRefObject, useEffect } from 'react';
 import type TReactPlayer from 'react-player';
 import { YouTubeConfig } from 'react-player/youtube';
 import * as Playback from '@/entities/current-partyroom/model/playback.model';
@@ -61,6 +61,26 @@ const VideoFrame: FC<Props> = ({
     if (!playback) return;
     playerRef.current?.seekTo(Playback.getInitialSeek(playback), 'seconds');
   };
+
+  // playback.id 변경 (트랙 변경 OR 같은 곡 회전) 감지 → 명시적 IFrame reload (#384).
+  // react-player 는 url prop 이 동일하면 (같은 linkId 회전 케이스) IFrame 에 reload 명령을 안 보낸다.
+  // 결과: 곡 ended state 그대로 유지 → DJ 1명+곡 1개 시나리오에서 재생 정지.
+  // 데스크탑 widgets/partyroom-display-board/.../video.component 와 정확히 동일 패턴.
+  const playbackId = playback?.id;
+  useEffect(() => {
+    if (!playbackId || !videoId || !playerRef.current) return;
+    const internal = playerRef.current.getInternalPlayer() as
+      | { loadVideoById?: (id: string, start?: number) => void; playVideo?: () => void }
+      | undefined;
+    const startSeconds = playback ? Playback.getInitialSeek(playback) : 0;
+    if (internal?.loadVideoById) {
+      internal.loadVideoById(videoId, startSeconds);
+    } else {
+      playerRef.current.seekTo(startSeconds, 'seconds');
+      internal?.playVideo?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playbackId]);
 
   const showOverlayGate = mode === 'A' && gate.autoplayBlocked && !gate.played;
   const showToggle = mode === 'A' || mode === 'B';

--- a/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/video.component.tsx
@@ -119,6 +119,28 @@ export default function Video({
     seekToLive();
   };
 
+  // playback.id 변경 (트랙 변경 OR 같은 곡 회전) 감지 → 명시적 IFrame reload (#384).
+  // react-player 는 url prop 이 동일하면 (같은 linkId 회전 케이스) IFrame 에 reload 명령을 안 보낸다.
+  // 결과: 곡 ended state 그대로 유지 → DJ 1명+곡 1개 시나리오에서 재생 정지.
+  // playback.id 는 backend 가 회전마다 갱신하므로 신뢰 가능한 reload 트리거.
+  // YouTube IFrame API 의 loadVideoById(videoId, startSeconds) 가 같은 영상도 정상 reload.
+  const playbackId = playback?.id;
+  useEffect(() => {
+    if (!playbackId || !videoId || !playerRef.current) return;
+    const internal = playerRef.current.getInternalPlayer() as
+      | { loadVideoById?: (id: string, start?: number) => void; playVideo?: () => void }
+      | undefined;
+    const startSeconds = Playback.getInitialSeek(playback as PartyroomPlayback);
+    if (internal?.loadVideoById) {
+      internal.loadVideoById(videoId, startSeconds);
+    } else {
+      // loadVideoById 없는 환경 (비 YouTube 임베드 등) 폴백.
+      playerRef.current.seekTo(startSeconds, 'seconds');
+      internal?.playVideo?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playbackId]);
+
   const onPlay = () => {
     setPlayed(true);
     setAutoplayBlocked(false);


### PR DESCRIPTION
closes #384

이전 PR #386 이 base 였던 `fix/mobile-widget-baseline-sweep` 가 #385 머지 시 `--delete-branch` 로 같이 삭제되며 자동 CLOSED. head branch `fix/same-video-rotation-reload` 가 살아있어 base=development 로 새 PR.

## Root cause + Fix

react-player wrapper 가 url prop 동일 시 IFrame reload 명령 안 보냄. `playback.id` 변경 감지 useEffect 에서 IFrame `loadVideoById` 명시적 호출. 데스크탑·모바일 동일 패턴.

## 검증

- [x] typecheck 0 + 108/108 unit tests GREEN
- [x] husky pre-push 통과
- [ ] 로컬 실측 (사용자)
- [ ] Vercel preview e2e

## 관련

- 이슈 #384, 이전 PR #386 (CLOSED, base orphan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)