### PR TITLE
fix(language): 첫 방문 언어 브라우저 언어 설정 동기화

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -95,6 +95,16 @@ describe('middleware', () => {
       expect(setCookieHeader).toContain('Secure');
     });
 
+    test(`${LANGUAGE_COOKIE_KEY} 쿠키 없음 + 브라우저 언어 ko → ${Language.Ko} 로 설정`, async () => {
+      const req = buildReq('http://localhost/parties', {
+        'accept-language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
+      });
+      const res = await middleware(req);
+
+      const setCookieHeader = res?.headers.get('set-cookie') ?? '';
+      expect(setCookieHeader).toContain(`${LANGUAGE_COOKIE_KEY}=${Language.Ko}`);
+    });
+
     test(`${LANGUAGE_COOKIE_KEY} 쿠키 있음 → 변경 안 함`, async () => {
       const req = buildReq('http://localhost/parties', {
         cookie: `${LANGUAGE_COOKIE_KEY}=${Language.Ko}`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,20 +28,21 @@ export const middleware = async (req: NextRequest) => {
   // 3) 언어 쿠키 default. NextResponse.next 호출 한 번으로 합쳐서 처리.
   //    기존 setCookieToRequestHeader helper 는 본 패턴에 흡수되어 불필요.
   const needsLanguageCookie = !req.cookies.get(LANGUAGE_COOKIE_KEY)?.value;
+  const language = getPreferredLanguage(req.headers.get('accept-language'));
   if (needsLanguageCookie) {
     // SSR 일관성: 현재 요청부터 새 쿠키를 본다 — req Cookie 헤더에도 합성
     const existingCookie = reqHeaders.get('cookie') ?? '';
     reqHeaders.set(
       'cookie',
       existingCookie
-        ? `${existingCookie}; ${LANGUAGE_COOKIE_KEY}=${Language.En}`
-        : `${LANGUAGE_COOKIE_KEY}=${Language.En}`
+        ? `${existingCookie}; ${LANGUAGE_COOKIE_KEY}=${language}`
+        : `${LANGUAGE_COOKIE_KEY}=${language}`
     );
   }
 
   const response = NextResponse.next({ request: { headers: reqHeaders } });
   if (needsLanguageCookie) {
-    response.cookies.set(LANGUAGE_COOKIE_KEY, Language.En, {
+    response.cookies.set(LANGUAGE_COOKIE_KEY, language, {
       path: '/',
       maxAge: TEN_YEARS,
       secure: true,
@@ -63,4 +64,31 @@ export const config = {
      */
     '/((?!maintenance|api|_next/static|_next/image|favicon.ico|images|icons).*)',
   ],
+};
+
+const getPreferredLanguage = (acceptLanguage: string | null): Language => {
+  const preferredLanguage = acceptLanguage
+    ?.split(',')
+    .map((part) => {
+      const [language = '', ...params] = part.trim().split(';');
+      const quality = params.find((param) => param.trim().startsWith('q='));
+
+      return {
+        language: language.toLowerCase(),
+        quality: quality ? Number(quality.trim().slice(2)) : 1,
+      };
+    })
+    .filter(({ language, quality }) => language && quality > 0)
+    .sort((a, b) => b.quality - a.quality)
+    .find(
+      ({ language }) =>
+        language === Language.Ko ||
+        language.startsWith(`${Language.Ko}-`) ||
+        language === Language.En ||
+        language.startsWith(`${Language.En}-`)
+    )?.language;
+
+  return preferredLanguage === Language.Ko || preferredLanguage?.startsWith(`${Language.Ko}-`)
+    ? Language.Ko
+    : Language.En;
 };


### PR DESCRIPTION
 ## 요약
  - 첫 방문 시 `lang` 쿠키 기본값을 브라우저 `Accept-Language` 기준으로 설정
  - 기존 `lang` 쿠키가 있으면 사용자 선택을 유지
  - middleware 테스트에 한국어 브라우저 언어 케이스 추가

  ## 테스트
  - `yarn test src/middleware.test.ts`
  - `yarn test:type`