### PR TITLE
feat(모바일): 로비 'Be a PFPlay Host' CTA 노출 (#381)

### DIFF
--- a/e2e/mobile/host-cta.spec.ts
+++ b/e2e/mobile/host-cta.spec.ts
@@ -1,0 +1,47 @@
+import { type Page, expect } from '@playwright/test';
+import { attachErrorTracing } from './chunk4.helpers';
+import { test } from '../fixtures/auth.fixtures';
+
+/**
+ * #381 — 모바일 로비 "Be a PFPlay Host" CTA (mobile project).
+ *
+ * 이슈: 모바일 로비에 방만들기 진입점이 없었음. 옵션 B = 파티룸 목록과 같은 컨테이너
+ * (1열 카드 리스트) 맨 위에 host CTA 카드 노출.
+ *
+ * 검증 본질:
+ * - 모바일 viewport(iPhone 13 → middleware x-pf-device=mobile → MobileLobby)의 로비에
+ *   host CTA(`mobile-create-partyroom-button`)가 실제로 노출된다(= 회귀 전 '미노출' 해소).
+ * - 멤버가 클릭하면 useBeAHost 멤버 분기 → 파티 생성 다이얼로그가 열린다.
+ *   (게스트 분기 = informSocialType 는 unit 커버. 여기선 멤버 경로만 e2e.)
+ *
+ * 파티룸을 실제 생성하지 않으므로(submit X) cleanup 불필요.
+ */
+test.describe('mobile lobby host CTA (#381)', () => {
+  test('모바일 로비에 host CTA 노출 + 멤버 클릭 시 파티 생성 다이얼로그', async ({
+    user1Context,
+  }) => {
+    test.setTimeout(60_000);
+    const t0 = Date.now();
+    const log = (m: string) => console.log(`[host-cta test][${Date.now() - t0}ms] ${m}`);
+    const page: Page = await user1Context.newPage();
+    attachErrorTracing(page, log);
+
+    log('goto mobile lobby');
+    await page.goto('/parties');
+
+    // 1) host CTA 가 로비 목록 안에 노출 (#381 핵심)
+    log('expect host CTA visible');
+    const cta = page.getByTestId('mobile-create-partyroom-button');
+    await expect(cta).toBeVisible({ timeout: 30_000 });
+    await expect(cta).toContainText(/Be a PFPlay Host/i);
+
+    // 2) 멤버 클릭 → 파티 생성 다이얼로그 (useBeAHost 멤버 분기)
+    log('click CTA');
+    await cta.click();
+
+    log('expect create-party dialog form');
+    // 생성 폼의 name 인풋 노출 = openDialog(CreatePartyroomForm) 발화 확인.
+    await expect(page.locator('input[name="name"]')).toBeVisible({ timeout: 15_000 });
+    log('done');
+  });
+});

--- a/src/features-mobile/partyroom/create/index.ts
+++ b/src/features-mobile/partyroom/create/index.ts
@@ -1,0 +1,1 @@
+export { default as MobilePartyroomCreateCard } from './ui/card.component';

--- a/src/features-mobile/partyroom/create/ui/card.component.test.tsx
+++ b/src/features-mobile/partyroom/create/ui/card.component.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import MobilePartyroomCreateCard from './card.component';
+
+const beAHostMock = vi.fn();
+vi.mock('@/features/partyroom/create/lib/use-be-a-host.hook', () => ({
+  default: () => beAHostMock,
+}));
+
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    lobby: {
+      title: { be_a_host: 'Be a PFPlay Host' },
+      para: { freely_host: '원하는 테마의 파티를 자유롭게 호스트 해보세요!' },
+    },
+  }),
+}));
+
+vi.mock('next/image', () => ({ __esModule: true, default: () => <img alt='' /> }));
+
+describe('MobilePartyroomCreateCard', () => {
+  beforeEach(() => {
+    beAHostMock.mockReset();
+  });
+
+  test('be_a_host 타이틀 + 부제 렌더', () => {
+    render(<MobilePartyroomCreateCard />);
+    expect(screen.getByText('Be a PFPlay Host')).toBeInTheDocument();
+    expect(screen.getByText('원하는 테마의 파티를 자유롭게 호스트 해보세요!')).toBeInTheDocument();
+  });
+
+  test('클릭 → useBeAHost 핸들러 호출', () => {
+    render(<MobilePartyroomCreateCard />);
+    fireEvent.click(screen.getByTestId('mobile-create-partyroom-button'));
+    expect(beAHostMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features-mobile/partyroom/create/ui/card.component.tsx
+++ b/src/features-mobile/partyroom/create/ui/card.component.tsx
@@ -1,0 +1,46 @@
+'use client';
+import Image from 'next/image';
+import { FC } from 'react';
+import useBeAHost from '@/features/partyroom/create/lib/use-be-a-host.hook';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Typography } from '@/shared/ui/components/typography';
+
+/**
+ * 모바일 로비 1컬럼 리스트 안의 "Be a PFPlay Host" 진입 카드 (이슈 #381, 옵션 B).
+ *
+ * - 데스크탑 `PartyroomCreateCard` 와 동일 핸들러(`useBeAHost`) 공유 — 게스트는 소셜
+ *   로그인 유도, 멤버는 생성 다이얼로그.
+ * - 룸 카드(BackdropBlur + 썸네일) 와 구별되는 액션 카드 폼팩터: 좌측 텍스트(red 타이틀
+ *   + 부제) + 우측 plus 아이콘, full-width.
+ */
+const MobilePartyroomCreateCard: FC = () => {
+  const t = useI18n();
+  const handleClickBeAHostBtn = useBeAHost();
+
+  return (
+    <button
+      type='button'
+      onClick={handleClickBeAHostBtn}
+      data-testid='mobile-create-partyroom-button'
+      className='appearance-none w-full bg-gray-900 rounded flexRow items-center justify-between gap-3 px-5 py-4 text-start'
+    >
+      <div className='flexCol gap-1 min-w-0'>
+        <Typography type='title2' className='text-red-300'>
+          {t.lobby.title.be_a_host}
+        </Typography>
+        <Typography type='detail1' className='text-gray-200'>
+          {t.lobby.para.freely_host}
+        </Typography>
+      </div>
+      <Image
+        src='/images/Background/bigPlus.png'
+        alt='Party Room Add'
+        width={44}
+        height={44}
+        className='shrink-0'
+      />
+    </button>
+  );
+};
+
+export default MobilePartyroomCreateCard;

--- a/src/features-mobile/partyroom/list/partyroom-list.component.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-list.component.tsx
@@ -3,6 +3,7 @@
 import { FC } from 'react';
 import { useFetchGeneralPartyrooms } from '@/features/partyroom/list/api/use-fetch-general-partyrooms.query';
 import { useSuspenseFetchMainPartyroom } from '@/features/partyroom/list/api/use-fetch-main-partyroom.query';
+import { MobilePartyroomCreateCard } from '@/features-mobile/partyroom/create';
 import MobilePartyroomCard from './partyroom-card.component';
 
 /**
@@ -13,6 +14,9 @@ import MobilePartyroomCard from './partyroom-card.component';
  * prepend. 모바일은 좌우 폭이 좁아 hero blur card 의 visual hierarchy 효과가 약하므로
  * 동일 카드 디자인 유지, 위치만 최상단.
  *
+ * 리스트 맨 위에 host CTA(`MobilePartyroomCreateCard`, 이슈 #381 옵션 B) 를 둬 방만들기
+ * 진입점을 파티룸 목록과 같은 컨테이너 안에 노출한다. 열린 파티가 없어도 CTA 는 항상 보인다.
+ *
  * - `useSuspenseFetchMainPartyroom` (suspense) + `useFetchGeneralPartyrooms` 는 같은
  *   `/api/v1/partyrooms` getList 응답을 query key 공유로 단일 fetch + 다른 select.
  * - Suspense boundary 는 호출자(`MobileLobby`)가 `SuspenseWithErrorBoundary` 로 처리.
@@ -21,16 +25,13 @@ const MobilePartyroomList: FC = () => {
   const { data: mainRoom } = useSuspenseFetchMainPartyroom();
   const { data: generalRooms } = useFetchGeneralPartyrooms();
 
-  if (!mainRoom && (!generalRooms || generalRooms.length === 0)) {
-    return (
-      <div className='w-full py-12 text-center text-sm text-gray-500'>
-        지금 열려 있는 파티가 없어요.
-      </div>
-    );
-  }
+  const hasRooms = !!mainRoom || (generalRooms?.length ?? 0) > 0;
 
   return (
     <ul className='flexCol gap-4 w-full'>
+      <li>
+        <MobilePartyroomCreateCard />
+      </li>
       {mainRoom && (
         <li key={mainRoom.partyroomId}>
           <MobilePartyroomCard roomId={mainRoom.partyroomId} summary={mainRoom} isMain />
@@ -41,6 +42,11 @@ const MobilePartyroomList: FC = () => {
           <MobilePartyroomCard roomId={summary.partyroomId} summary={summary} />
         </li>
       ))}
+      {!hasRooms && (
+        <li className='w-full py-12 text-center text-sm text-gray-500'>
+          지금 열려 있는 파티가 없어요.
+        </li>
+      )}
     </ul>
   );
 };

--- a/src/features/partyroom/create/lib/use-be-a-host.hook.tsx
+++ b/src/features/partyroom/create/lib/use-be-a-host.hook.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useIsGuest } from '@/entities/me';
+import { useInformSocialType } from '@/features/sign-in/by-social';
+import { Language } from '@/shared/lib/localization/constants';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useLang } from '@/shared/lib/localization/lang.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import CreatePartyroomForm from '../ui/form.component';
+
+/**
+ * "Be a PFPlay Host" 클릭 핸들러 (데스크탑 카드 + 모바일 카드 공유).
+ *
+ * - 게스트(GT) → 소셜 로그인 유도 모달(informSocialType), 생성 다이얼로그 미오픈.
+ *   (AM/FM 모두 생성 가능 — backend PartyroomCreationPolicy = FM|AM. 지갑 게이트 없음.)
+ * - 멤버 → 파티룸 생성 다이얼로그(CreatePartyroomForm).
+ *
+ * 데스크탑 `card.component.tsx` 의 인라인 핸들러를 추출 — 동작 동일.
+ */
+export default function useBeAHost(): () => Promise<void> {
+  const t = useI18n();
+  const lang = useLang();
+  const { openDialog, openConfirmDialog } = useDialog();
+  const isGuest = useIsGuest();
+  const informSocialType = useInformSocialType();
+
+  return async () => {
+    if (await isGuest()) {
+      informSocialType();
+      return;
+    }
+
+    openDialog((_, onCancel) => ({
+      title: t.createparty.title.create_party,
+      titleAlign: 'left',
+      showCloseIcon: true,
+      closeConfirm: () => {
+        const [title, content] = t.createparty.para.cancel_confirm.split('\n');
+        return openConfirmDialog({
+          title,
+          content,
+        });
+      },
+      classNames: {
+        container: lang === Language.Ko ? 'w-[800px]' : 'w-[900px]',
+      },
+      Body: () => <CreatePartyroomForm onSuccess={onCancel} />,
+    }));
+  };
+}

--- a/src/features/partyroom/create/ui/card.component.tsx
+++ b/src/features/partyroom/create/ui/card.component.tsx
@@ -1,46 +1,12 @@
 'use client';
 import Image from 'next/image';
-import { useIsGuest } from '@/entities/me';
-import { useInformSocialType } from '@/features/sign-in/by-social';
-import { Language } from '@/shared/lib/localization/constants';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
-import { useLang } from '@/shared/lib/localization/lang.context';
-import { useDialog } from '@/shared/ui/components/dialog';
 import { Typography } from '@/shared/ui/components/typography';
-import CreatePartyroomForm from './form.component';
+import useBeAHost from '../lib/use-be-a-host.hook';
 
 export default function PartyroomCreateCard() {
   const t = useI18n();
-  const lang = useLang();
-  const { openDialog, openConfirmDialog } = useDialog();
-  const isGuest = useIsGuest();
-  const informSocialType = useInformSocialType();
-
-  // 게스트(GT)만 차단. AM/FM 모두 파티룸 생성 가능 (backend PartyroomCreationPolicy = FM|AM).
-  // 지갑 연결 게이트는 제거 — 지갑 미연결 AM 도 생성 가능해야 하므로(지갑=FM 승급 경로는 별개).
-  const handleClickBeAHostBtn = async () => {
-    if (await isGuest()) {
-      informSocialType();
-      return;
-    }
-
-    openDialog((_, onCancel) => ({
-      title: t.createparty.title.create_party,
-      titleAlign: 'left',
-      showCloseIcon: true,
-      closeConfirm: () => {
-        const [title, content] = t.createparty.para.cancel_confirm.split('\n');
-        return openConfirmDialog({
-          title,
-          content,
-        });
-      },
-      classNames: {
-        container: lang === Language.Ko ? 'w-[800px]' : 'w-[900px]',
-      },
-      Body: () => <CreatePartyroomForm onSuccess={onCancel} />,
-    }));
-  };
+  const handleClickBeAHostBtn = useBeAHost();
 
   return (
     <button


### PR DESCRIPTION
## 개요

모바일 로비에 "Be a PFPlay Host" 방만들기 진입점이 없던 문제(#381) 해결. 파티룸 목록과 **같은 컨테이너(1열 카드 리스트) 안 맨 위**에 host CTA 카드를 노출(옵션 B). closes #381

## 변경

1. **`useBeAHost` hook 추출** (`features/partyroom/create/lib/`) — 데스크탑 카드의 `handleClickBeAHostBtn` 로직(게스트→소셜 로그인 유도 / 멤버→생성 다이얼로그)을 hook 으로 분리. 데스크탑 `PartyroomCreateCard` 가 이 hook 사용 (동작 0, 기존 테스트 GREEN).
2. **`MobilePartyroomCreateCard` 신규** (`features-mobile/partyroom/create/`) — 동일 hook 공유, 모바일 리스트 폼팩터(red 타이틀 + 부제 + plus, full-width 액션 카드).
3. **리스트 wiring** — `MobilePartyroomList` 맨 위 `<li>` 로 CTA. 열린 파티가 없어도 CTA 는 항상 노출(빈-상태 안내는 보존).

## 설계 결정

- **위치**: 리스트 맨 위 (이슈가 'CTA 미노출' → 발견성 최우선, 같은 컨테이너 안 = 옵션 B 잠금 결정)
- **게스트 노출**: 노출 + 클릭 시 소셜 로그인 유도(데스크탑 baseline 동등 = 전환 게이트)
- **DRY**: 핸들러를 데스크탑/모바일이 `useBeAHost` 로 공유 — 중복 0

## 검증

- 전체 `vitest run`: **281 files / 1537 passed + 1 todo, 0 failed**
- 데스크탑 create 카드 테스트 2/2 GREEN (hook 추출 후 동작 보존)
- 모바일 카드 신규 테스트 2/2 / typecheck 0 / lint 0 error
- 회귀 0 (hook 추출은 public API·testid·props 불변)

## 후속

- release/main ship = 사용자 게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)