### PR TITLE
feat(모바일): 신규 소셜 가입자 강제 프로필 온보딩 (#393)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-mobile-profile-onboarding.md
+++ b/docs/superpowers/plans/2026-06-05-mobile-profile-onboarding.md
@@ -1,0 +1,666 @@
+# 모바일 신규 소셜 가입자 강제 프로필 온보딩 — 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 모바일 신규 소셜 가입자(AM 준회원)가 강제 프로필 온보딩을 모바일에서 완료하고 `/parties`로 진입하게 만들어, 데드엔드 2겹(프로필·아바타 desktop-only 카드)을 해소한다.
+
+**Architecture:** 데스크탑 `ProfileEditFormV1`의 react-hook-form 로직을 공유 훅(`useEditProfileBioForm`)으로 추출(데스크탑 마크업 불변), 신규 모바일 폼이 동일 훅 + 모바일 레이아웃을 소비. `/settings/profile` 모바일 분기를 폼으로 교체. `settings/profile/layout.tsx`를 RSC로 전환해 `x-pf-device`를 읽고 client redirect-guard에 prop 전달 → 모바일 AM은 프로필 후 `/parties`(아바타 강제 단계 생략).
+
+**Tech Stack:** Next.js App Router(RSC + 'use client'), react-hook-form + zod, TanStack Query(useSuspenseFetchMe / useUpdateMyBio), vitest + @testing-library/react, Playwright(`--project=mobile`).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-mobile-profile-onboarding-design.md`
+
+---
+
+## File Structure
+
+| 파일                                                                                                       | 책임                                             | 동작                                    |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------- |
+| `src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts`                                           | 프로필 바이오 폼 로직(검증·submit·409) 단일 출처 | **신규**                                |
+| `src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts`                                      | 훅 단위 테스트                                   | **신규**                                |
+| `src/features/edit-profile-bio/ui/v1.component.tsx`                                                        | 데스크탑 프로필 폼(레이아웃)                     | **수정**(훅 소비, 마크업 불변)          |
+| `src/features/edit-profile-bio/index.ts`                                                                   | barrel                                           | **수정**(훅 export 추가)                |
+| `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`                                    | 모바일 프로필 폼(레이아웃)                       | **신규**                                |
+| `src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx`                               | 모바일 폼 테스트                                 | **신규**                                |
+| `src/features-mobile/profile/index.ts`                                                                     | barrel                                           | **신규**                                |
+| `src/app/settings/profile/page.tsx`                                                                        | device 분기 페이지                               | **수정**(모바일 분기 폼으로)            |
+| `src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx` | desktop-only 안내 카드                           | **수정**(`'profile-edit'` variant 제거) |
+| `src/app/settings/profile/profile-edit-redirect-guard.tsx`                                                 | me 기반 device-aware 리다이렉트                  | **신규**('use client')                  |
+| `src/app/settings/profile/profile-edit-redirect-guard.test.tsx`                                            | guard 5분기 테스트                               | **신규**                                |
+| `src/app/settings/profile/layout.tsx`                                                                      | device 읽어 guard에 전달                         | **수정**(RSC 전환)                      |
+| `e2e/mobile/profile-onboarding.spec.ts`                                                                    | 모바일 온보딩 happy-path                         | **신규**                                |
+
+빌드 환경 참고: 로컬 검증은 `npx next dev`(http+webpack), `yarn dev` 금지. e2e는 풀스택(backend docker :8080 + next dev :3000).
+
+---
+
+## Chunk 1: 공유 훅 + 데스크탑 무회귀
+
+### Task 1: `useEditProfileBioForm` 훅 추출
+
+**Files:**
+
+- Create: `src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts`
+- Test: `src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { useEditProfileBioForm } from './use-edit-profile-bio-form';
+
+const updateBioMock = vi.fn();
+vi.mock('../api/use-update-my-bio.mutation', () => ({
+  useUpdateMyBio: () => ({ mutate: updateBioMock, isPending: false }),
+}));
+vi.mock('@/entities/me', () => ({
+  useSuspenseFetchMe: () => ({ data: { nickname: 'olddata', introduction: 'hi' } }),
+}));
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    common: {
+      ec: { char_field_required: 'required', char_limit_12: 'max12', char_limit_50: 'max50' },
+    },
+    settings: { para: { nickname_taken: '이미 사용 중인 닉네임' } },
+  }),
+}));
+
+describe('useEditProfileBioForm', () => {
+  beforeEach(() => updateBioMock.mockReset());
+
+  test('onSubmit 시 me 기본값으로 updateBio 호출', async () => {
+    const { result } = renderHook(() => useEditProfileBioForm());
+    await act(async () => {
+      await result.current.onSubmit({ preventDefault: () => {} } as any);
+    });
+    expect(updateBioMock).toHaveBeenCalledTimes(1);
+    expect(updateBioMock.mock.calls[0][0]).toEqual({ nickname: 'olddata', introduction: 'hi' });
+  });
+
+  test('409 응답 시 nickname 에러 셋팅', async () => {
+    updateBioMock.mockImplementation((_values, opts) =>
+      opts.onError({ response: { data: { code: 409 } } })
+    );
+    const { result } = renderHook(() => useEditProfileBioForm());
+    await act(async () => {
+      await result.current.onSubmit({ preventDefault: () => {} } as any);
+    });
+    expect(result.current.errors.nickname?.message).toBe('이미 사용 중인 닉네임');
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn vitest run src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts`
+Expected: FAIL (모듈 없음)
+
+- [ ] **Step 3: 최소 구현**
+
+```ts
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSuspenseFetchMe } from '@/entities/me';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useUpdateMyBio } from '../api/use-update-my-bio.mutation';
+import * as Form from '../model/form.model';
+
+export const useEditProfileBioForm = () => {
+  const t = useI18n();
+  const { data: me } = useSuspenseFetchMe();
+  const { mutate: updateBio, isPending } = useUpdateMyBio();
+
+  const {
+    handleSubmit,
+    control,
+    setError,
+    formState: { errors, isValid },
+  } = useForm<Form.Model>({
+    mode: 'all',
+    resolver: zodResolver(Form.getSchema(t)),
+    defaultValues: {
+      nickname: me.nickname,
+      introduction: me.introduction,
+    },
+  });
+
+  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
+
+  const onSubmit = handleSubmit((values) => {
+    updateBio(values, {
+      onError: (err) => {
+        if (err.response?.data.code === 409) {
+          setError('nickname', { message: t.settings.para.nickname_taken });
+        }
+      },
+    });
+  });
+
+  return { control, onSubmit, errors, btnDisabled, isPending };
+};
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn vitest run src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts
+git commit -m "feat(edit-profile-bio): 프로필 바이오 폼 로직 공유 훅 추출 (#393)"
+```
+
+### Task 2: 데스크탑 V1을 훅 소비로 리팩터 (마크업 불변)
+
+**Files:**
+
+- Modify: `src/features/edit-profile-bio/ui/v1.component.tsx`
+- Modify: `src/features/edit-profile-bio/index.ts` (훅 barrel export 추가)
+
+- [ ] **Step 1: V1 리팩터** — `useForm`/`handleFormSubmit`/`btnDisabled` 로컬 정의를 제거하고 `const { control, onSubmit, errors, btnDisabled, isPending } = useEditProfileBioForm();` 로 대체. `<form onSubmit={handleSubmit(handleFormSubmit)}>` → `<form onSubmit={onSubmit}>`. **두 `Controller`, 두 `FormItem`, `Input`/`TextArea` props, `Button`(variant/size/className/disabled/loading), 모든 className·`data-*` 100% 그대로.** 제거되는 import: `useForm`, `SubmitHandler`, `zodResolver`, `useSuspenseFetchMe`, `useUpdateMyBio`, `Form`. 추가 import: `useEditProfileBioForm`.
+
+- [ ] **Step 2: barrel export** — `src/features/edit-profile-bio/index.ts` 에 `export { useEditProfileBioForm } from './lib/use-edit-profile-bio-form';` 추가.
+
+- [ ] **Step 3: 회귀 게이트** — V1 컴포넌트 단위 테스트는 본래 없음. 회귀 가드 = 타입체크 + 기존 form.model/integration 테스트 + 마크업 무변경.
+
+Run:
+
+```bash
+yarn vitest run src/features/edit-profile-bio
+npx tsc --noEmit
+```
+
+Expected: 기존 테스트 PASS, tsc 0 error
+
+- [ ] **Step 4: 마크업 불변 확인** — `git diff src/features/edit-profile-bio/ui/v1.component.tsx` 로 JSX(`return (...)`) 영역에 className/구조 변경이 없는지 육안 확인(로직 라인만 변경돼야 함).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/features/edit-profile-bio/ui/v1.component.tsx src/features/edit-profile-bio/index.ts
+git commit -m "refactor(edit-profile-bio): 데스크탑 V1을 공유 훅 소비로 전환 (마크업 불변, #393)"
+```
+
+---
+
+## Chunk 2: 모바일 폼 + 페이지 와이어링
+
+### Task 3: 모바일 프로필 폼 컴포넌트
+
+**Files:**
+
+- Create: `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`
+- Create: `src/features-mobile/profile/index.ts`
+- Test: `src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성** (#390 mobile card 테스트 패턴 — 공유 훅 mock)
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import MobileProfileEditForm from './mobile-profile-edit-form.component';
+
+const onSubmitMock = vi.fn((e) => e?.preventDefault?.());
+vi.mock('@/features/edit-profile-bio', () => ({
+  useEditProfileBioForm: () => ({
+    control: { register: () => ({}), _formState: {}, _options: {} } as any,
+    onSubmit: onSubmitMock,
+    errors: {},
+    btnDisabled: false,
+    isPending: false,
+  }),
+}));
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    settings: { title: { nickname: '닉네임', introduction: '소개', who_r_u: 'Who R U' } },
+    common: { ec: { char_limit_12: '12자', char_limit_50: '50자' } },
+  }),
+}));
+// react-hook-form Controller 는 control 의존 — render 가 깨지면 Controller 를 얕게 mock
+vi.mock('react-hook-form', async (orig) => {
+  const actual = await (orig as any)();
+  return {
+    ...actual,
+    Controller: ({ render }: any) =>
+      render({ field: { value: '', onChange: () => {}, name: '', ref: () => {} } }),
+  };
+});
+
+describe('MobileProfileEditForm', () => {
+  beforeEach(() => onSubmitMock.mockClear());
+
+  test('닉네임·소개 필드 + CTA 렌더', () => {
+    render(<MobileProfileEditForm />);
+    expect(screen.getByText('닉네임')).toBeInTheDocument();
+    expect(screen.getByText('소개')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-profile-submit')).toBeInTheDocument();
+  });
+
+  test('제출 시 onSubmit 호출', () => {
+    render(<MobileProfileEditForm />);
+    fireEvent.submit(screen.getByTestId('mobile-profile-form'));
+    expect(onSubmitMock).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn vitest run src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx`
+Expected: FAIL (모듈 없음)
+
+- [ ] **Step 3: 최소 구현**
+
+```tsx
+'use client';
+
+import { Controller } from 'react-hook-form';
+import { useEditProfileBioForm } from '@/features/edit-profile-bio';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import { FormItem } from '@/shared/ui/components/form-item';
+import { Input } from '@/shared/ui/components/input';
+import { TextArea } from '@/shared/ui/components/textarea';
+
+const MobileProfileEditForm = () => {
+  const t = useI18n();
+  const { control, onSubmit, errors, btnDisabled, isPending } = useEditProfileBioForm();
+
+  return (
+    <form
+      data-testid='mobile-profile-form'
+      onSubmit={onSubmit}
+      className='flexCol gap-10 w-full px-app pt-6 pb-10'
+    >
+      <div className='flexCol gap-8 w-full'>
+        <Controller
+          control={control}
+          name='nickname'
+          render={({ field }) => (
+            <FormItem
+              label={t.settings.title.nickname}
+              error={errors.nickname?.message}
+              required
+              classNames={{ label: 'text-gray-200' }}
+            >
+              <Input
+                {...field}
+                maxLength={16}
+                placeholder={t.common.ec.char_limit_12}
+                classNames={{ container: 'w-full' }}
+              />
+            </FormItem>
+          )}
+        />
+        <Controller
+          control={control}
+          name='introduction'
+          render={({ field }) => (
+            <FormItem
+              label={t.settings.title.introduction}
+              error={errors.introduction?.message}
+              classNames={{ label: 'text-gray-200' }}
+            >
+              <TextArea
+                {...field}
+                maxLength={50}
+                rows={3}
+                placeholder={t.common.ec.char_limit_50}
+                classNames={{ container: 'w-full' }}
+              />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <Button
+        type='submit'
+        data-testid='mobile-profile-submit'
+        variant={btnDisabled ? 'outline' : 'fill'}
+        size='xl'
+        className='w-full'
+        disabled={btnDisabled}
+        loading={isPending}
+      >
+        Let&apos;s get in
+      </Button>
+    </form>
+  );
+};
+
+export default MobileProfileEditForm;
+```
+
+barrel `src/features-mobile/profile/index.ts`:
+
+```ts
+export { default as MobileProfileEditForm } from './ui/mobile-profile-edit-form.component';
+```
+
+> 구현 주의: `Input`/`TextArea`/`Button`/`FormItem` 의 실제 prop 시그니처를 해당 컴포넌트에서 확인 후 맞출 것(`classNames` 키, `data-testid` 전달 가능 여부). `Button` 이 `data-testid` 를 통과시키지 않으면 wrapper 또는 `data-testid` 지원 prop 사용. 데스크탑 V1 의 동일 props 를 baseline 으로 참조([[feedback_mobile_widget_baseline_reflex]]).
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn vitest run src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/features-mobile/profile/
+git commit -m "feat(모바일): 프로필 편집 폼 컴포넌트 (MobileProfileEditForm, #393)"
+```
+
+### Task 4: 페이지 모바일 분기 + 데드코드 variant 제거
+
+**Files:**
+
+- Modify: `src/app/settings/profile/page.tsx`
+- Modify: `src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx`
+
+- [ ] **Step 1: 사전 grep** — `'profile-edit'` 참조처 확인.
+
+Run: `git grep -n "feature='profile-edit'\|profile-edit" src`
+Expected: `settings/profile/page.tsx` 만(곧 교체). 그 외 참조 없으면 variant 제거 안전.
+
+- [ ] **Step 2: page.tsx 모바일 분기 교체**
+
+```tsx
+import { headers } from 'next/headers';
+import { MobileProfileEditForm } from '@/features-mobile/profile';
+import { ProfileEditFormV1 } from '@/features/edit-profile-bio';
+import { getServerDictionary } from '@/shared/lib/localization/get-server-dictionary';
+import { BackButton } from '@/shared/ui/components/back-button';
+
+const ProfileSettingsPage = async () => {
+  const isMobile = headers().get('x-pf-device') === 'mobile';
+  const t = await getServerDictionary();
+
+  if (isMobile) {
+    return (
+      <div className='flexCol w-full pt-app-header'>
+        <h1 className='px-app text-h2 text-white'>{t.settings.title.who_r_u}</h1>
+        <MobileProfileEditForm />
+      </div>
+    );
+  }
+
+  return (
+    <div className='absolute-user-form-section flexColCenter py-10 px-[60px]'>
+      <BackButton text={t.settings.title.who_r_u} className='absolute self-start top-10' />
+      <ProfileEditFormV1 />
+    </div>
+  );
+};
+
+export default ProfileSettingsPage;
+```
+
+> 주의: `pt-app-header`/`text-h2` 등 유틸 클래스가 실제 tailwind config 에 존재하는지 확인, 없으면 기존 모바일 페이지(`MobileLobby` 등)에서 쓰는 헤더 오프셋/타이포 클래스로 맞출 것. `MobileOnlyDesktopFeatureCard` import 는 제거.
+
+- [ ] **Step 3: `'profile-edit'` variant 제거** — `mobile-only-desktop-feature-card.component.tsx` 의 `MobileOnlyDesktopFeature` 유니온에서 `| 'profile-edit'` 제거, `featureLabel` 맵에서 `'profile-edit': '프로필 편집',` 라인 제거. `'avatar-edit'`, `'withdraw'` 유지.
+
+- [ ] **Step 4: 타입체크 + 카드 테스트**
+
+Run:
+
+```bash
+npx tsc --noEmit
+yarn vitest run src/shared/ui/components/mobile-only-desktop-feature-card
+```
+
+Expected: tsc 0 error(`profile-edit` 미참조 확인), 카드 테스트 PASS(있으면)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/app/settings/profile/page.tsx src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx
+git commit -m "feat(모바일): /settings/profile 모바일 분기를 온보딩 폼으로 교체 + profile-edit 안내 variant 제거 (#393)"
+```
+
+---
+
+## Chunk 3: 데드엔드 #2 fix — device-aware 리다이렉트
+
+### Task 5: redirect-guard (5분기)
+
+**Files:**
+
+- Create: `src/app/settings/profile/profile-edit-redirect-guard.tsx`
+- Test: `src/app/settings/profile/profile-edit-redirect-guard.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성** (5분기)
+
+```tsx
+import { render } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import ProfileEditRedirectGuard from './profile-edit-redirect-guard';
+
+const replaceMock = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ replace: replaceMock }) }));
+
+let meValue: any;
+vi.mock('@/entities/me', () => ({ useSuspenseFetchMe: () => ({ data: meValue }) }));
+
+const renderGuard = (device: 'mobile' | 'desktop') =>
+  render(
+    <ProfileEditRedirectGuard device={device}>
+      <div>child</div>
+    </ProfileEditRedirectGuard>
+  );
+
+describe('ProfileEditRedirectGuard', () => {
+  beforeEach(() => replaceMock.mockReset());
+
+  test('GT → /', () => {
+    meValue = { authorityTier: AuthorityTier.GT, profileUpdated: true };
+    renderGuard('mobile');
+    expect(replaceMock).toHaveBeenCalledWith('/');
+  });
+
+  test('profileUpdated=false → 리다이렉트 없음(폼 노출)', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: false };
+    renderGuard('mobile');
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('FM + profileUpdated → /parties', () => {
+    meValue = { authorityTier: AuthorityTier.FM, profileUpdated: true };
+    renderGuard('desktop');
+    expect(replaceMock).toHaveBeenCalledWith('/parties');
+  });
+
+  test('AM + desktop + profileUpdated → /settings/avatar', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: true };
+    renderGuard('desktop');
+    expect(replaceMock).toHaveBeenCalledWith('/settings/avatar');
+  });
+
+  test('AM + mobile + profileUpdated → /parties (아바타 강제 단계 생략)', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: true };
+    renderGuard('mobile');
+    expect(replaceMock).toHaveBeenCalledWith('/parties');
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn vitest run src/app/settings/profile/profile-edit-redirect-guard.test.tsx`
+Expected: FAIL (모듈 없음)
+
+- [ ] **Step 3: 최소 구현**
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { PropsWithChildren, useEffect } from 'react';
+import { useSuspenseFetchMe } from '@/entities/me';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+
+type Props = PropsWithChildren<{ device: 'mobile' | 'desktop' }>;
+
+const ProfileEditRedirectGuard = ({ device, children }: Props) => {
+  const { data: me } = useSuspenseFetchMe();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (me.authorityTier === AuthorityTier.GT) {
+      router.replace('/');
+      return;
+    }
+
+    if (me.profileUpdated) {
+      if (me.authorityTier === AuthorityTier.AM) {
+        router.replace(device === 'mobile' ? '/parties' : '/settings/avatar');
+      }
+      if (me.authorityTier === AuthorityTier.FM) {
+        router.replace('/parties');
+      }
+    }
+  }, [me, device, router]);
+
+  return <>{children}</>;
+};
+
+export default ProfileEditRedirectGuard;
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn vitest run src/app/settings/profile/profile-edit-redirect-guard.test.tsx`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/app/settings/profile/profile-edit-redirect-guard.tsx src/app/settings/profile/profile-edit-redirect-guard.test.tsx
+git commit -m "feat(settings): device-aware 프로필 리다이렉트 guard — 모바일 AM은 /parties (#393)"
+```
+
+### Task 6: layout.tsx RSC 전환
+
+**Files:**
+
+- Modify: `src/app/settings/profile/layout.tsx`
+
+- [ ] **Step 1: RSC로 교체**
+
+```tsx
+import { headers } from 'next/headers';
+import { PropsWithChildren } from 'react';
+import ProfileEditRedirectGuard from './profile-edit-redirect-guard';
+
+const ProfileEditLayout = ({ children }: PropsWithChildren) => {
+  const device = headers().get('x-pf-device') === 'mobile' ? 'mobile' : 'desktop';
+
+  return <ProfileEditRedirectGuard device={device}>{children}</ProfileEditRedirectGuard>;
+};
+
+export default ProfileEditLayout;
+```
+
+('use client' 제거, `useSuspenseFetchMe`/`useRouter`/`useEffect`/`AuthorityTier` import 제거 — 모두 guard 로 이전됨.)
+
+- [ ] **Step 2: 타입체크 + 관련 테스트**
+
+Run:
+
+```bash
+npx tsc --noEmit
+yarn vitest run src/app/settings/profile
+```
+
+Expected: tsc 0 error, guard 테스트 PASS
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/settings/profile/layout.tsx
+git commit -m "refactor(settings): 프로필 layout RSC 전환 — x-pf-device 읽어 guard 전달 (#393)"
+```
+
+---
+
+## Chunk 4: e2e + 전체 품질 게이트
+
+### Task 7: 모바일 온보딩 e2e (happy-path)
+
+**Files:**
+
+- Create: `e2e/mobile/profile-onboarding.spec.ts`
+
+- [ ] **Step 1: spec 작성** — 기존 `e2e/mobile/*.spec.ts`(host-cta·playlist-management) 의 셋업/픽스처/로그인 헬퍼를 참조해 동일 패턴으로 작성. 시나리오:
+
+  1. profileUpdated=false 인 신규 AM 상태로 진입(기존 e2e 의 신규 가입/시드 헬퍼 재사용; 없으면 가장 가까운 로그인 헬퍼 + 백엔드 시드).
+  2. `/settings/profile` 로 강제 이동돼 **모바일 폼(닉네임 input + `mobile-profile-submit`)이 노출**되는지(폴백 카드 "데스크탑에서 사용 가능"이 **아님**) 확인.
+  3. 닉네임 입력 → 제출.
+  4. **`/parties` 로 착지**(아바타 desktop-only 카드를 거치지 않음) 확인 = 데드엔드 2겹 해소 실증.
+
+  로케일 독립 `data-testid` 셀렉터 사용([[reference_pfplay_web_local_e2e_run]]). 로케일 텍스트 단언 회피.
+
+- [ ] **Step 2: 로컬 풀스택 e2e 실행** ([[reference_pfplay_web_local_e2e_run]], [[reference_pfplay_web_local_dev_http_webpack]])
+
+```bash
+# 터미널 A: backend docker :8080 (로컬 compose)
+# 터미널 B: npx next dev  (http :3000)
+E2E_BASE_URL=http://localhost:3000 E2E_API_BASE=http://localhost:8080 \
+  npx playwright test e2e/mobile/profile-onboarding.spec.ts --project=mobile
+```
+
+Expected: PASS. cold-start IFrame/boundingBox flake 시 warm 재실행. 기존 mobile spec 들도 함께 그린 확인.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add e2e/mobile/profile-onboarding.spec.ts
+git commit -m "test(e2e): 모바일 신규 AM 프로필 온보딩 → /parties happy-path (#393)"
+```
+
+### Task 8: 전체 품질 게이트
+
+- [ ] **Step 1: 전체 단위 테스트**
+
+Run: `yarn vitest run`
+Expected: 전체 GREEN (신규 테스트 포함, 회귀 0)
+
+- [ ] **Step 2: 타입체크 + lint**
+
+Run:
+
+```bash
+npx tsc --noEmit
+yarn lint
+```
+
+Expected: tsc 0 error, lint 0 error(기존 baseline warning 외)
+
+- [ ] **Step 3: i18n drift 점검** — 신규 키 추가했다면 ko/en json 직접 동기화 확인([[feedback_pfplay_web_i18n_drift]]). 본 계획은 신규 키 없음(재사용만) 전제.
+
+- [ ] **Step 4: 코드 리뷰** — superpowers:requesting-code-review (fresh-eyes 서브에이전트)로 변경 전체 리뷰, must-fix 반영.
+
+- [ ] **Step 5: push + PR**
+
+```bash
+git push -u origin feature/mobile-profile-onboarding-393
+gh pr create --title "feat(모바일): 신규 소셜 가입자 강제 프로필 온보딩 (#393)" --body "..."  # closes #393, 데드엔드 2겹 해소 요약 + 로컬 e2e 결과
+```
+
+dev 머지 = 사용자 게이트.
+
+---
+
+## 회귀/위험 체크리스트
+
+- [ ] 데스크탑 V1 마크업 `git diff` 무변경(로직 라인만)
+- [ ] `'profile-edit'` variant 제거 후 tsc 통과(미참조 확인됨)
+- [ ] layout RSC 전환 후 `/settings/profile` 데스크탑/모바일 양쪽 정상(폼 노출 + 제출 후 올바른 리다이렉트)
+- [ ] 모바일 폼 공통 컴포넌트 props 시그니처 실제와 일치(`classNames` 키, `data-testid` 통과)
+- [ ] 로컬 e2e 신규 1 + 기존 mobile spec 그린

--- a/docs/superpowers/plans/2026-06-05-mobile-profile-onboarding.md
+++ b/docs/superpowers/plans/2026-06-05-mobile-profile-onboarding.md
@@ -376,6 +376,7 @@ import { MobileProfileEditForm } from '@/features-mobile/profile';
 import { ProfileEditFormV1 } from '@/features/edit-profile-bio';
 import { getServerDictionary } from '@/shared/lib/localization/get-server-dictionary';
 import { BackButton } from '@/shared/ui/components/back-button';
+import { Typography } from '@/shared/ui/components/typography';
 
 const ProfileSettingsPage = async () => {
   const isMobile = headers().get('x-pf-device') === 'mobile';
@@ -383,8 +384,10 @@ const ProfileSettingsPage = async () => {
 
   if (isMobile) {
     return (
-      <div className='flexCol w-full pt-app-header'>
-        <h1 className='px-app text-h2 text-white'>{t.settings.title.who_r_u}</h1>
+      <div className='flexCol w-full min-h-screen pt-[var(--header-height)]'>
+        <Typography type='title2' as='h1' className='text-white px-app pt-6'>
+          {t.settings.title.who_r_u}
+        </Typography>
         <MobileProfileEditForm />
       </div>
     );
@@ -401,7 +404,7 @@ const ProfileSettingsPage = async () => {
 export default ProfileSettingsPage;
 ```
 
-> 주의: `pt-app-header`/`text-h2` 등 유틸 클래스가 실제 tailwind config 에 존재하는지 확인, 없으면 기존 모바일 페이지(`MobileLobby` 등)에서 쓰는 헤더 오프셋/타이포 클래스로 맞출 것. `MobileOnlyDesktopFeatureCard` import 는 제거.
+> 실측 검증 완료(2026-06-05): `Typography`(`type='title2'`)·`px-app`·CSS 변수 `--header-height`(글로벌 `Header` 가 `h-[var(--header-height)]` 로 사용) 모두 실존. **`pt-app-header`/`text-h2` 는 미존재 클래스라 사용 금지**(리뷰어 지적, silent no-op). 수평 패딩은 폼(`MobileProfileEditForm`)이 자체 `px-app` 으로 처리하므로 페이지 컨테이너엔 중복 부여 금지(제목만 `px-app`). `settings/layout.tsx` 가 글로벌 `<Header/>`(fixed)+`<main>` 으로 감싸므로 본 분기는 추가 `<main>` 없이 헤더 오프셋만. `MobileOnlyDesktopFeatureCard` import 는 제거.
 
 - [ ] **Step 3: `'profile-edit'` variant 제거** — `mobile-only-desktop-feature-card.component.tsx` 의 `MobileOnlyDesktopFeature` 유니온에서 `| 'profile-edit'` 제거, `featureLabel` 맵에서 `'profile-edit': '프로필 편집',` 라인 제거. `'avatar-edit'`, `'withdraw'` 유지.
 
@@ -597,14 +600,47 @@ git commit -m "refactor(settings): 프로필 layout RSC 전환 — x-pf-device �
 
 - Create: `e2e/mobile/profile-onboarding.spec.ts`
 
-- [ ] **Step 1: spec 작성** — 기존 `e2e/mobile/*.spec.ts`(host-cta·playlist-management) 의 셋업/픽스처/로그인 헬퍼를 참조해 동일 패턴으로 작성. 시나리오:
+- [ ] **Step 1: spec 작성**
 
-  1. profileUpdated=false 인 신규 AM 상태로 진입(기존 e2e 의 신규 가입/시드 헬퍼 재사용; 없으면 가장 가까운 로그인 헬퍼 + 백엔드 시드).
-  2. `/settings/profile` 로 강제 이동돼 **모바일 폼(닉네임 input + `mobile-profile-submit`)이 노출**되는지(폴백 카드 "데스크탑에서 사용 가능"이 **아님**) 확인.
-  3. 닉네임 입력 → 제출.
-  4. **`/parties` 로 착지**(아바타 desktop-only 카드를 거치지 않음) 확인 = 데드엔드 2겹 해소 실증.
+  ⚠️ **캐시 auth 픽스처 사용 금지**(리뷰어 지적): `e2e/fixtures/auth.fixtures.ts` 의 `user1Context` 등은 **FM + profileUpdated=true** storageState 라, 신규 guard 가 FM→/parties 로 **즉시 리다이렉트**해 폼이 렌더되지 않는다. 본 테스트는 **fresh 컨텍스트 + associate(AM) dev 로그인**으로 `profileUpdated=false` AM 을 만들어야 한다.
 
-  로케일 독립 `data-testid` 셀렉터 사용([[reference_pfplay_web_local_e2e_run]]). 로케일 텍스트 단언 회피.
+  로그인 동선(실측): sign-in 페이지 → `[data-testid="dev-sign-in-button"]` 클릭 → 다이얼로그 `[data-testid="dialog-panel"]` → `[data-testid="dev-sign-in-associate"]` 클릭(= `temporary_SignInAssociateCrew()` = AM 생성). 이후 `Me.serviceEntry`(profileUpdated=false) 가 `/settings/profile` 로 push. (`e2e/auth/shared.ts` 의 full 버전 패턴을 associate testid 로 차용.)
+
+  spec 골격:
+
+  ```ts
+  import { test, expect } from '@playwright/test';
+
+  // 캐시 storageState 무시 — fresh 컨텍스트로 신규 AM 로그인
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('모바일 신규 AM: 강제 프로필 온보딩 → /parties (데드엔드 2겹 해소)', async ({ page }) => {
+    await page.goto('/sign-in');
+    await page.locator('[data-testid="dev-sign-in-button"]').click({ force: true });
+    const dialog = page
+      .locator('[data-testid="dialog-panel"]')
+      .filter({ has: page.locator('[data-testid="dev-sign-in-associate"]') })
+      .first();
+    await expect(dialog).toBeVisible();
+    await dialog.locator('[data-testid="dev-sign-in-associate"]').click({ force: true });
+
+    // 데드엔드 #1 해소: /settings/profile 모바일 폼 노출 (폴백 카드 아님)
+    await expect(page).toHaveURL(/\/settings\/profile/);
+    await expect(page.locator('[data-testid="mobile-profile-form"]')).toBeVisible();
+
+    // 닉네임 입력 → 제출
+    const unique = `am${Date.now() % 100000}`;
+    await page.locator('[data-testid="mobile-profile-form"] input').first().fill(unique);
+    await page.locator('[data-testid="mobile-profile-submit"]').click();
+
+    // 데드엔드 #2 해소: 아바타 desktop-only 카드 거치지 않고 /parties 착지
+    await expect(page).toHaveURL(/\/parties/);
+  });
+  ```
+
+  로케일 독립 `data-testid` 셀렉터만 사용([[reference_pfplay_web_local_e2e_run]]). 로케일 텍스트 단언 회피.
+
+  ⚠️ **실행 시 확인할 백엔드 동작**: `temporary_SignInAssociateCrew()` 가 호출마다 **fresh `profileUpdated=false` AM** 을 주는지(아니면 재사용 계정이라 이미 profileUpdated=true 일 수 있음). 후자면 즉시 리다이렉트로 실패하므로, 로컬 backend 의 associate dev-signin 시드 동작을 먼저 확인하고 필요 시 DB cleanup 으로 보정. STEP_TIMEOUT(cold-start) 고려해 `--project=mobile` warm 재실행 허용.
 
 - [ ] **Step 2: 로컬 풀스택 e2e 실행** ([[reference_pfplay_web_local_e2e_run]], [[reference_pfplay_web_local_dev_http_webpack]])
 

--- a/docs/superpowers/specs/2026-06-05-mobile-profile-onboarding-design.md
+++ b/docs/superpowers/specs/2026-06-05-mobile-profile-onboarding-design.md
@@ -1,0 +1,137 @@
+# 모바일 신규 소셜 가입자 강제 프로필 온보딩 — 설계
+
+- 이슈: [pfplay-web#393](https://github.com/pfplay/pfplay-web/issues/393)
+- 날짜: 2026-06-05
+- 스코프 상위 맥락: 모바일 반응형 개편(이슈 #340) 후속. 전환 깔때기 누수 차단.
+
+## 1. 배경 / 문제
+
+모바일에서 신규 소셜 가입자(지갑인증 X = **AM 준회원**, `AuthorityTier.AM`)가 가입 직후 **강제 리다이렉트 2겹에 모두 막다른 길**로 빠져 이탈한다.
+
+```
+신규 AM 모바일 가입
+  → parties/layout.tsx: me.profileUpdated === false → router.replace('/settings/profile')
+      → settings/profile/page.tsx 모바일 분기: <MobileOnlyDesktopFeatureCard feature='profile-edit'/>  ❌ 데드엔드 #1
+  → (프로필 설정 가정) settings/profile/layout.tsx: AM → router.replace('/settings/avatar')
+      → settings/avatar/page.tsx 모바일 분기: <MobileOnlyDesktopFeatureCard feature='avatar-edit'/>  ❌ 데드엔드 #2
+```
+
+`parties/layout.tsx` 는 `profileUpdated` 가 true 가 될 때까지 `null` 을 렌더하므로, 모바일 신규 회원은 **프로필 설정도 못 하고 어떤 파티에도 진입하지 못한다.** 게스트(GT)는 `profileUpdated=true`/좀비 안전망으로 면제되어 맛보기 깔때기는 작동하지만, 갓 가입한 소셜 회원은 벽에 부딪힌다.
+
+근거(실측, 2026-06-05):
+
+- `src/app/parties/layout.tsx:35` — `if (me && !me.profileUpdated) router.replace('/settings/profile')`, `:42` — `!me.profileUpdated` 면 `null` 렌더
+- `src/app/settings/profile/page.tsx:8-9` — 모바일이면 `MobileOnlyDesktopFeatureCard feature='profile-edit'`
+- `src/app/settings/profile/layout.tsx:21-28` — `profileUpdated && AM → /settings/avatar`, `FM → /parties`, `GT → /`
+- `src/app/settings/avatar/page.tsx:6-7` — 모바일이면 `MobileOnlyDesktopFeatureCard feature='avatar-edit'`
+- `src/shared/api/http/types/@enums.ts:144-146` — `FM=Full Crew(지갑인증)`, `AM=Associate Crew(지갑인증 X)`, `GT=Guest`
+
+## 2. 기획 결정 (잠금)
+
+- **프로필만 강제.** 모바일 프로필 편집 화면을 신규 구현한다.
+- **아바타는 서버가 자동 셋팅.** 모바일에서 아바타 강제 단계는 불필요하다. 모바일 아바타 '편집' 클릭 시 "데스크탑에서만 가능" 안내(`MobileOnlyDesktopFeatureCard feature='avatar-edit'`)는 **의도된 동작으로 유지**(합의된 타협) — 작업 없음.
+- **모바일 AM은 프로필 완료 후 아바타 강제 단계를 건너뛰고 `/parties`로** 간다. 데스크탑 AM 은 기존대로 `/settings/avatar` 유지.
+
+## 3. 작업 범위
+
+1. **모바일 프로필 편집 화면** — `/settings/profile` 모바일 분기를 폴백 카드 → 반응형 강제 온보딩 폼(닉네임 + 소개 → "Let's get in")으로 교체.
+2. **데드엔드 #2 fix** — `settings/profile/layout.tsx` 에서 **모바일 AM → `/parties`** (데스크탑 AM 불변).
+3. **아바타** — 작업 없음(의도된 데스크탑 전용 안내 유지).
+
+### 범위 밖 (명시)
+
+- 기존 회원의 모바일 프로필 재편집(데스크탑은 사이드바 `ProfileEditFormV2` 전용 — 모바일 사이드바 없음). 후속 과제.
+- 모바일 아바타 편집 화면.
+- 데스크탑 AM → `/settings/avatar` 동작 변경.
+
+## 4. 접근법 (선택: A)
+
+데스크탑 `ProfileEditFormV1`(`src/features/edit-profile-bio/ui/v1.component.tsx`)은 고정폭(`w-[550px]`)+absolute 버튼이라 모바일에 직접 못 쓴다.
+
+**A. 공유 훅 추출 + 모바일 전용 레이아웃** (채택) — `ProfileEditFormV1` 의 react-hook-form 로직을 훅으로 추출, 데스크탑 V1 은 레이아웃 불변으로 그 훅을 소비하고, 신규 모바일 폼이 동일 훅 + 모바일 레이아웃을 소비. PR #390 `useBeAHost`(데스크탑/모바일 공유 훅 + 폼팩터별 레이아웃)와 동일 패턴. 데스크탑 픽셀/테스트 불변, DRY.
+
+- B(V1 in-place 반응형 개조): 한 파일에 두 폼팩터 혼입 + 데스크탑 회귀 위험 → 기각.
+- C(데이터층만 재사용, 폼 로직 별도): 폼 로직 중복(DRY 위반) → 기각.
+
+device-aware 리다이렉트 fix는 클라이언트 layout 이 `x-pf-device`(서버 전용 request 헤더)를 직접 못 읽으므로, **`settings/profile/layout.tsx`를 얇은 RSC로 전환**해 `headers()`로 device 를 읽고 client redirect-guard 에 prop 으로 전달한다(기존 "RSC page.tsx가 headers 읽고 분기" 컨벤션과 일치). 대안(middleware 가 device 쿠키 주입)은 전역 신규 메커니즘이라 YAGNI 기각.
+
+## 5. 컴포넌트 / 파일 설계
+
+### 5.1 공유 훅 추출 (데스크탑 무회귀)
+
+- **신규** `src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts`
+  - 내부: `useI18n()`, `useSuspenseFetchMe()`, `useUpdateMyBio()`
+  - `useForm<Form.Model>({ mode: 'all', resolver: zodResolver(Form.getSchema(t)), defaultValues: { nickname: me.nickname, introduction: me.introduction } })`
+  - `handleFormSubmit`: `updateBio(values, { onError: 409 → setError('nickname', nickname_taken) })`
+  - 반환: `{ control, handleSubmit, onSubmit: handleFormSubmit, errors, btnDisabled, isPending }`
+  - `btnDisabled = Object.keys(errors).length > 0 || !isValid`
+- **수정** `src/features/edit-profile-bio/ui/v1.component.tsx`
+  - 위 훅을 소비하도록 리팩터. **JSX 마크업·className·`data-*`·버튼 배치 100% 불변.** 동작/픽셀/기존 테스트 동일.
+
+### 5.2 모바일 폼 (신규)
+
+- **신규** `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`
+  - `useEditProfileBioForm()` 소비.
+  - 레이아웃: 세로 스택. `FormItem`(닉네임, 필수, `Input maxLength=16`) + `FormItem`(소개, `TextArea maxLength=50 rows=3`) **full-width**(`w-full`, 모바일 `px-app` 패딩). 하단 full-width "Let's get in" `Button`(`btnDisabled`/`isPending` 바인딩). 데스크탑의 absolute 배치 대신 일반 흐름 하단 고정.
+  - 재사용 공통 컴포넌트: `FormItem`, `Input`, `TextArea`, `Button` (`@/shared/ui/components/*`).
+- **신규** `src/features-mobile/profile/index.ts` — barrel export.
+
+### 5.3 페이지 와이어링
+
+- **수정** `src/app/settings/profile/page.tsx`
+  - 모바일 분기: `MobileOnlyDesktopFeatureCard feature='profile-edit'` → 모바일 컨테이너(제목 `t.settings.title.who_r_u` 헤딩 + `<MobileProfileEditForm/>`). 데스크탑 분기 불변.
+- **수정** `src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx`
+  - `'profile-edit'` variant + 라벨 제거(데드코드 회피). `'avatar-edit'`, `'withdraw'` 유지.
+
+### 5.4 데드엔드 #2 fix (device-aware AM)
+
+- **수정** `src/app/settings/profile/layout.tsx` — 얇은 **RSC**로 전환. `const device = headers().get('x-pf-device') === 'mobile' ? 'mobile' : 'desktop'`. `<ProfileEditRedirectGuard device={device}>{children}</ProfileEditRedirectGuard>` 렌더. (Server Component 이므로 `useSuspenseFetchMe`/`useRouter` 제거.)
+- **신규** `src/app/settings/profile/profile-edit-redirect-guard.tsx` ('use client') — `device: 'mobile'|'desktop'` prop 수신. 기존 me 기반 리다이렉트 이전:
+  - `GT` → `/` (불변)
+  - `profileUpdated && FM` → `/parties` (불변)
+  - `profileUpdated && AM` → **`device === 'mobile' ? '/parties' : '/settings/avatar'`** (유일한 신규 분기)
+  - `profileUpdated === false` → 리다이렉트 없음(폼 노출)
+
+## 6. 데이터 흐름
+
+```
+me(useSuspenseFetchMe) → nickname/introduction defaultValues + authorityTier
+  → 모바일 폼 제출 → useUpdateMyBio PATCH bio
+      → onSuccess: invalidate [Me] + track('Bio Updated')
+          → me refetch → profileUpdated=true
+              → settings/profile/layout guard: AM && mobile → router.replace('/parties')
+```
+
+신규 mutation/엔드포인트 0. redirect-in(`parties/layout`)·redirect-out(guard) 모두 기존 메커니즘 재사용.
+
+## 7. 에러 처리
+
+- 닉네임 중복 `409` → `setError('nickname', t.settings.para.nickname_taken)` (공유 훅, 데스크탑 동일)
+- zod 검증 실패 → `FormItem` 인라인 에러
+- 그 외 mutation 에러 → 기존 동작 유지(별도 처리 없음 — 데스크탑과 동일 수준)
+
+## 8. i18n
+
+기존 키 재사용: `t.settings.title.who_r_u`, `t.settings.title.nickname`, `t.settings.title.introduction`, `t.common.ec.char_limit_12`, `t.common.ec.char_limit_50`, `t.settings.para.nickname_taken`. "Let's get in" 은 데스크탑 V1 과 동일하게 리터럴 유지. **신규 키 없음**(있다면 ko/en json 직접 편집, [[feedback_pfplay_web_i18n_drift]]).
+
+## 9. 테스트 전략
+
+### 단위 (vitest)
+
+- `use-edit-profile-bio-form` — 검증/submit→updateBio 호출/409→setError
+- `mobile-profile-edit-form` — 필드 렌더, CTA `disabled`(invalid 시), 제출 호출
+- `profile-edit-redirect-guard` — 5분기: `GT→/`, `FM→/parties`, `AM+mobile→/parties`, `AM+desktop→/settings/avatar`, `profileUpdated=false→리다이렉트 없음`
+- 데스크탑 `v1.component` 기존 테스트 **그린 유지**(회귀 가드)
+
+### 로컬 풀스택 e2e (Playwright `--project=mobile`)
+
+[[feedback_local_e2e_before_dev_merge]] 게이트. 신규 spec `e2e/mobile/profile-onboarding.spec.ts`:
+
+- 모바일 신규 AM(또는 profileUpdated=false 회원) → `/settings/profile` 모바일 폼 노출 → 닉네임 입력 → 제출 → **`/parties` 착지(아바타 단계 건너뜀)** happy-path 1개 = 데드엔드 2겹 모두 해소 실증.
+- 절차: 로컬 backend docker `:8080` + `npx next dev` http `:3000` + `E2E_API_BASE`/`E2E_BASE_URL` inline ([[reference_pfplay_web_local_e2e_run]], [[reference_pfplay_web_local_dev_http_webpack]]).
+
+## 10. 회귀/위험
+
+- 데스크탑 V1 무회귀: 훅 추출은 public 마크업 불변 → 기존 테스트가 가드.
+- layout RSC 전환: `useSuspenseFetchMe` Suspense 경계가 guard(client) 로 이동해도 상위 provider 트리(QueryClient) 동일 → 동작 보존. RSC 가 `headers()` 호출 → 해당 route 동적 렌더(이미 page.tsx 가 `headers()` 사용해 동적).
+- [[feedback_mobile_widget_baseline_reflex]]: 데스크탑 V1 baseline(필드 구성·검증·mutation) grep·diff 완료 후 모바일 폼 작성.

--- a/docs/superpowers/specs/2026-06-05-mobile-profile-onboarding-design.md
+++ b/docs/superpowers/specs/2026-06-05-mobile-profile-onboarding-design.md
@@ -18,6 +18,8 @@
 
 `parties/layout.tsx` 는 `profileUpdated` 가 true 가 될 때까지 `null` 을 렌더하므로, 모바일 신규 회원은 **프로필 설정도 못 하고 어떤 파티에도 진입하지 못한다.** 게스트(GT)는 `profileUpdated=true`/좀비 안전망으로 면제되어 맛보기 깔때기는 작동하지만, 갓 가입한 소셜 회원은 벽에 부딪힌다.
 
+> **데드엔드 #2 의 발화 시점 주의**: `settings/profile/layout.tsx` 의 AM→avatar 리다이렉트는 `me.profileUpdated` 에 게이트돼 있다. 신규 가입자는 진입 시 `profileUpdated=false` 라 리다이렉트가 **즉시 발화하지 않고** 폼이 노출된다. 데드엔드 #2 는 데드엔드 #1 을 고쳐 프로필 제출 → `profileUpdated=true` 로 전이된 **직후**에 비로소 발화한다(§6 데이터 흐름 순서대로). 즉 #1 만 고치면 #2 가 드러나는 구조 — 둘을 한 번에 고쳐야 하는 이유.
+
 근거(실측, 2026-06-05):
 
 - `src/app/parties/layout.tsx:35` — `if (me && !me.profileUpdated) router.replace('/settings/profile')`, `:42` — `!me.profileUpdated` 면 `null` 렌더
@@ -74,6 +76,7 @@ device-aware 리다이렉트 fix는 클라이언트 layout 이 `x-pf-device`(서
   - `useEditProfileBioForm()` 소비.
   - 레이아웃: 세로 스택. `FormItem`(닉네임, 필수, `Input maxLength=16`) + `FormItem`(소개, `TextArea maxLength=50 rows=3`) **full-width**(`w-full`, 모바일 `px-app` 패딩). 하단 full-width "Let's get in" `Button`(`btnDisabled`/`isPending` 바인딩). 데스크탑의 absolute 배치 대신 일반 흐름 하단 고정.
   - 재사용 공통 컴포넌트: `FormItem`, `Input`, `TextArea`, `Button` (`@/shared/ui/components/*`).
+  - ⚠️ **닉네임 `maxLength={16}` 은 데스크탑 V1 그대로 미러링한다(의도된 비대칭).** zod 스키마는 `nickname.max(12)`, placeholder 는 `char_limit_12` 지만 input maxLength 는 16 — 데스크탑 상속 동작이다. "고치지" 말 것(데스크탑 drift 유발). 검증은 zod 가, 하드 컷은 16 으로 동일하게 둔다.
 - **신규** `src/features-mobile/profile/index.ts` — barrel export.
 
 ### 5.3 페이지 와이어링

--- a/e2e/mobile/profile-onboarding.spec.ts
+++ b/e2e/mobile/profile-onboarding.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * #393 — 모바일 신규 소셜 가입자(AM 준회원) 강제 프로필 온보딩 (mobile project).
+ *
+ * 이슈: 모바일 신규 AM 은 가입 직후 강제 리다이렉트 2겹에 모두 막다른 길로 빠졌다.
+ *   #1 parties/layout → /settings/profile → 모바일 "데스크탑 전용" 폴백 카드
+ *   #2 settings/profile/layout(AM) → /settings/avatar → 모바일 "데스크탑 전용" 폴백 카드
+ *
+ * 검증 본질(데드엔드 2겹 해소):
+ * - 모바일 viewport(iPhone 13 → x-pf-device=mobile)에서 /settings/profile 이
+ *   폴백 카드가 아니라 실제 폼(`mobile-profile-form`)을 렌더한다(#1 해소).
+ * - 닉네임 입력→제출 후 아바타 desktop-only 카드를 거치지 않고 /parties 로 착지한다(#2 해소).
+ *
+ * ⚠️ 캐시 auth 픽스처(user1Context = FM, profileUpdated=true) 미사용: guard 가 FM→/parties
+ *    로 즉시 리다이렉트해 폼이 안 뜬다. fresh 컨텍스트 + associate(AM) dev 로그인으로
+ *    profileUpdated=false AM 을 생성해야 한다.
+ */
+
+// 캐시 storageState 무시 — fresh 컨텍스트로 신규 AM 로그인 (mobile UA 는 project use 가 유지)
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('mobile 신규 AM 프로필 온보딩 (#393)', () => {
+  test('강제 프로필 온보딩 → /parties (데드엔드 2겹 해소)', async ({ page }) => {
+    test.setTimeout(60_000);
+    const t0 = Date.now();
+    const log = (m: string) => console.log(`[profile-onboarding test][${Date.now() - t0}ms] ${m}`);
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') log(`console.error: ${msg.text()}`);
+    });
+
+    log('goto /sign-in');
+    await page.goto('/sign-in');
+
+    log('open dev sign-in dialog');
+    await page.locator('[data-testid="dev-sign-in-button"]').click({ force: true });
+    const dialog = page
+      .locator('[data-testid="dialog-panel"]')
+      .filter({ has: page.locator('[data-testid="dev-sign-in-associate"]') })
+      .first();
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    log('sign in as associate (AM)');
+    await dialog.locator('[data-testid="dev-sign-in-associate"]').click({ force: true });
+
+    // 데드엔드 #1 해소: /settings/profile 모바일 폼 노출(폴백 카드 아님)
+    log('expect /settings/profile mobile form');
+    await expect(page).toHaveURL(/\/settings\/profile/, { timeout: 30_000 });
+    await expect(page.locator('[data-testid="mobile-profile-form"]')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    log('fill nickname + submit');
+    const unique = `am${Date.now() % 100000}`;
+    await page.locator('[data-testid="mobile-profile-form"] input').first().fill(unique);
+    await page.locator('[data-testid="mobile-profile-submit"]').click();
+
+    // 데드엔드 #2 해소: 아바타 desktop-only 카드 거치지 않고 /parties 착지
+    log('expect /parties landing (avatar 단계 생략)');
+    await expect(page).toHaveURL(/\/parties/, { timeout: 30_000 });
+  });
+});

--- a/src/app/settings/profile/layout.tsx
+++ b/src/app/settings/profile/layout.tsx
@@ -1,34 +1,11 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { PropsWithChildren, useEffect } from 'react';
-import { useSuspenseFetchMe } from '@/entities/me';
-import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import { headers } from 'next/headers';
+import { PropsWithChildren } from 'react';
+import ProfileEditRedirectGuard from './profile-edit-redirect-guard';
 
 const ProfileEditLayout = ({ children }: PropsWithChildren) => {
-  const { data: me } = useSuspenseFetchMe();
-  const router = useRouter();
+  const device = headers().get('x-pf-device') === 'mobile' ? 'mobile' : 'desktop';
 
-  useEffect(() => {
-    if (me.authorityTier === AuthorityTier.GT) {
-      router.replace('/');
-      return;
-    }
-
-    /**
-     * 프로필을 등록한 사용자의 경우, 접근 불가
-     */
-    if (me.profileUpdated) {
-      if (me.authorityTier === AuthorityTier.AM) {
-        router.replace('/settings/avatar');
-      }
-      if (me.authorityTier === AuthorityTier.FM) {
-        router.replace('/parties');
-      }
-    }
-  }, [me]);
-
-  return <>{children}</>;
+  return <ProfileEditRedirectGuard device={device}>{children}</ProfileEditRedirectGuard>;
 };
 
 export default ProfileEditLayout;

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1,14 +1,24 @@
 import { headers } from 'next/headers';
 import { ProfileEditFormV1 } from '@/features/edit-profile-bio';
+import { MobileProfileEditForm } from '@/features-mobile/profile';
 import { getServerDictionary } from '@/shared/lib/localization/get-server-dictionary';
 import { BackButton } from '@/shared/ui/components/back-button';
-import { MobileOnlyDesktopFeatureCard } from '@/shared/ui/components/mobile-only-desktop-feature-card';
+import { Typography } from '@/shared/ui/components/typography';
 
 const ProfileSettingsPage = async () => {
   const isMobile = headers().get('x-pf-device') === 'mobile';
-  if (isMobile) return <MobileOnlyDesktopFeatureCard feature='profile-edit' />;
-
   const t = await getServerDictionary();
+
+  if (isMobile) {
+    return (
+      <div className='flexCol w-full min-h-screen pt-[var(--header-height)]'>
+        <Typography type='title2' as='h1' className='text-white px-app pt-6'>
+          {t.settings.title.who_r_u}
+        </Typography>
+        <MobileProfileEditForm />
+      </div>
+    );
+  }
 
   return (
     <div className='absolute-user-form-section flexColCenter py-10 px-[60px]'>

--- a/src/app/settings/profile/profile-edit-redirect-guard.test.tsx
+++ b/src/app/settings/profile/profile-edit-redirect-guard.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import ProfileEditRedirectGuard from './profile-edit-redirect-guard';
+
+const replaceMock = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ replace: replaceMock }) }));
+
+let meValue: any;
+vi.mock('@/entities/me', () => ({ useSuspenseFetchMe: () => ({ data: meValue }) }));
+
+const renderGuard = (device: 'mobile' | 'desktop') =>
+  render(
+    <ProfileEditRedirectGuard device={device}>
+      <div>child</div>
+    </ProfileEditRedirectGuard>
+  );
+
+describe('ProfileEditRedirectGuard', () => {
+  beforeEach(() => replaceMock.mockReset());
+
+  test('GT → /', () => {
+    meValue = { authorityTier: AuthorityTier.GT, profileUpdated: true };
+    renderGuard('mobile');
+    expect(replaceMock).toHaveBeenCalledWith('/');
+  });
+
+  test('profileUpdated=false → 리다이렉트 없음(폼 노출)', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: false };
+    renderGuard('mobile');
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  test('FM + profileUpdated → /parties', () => {
+    meValue = { authorityTier: AuthorityTier.FM, profileUpdated: true };
+    renderGuard('desktop');
+    expect(replaceMock).toHaveBeenCalledWith('/parties');
+  });
+
+  test('AM + desktop + profileUpdated → /settings/avatar', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: true };
+    renderGuard('desktop');
+    expect(replaceMock).toHaveBeenCalledWith('/settings/avatar');
+  });
+
+  test('AM + mobile + profileUpdated → /parties (아바타 강제 단계 생략)', () => {
+    meValue = { authorityTier: AuthorityTier.AM, profileUpdated: true };
+    renderGuard('mobile');
+    expect(replaceMock).toHaveBeenCalledWith('/parties');
+  });
+});

--- a/src/app/settings/profile/profile-edit-redirect-guard.tsx
+++ b/src/app/settings/profile/profile-edit-redirect-guard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { PropsWithChildren, useEffect } from 'react';
+import { useSuspenseFetchMe } from '@/entities/me';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+
+type Props = PropsWithChildren<{ device: 'mobile' | 'desktop' }>;
+
+/**
+ * 프로필 설정 페이지 접근 가드 + 완료 후 라우팅.
+ *
+ * 기존 동작 유지:
+ * - GT(게스트)는 접근 불가 → '/'
+ * - 프로필 등록 완료(FM)는 접근 불가 → '/parties'
+ *
+ * device-aware 분기(신규):
+ * - 프로필 등록 완료 AM 은 데스크탑에서 아바타 설정으로 유도되지만,
+ *   모바일은 아바타가 서버 자동셋팅이라 강제 단계를 건너뛰고 '/parties' 로.
+ *   (모바일 아바타 편집은 의도적으로 desktop-only 안내 — 데드엔드 회피)
+ */
+const ProfileEditRedirectGuard = ({ device, children }: Props) => {
+  const { data: me } = useSuspenseFetchMe();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (me.authorityTier === AuthorityTier.GT) {
+      router.replace('/');
+      return;
+    }
+
+    if (me.profileUpdated) {
+      if (me.authorityTier === AuthorityTier.AM) {
+        router.replace(device === 'mobile' ? '/parties' : '/settings/avatar');
+      }
+      if (me.authorityTier === AuthorityTier.FM) {
+        router.replace('/parties');
+      }
+    }
+  }, [me, device, router]);
+
+  return <>{children}</>;
+};
+
+export default ProfileEditRedirectGuard;

--- a/src/features-mobile/profile/index.ts
+++ b/src/features-mobile/profile/index.ts
@@ -1,0 +1,1 @@
+export { default as MobileProfileEditForm } from './ui/mobile-profile-edit-form.component';

--- a/src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx
+++ b/src/features-mobile/profile/ui/mobile-profile-edit-form.component.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import MobileProfileEditForm from './mobile-profile-edit-form.component';
+
+const onSubmitMock = vi.fn((e) => e?.preventDefault?.());
+vi.mock('@/features/edit-profile-bio', () => ({
+  useEditProfileBioForm: () => ({
+    control: {} as any,
+    onSubmit: onSubmitMock,
+    errors: {},
+    btnDisabled: false,
+    isPending: false,
+  }),
+}));
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    settings: { title: { nickname: '닉네임', introduction: '소개', who_r_u: 'Who R U' } },
+    common: { ec: { char_limit_12: '12자', char_limit_50: '50자' } },
+  }),
+}));
+// Controller 는 control 의존 — 얕게 mock 해 render prop 만 호출
+vi.mock('react-hook-form', () => ({
+  Controller: ({ render }: any) =>
+    render({ field: { value: '', onChange: () => {}, onBlur: () => {}, name: '', ref: () => {} } }),
+}));
+
+describe('MobileProfileEditForm', () => {
+  beforeEach(() => onSubmitMock.mockClear());
+
+  test('닉네임·소개 필드 + CTA 렌더', () => {
+    render(<MobileProfileEditForm />);
+    expect(screen.getByText('닉네임')).toBeInTheDocument();
+    expect(screen.getByText('소개')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-profile-submit')).toBeInTheDocument();
+  });
+
+  test('제출 시 onSubmit 호출', () => {
+    render(<MobileProfileEditForm />);
+    fireEvent.submit(screen.getByTestId('mobile-profile-form'));
+    expect(onSubmitMock).toHaveBeenCalled();
+  });
+});

--- a/src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx
+++ b/src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Controller } from 'react-hook-form';
+import { useEditProfileBioForm } from '@/features/edit-profile-bio';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import { FormItem } from '@/shared/ui/components/form-item';
+import { Input } from '@/shared/ui/components/input';
+import { TextArea } from '@/shared/ui/components/textarea';
+
+/**
+ * 모바일 강제 프로필 온보딩 폼. 데스크탑 `ProfileEditFormV1` 과 동일한
+ * `useEditProfileBioForm` 로직을 공유하고, 레이아웃만 모바일 폼팩터
+ * (full-width 필드 + 하단 full-width CTA)로 다르다.
+ */
+const MobileProfileEditForm = () => {
+  const t = useI18n();
+  const { control, onSubmit, errors, btnDisabled, isPending } = useEditProfileBioForm();
+
+  return (
+    <form
+      data-testid='mobile-profile-form'
+      onSubmit={onSubmit}
+      className='flexCol gap-10 w-full px-app pt-6 pb-10'
+    >
+      <div className='flexCol gap-8 w-full'>
+        <Controller
+          control={control}
+          name='nickname'
+          render={({ field }) => (
+            <FormItem
+              label={t.settings.title.nickname}
+              error={errors.nickname?.message}
+              required
+              classNames={{ label: 'text-gray-200' }}
+            >
+              <Input
+                {...field}
+                maxLength={16}
+                placeholder={t.common.ec.char_limit_12}
+                classNames={{ container: 'w-full' }}
+              />
+            </FormItem>
+          )}
+        />
+        <Controller
+          control={control}
+          name='introduction'
+          render={({ field }) => (
+            <FormItem
+              label={t.settings.title.introduction}
+              error={errors.introduction?.message}
+              classNames={{ label: 'text-gray-200' }}
+            >
+              <TextArea
+                {...field}
+                maxLength={50}
+                rows={3}
+                placeholder={t.common.ec.char_limit_50}
+                classNames={{ container: 'w-full' }}
+              />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <Button
+        type='submit'
+        data-testid='mobile-profile-submit'
+        variant={btnDisabled ? 'outline' : 'fill'}
+        size='xl'
+        className='w-full'
+        disabled={btnDisabled}
+        loading={isPending}
+      >
+        Let&apos;s get in
+      </Button>
+    </form>
+  );
+};
+
+export default MobileProfileEditForm;

--- a/src/features/edit-profile-bio/index.ts
+++ b/src/features/edit-profile-bio/index.ts
@@ -1,3 +1,4 @@
 export { default as ProfileEditFormV1 } from './ui/v1.component';
 export { default as ProfileEditFormV2 } from './ui/v2.component';
 export * as ProfileForm from './model/form.model';
+export { useEditProfileBioForm } from './lib/use-edit-profile-bio-form';

--- a/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts
+++ b/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts
@@ -30,7 +30,7 @@ describe('useEditProfileBioForm', () => {
     expect(updateBioMock.mock.calls[0][0]).toEqual({ nickname: 'olddata', introduction: 'hi' });
   });
 
-  test('409 응답 시 nickname 에러 셋팅', async () => {
+  test('onError(409) 와이어링 — nickname 에러 셋팅', async () => {
     const { result } = renderHook(() => useEditProfileBioForm());
     await act(async () => {
       await result.current.onSubmit({ preventDefault: () => {} } as any);

--- a/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts
+++ b/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.test.ts
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { useEditProfileBioForm } from './use-edit-profile-bio-form';
+
+const updateBioMock = vi.fn();
+vi.mock('../api/use-update-my-bio.mutation', () => ({
+  useUpdateMyBio: () => ({ mutate: updateBioMock, isPending: false }),
+}));
+vi.mock('@/entities/me', () => ({
+  useSuspenseFetchMe: () => ({ data: { nickname: 'olddata', introduction: 'hi' } }),
+}));
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    common: {
+      ec: { char_field_required: 'required', char_limit_12: 'max12', char_limit_50: 'max50' },
+    },
+    settings: { para: { nickname_taken: '이미 사용 중인 닉네임' } },
+  }),
+}));
+
+describe('useEditProfileBioForm', () => {
+  beforeEach(() => updateBioMock.mockReset());
+
+  test('onSubmit 시 me 기본값으로 updateBio 호출', async () => {
+    const { result } = renderHook(() => useEditProfileBioForm());
+    await act(async () => {
+      await result.current.onSubmit({ preventDefault: () => {} } as any);
+    });
+    expect(updateBioMock).toHaveBeenCalledTimes(1);
+    expect(updateBioMock.mock.calls[0][0]).toEqual({ nickname: 'olddata', introduction: 'hi' });
+  });
+
+  test('409 응답 시 nickname 에러 셋팅', async () => {
+    const { result } = renderHook(() => useEditProfileBioForm());
+    await act(async () => {
+      await result.current.onSubmit({ preventDefault: () => {} } as any);
+    });
+    expect(updateBioMock).toHaveBeenCalledTimes(1);
+    const opts = updateBioMock.mock.calls[0][1];
+    expect(opts?.onError).toBeTypeOf('function');
+    act(() => opts.onError({ response: { data: { code: 409 } } }));
+    expect(result.current.errors.nickname?.message).toBe('이미 사용 중인 닉네임');
+  });
+});

--- a/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts
+++ b/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSuspenseFetchMe } from '@/entities/me';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useUpdateMyBio } from '../api/use-update-my-bio.mutation';
+import * as Form from '../model/form.model';
+
+/**
+ * 프로필 바이오(닉네임·소개) 편집 폼 로직의 단일 출처.
+ * 데스크탑 `ProfileEditFormV1` 과 모바일 `MobileProfileEditForm` 이 공유한다
+ * (레이아웃만 폼팩터별로 다름 — #390 `useBeAHost` 와 동일 패턴).
+ */
+export const useEditProfileBioForm = () => {
+  const t = useI18n();
+  const { data: me } = useSuspenseFetchMe();
+  const { mutate: updateBio, isPending } = useUpdateMyBio();
+
+  const {
+    handleSubmit,
+    control,
+    setError,
+    formState: { errors, isValid },
+  } = useForm<Form.Model>({
+    mode: 'all',
+    resolver: zodResolver(Form.getSchema(t)),
+    defaultValues: {
+      nickname: me.nickname,
+      introduction: me.introduction,
+    },
+  });
+
+  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
+
+  const onSubmit = handleSubmit((values) => {
+    updateBio(values, {
+      onError: (err) => {
+        if (err.response?.data.code === 409) {
+          setError('nickname', { message: t.settings.para.nickname_taken });
+        }
+      },
+    });
+  });
+
+  return { control, onSubmit, errors, btnDisabled, isPending };
+};

--- a/src/features/edit-profile-bio/ui/v1.component.tsx
+++ b/src/features/edit-profile-bio/ui/v1.component.tsx
@@ -1,54 +1,20 @@
 'use client';
 
-import { Controller, SubmitHandler, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseFetchMe } from '@/entities/me';
+import { Controller } from 'react-hook-form';
 import { cn } from '@/shared/lib/functions/cn';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import { FormItem } from '@/shared/ui/components/form-item';
 import { Input } from '@/shared/ui/components/input';
 import { TextArea } from '@/shared/ui/components/textarea';
-import { useUpdateMyBio } from '../api/use-update-my-bio.mutation';
-import * as Form from '../model/form.model';
+import { useEditProfileBioForm } from '../lib/use-edit-profile-bio-form';
 
 const ProfileEditFormV1 = () => {
   const t = useI18n();
-  const { data: me } = useSuspenseFetchMe();
-  const { mutate: updateBio, isPending } = useUpdateMyBio();
-
-  const {
-    handleSubmit,
-    control,
-    setError,
-    formState: { errors, isValid },
-  } = useForm<Form.Model>({
-    mode: 'all',
-    resolver: zodResolver(Form.getSchema(t)),
-    defaultValues: {
-      nickname: me.nickname,
-      introduction: me.introduction,
-    },
-  });
-  const btnDisabled = Object.keys(errors).length > 0 || !isValid;
-
-  const handleFormSubmit: SubmitHandler<Form.Model> = (values) => {
-    updateBio(values, {
-      // onSuccess 시 어디로 이동할지는, 사용부에서 me 변경따른 effect로 처리
-      onError: (err) => {
-        // FIXME: 다른 브랜치에서 작업한 server response 를 제네릭으로 변경
-        if (err.response?.data.code === 409) {
-          setError('nickname', { message: t.settings.para.nickname_taken });
-        }
-      },
-    });
-  };
+  const { control, onSubmit, errors, btnDisabled, isPending } = useEditProfileBioForm();
 
   return (
-    <form
-      onSubmit={handleSubmit(handleFormSubmit)}
-      className='items-center justify-between py-24 flexCol'
-    >
+    <form onSubmit={onSubmit} className='items-center justify-between py-24 flexCol'>
       <div className='items-end gap-12 flexCol'>
         <Controller
           control={control}

--- a/src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx
+++ b/src/shared/ui/components/mobile-only-desktop-feature-card/mobile-only-desktop-feature-card.component.tsx
@@ -5,7 +5,6 @@ import { FC } from 'react';
 
 export type MobileOnlyDesktopFeature =
   | 'avatar-edit'
-  | 'profile-edit'
   | 'room-create'
   | 'moderation'
   | 'bug-report'
@@ -13,7 +12,6 @@ export type MobileOnlyDesktopFeature =
 
 const featureLabel: Record<MobileOnlyDesktopFeature, string> = {
   'avatar-edit': '아바타 편집',
-  'profile-edit': '프로필 편집',
   'room-create': '룸 생성',
   moderation: '모더레이션',
   'bug-report': '버그 리포트',


### PR DESCRIPTION
## 무엇을 / 왜

모바일 신규 소셜 가입자(지갑인증 X = **AM 준회원**)가 가입 직후 **강제 리다이렉트 2겹에 모두 막다른 길**로 빠져 이탈하던 문제를 해소합니다. closes #393

```
신규 AM 모바일 가입
  → parties/layout: profileUpdated=false → /settings/profile
      → 모바일: "데스크탑 전용" 폴백 카드  ❌ 데드엔드 #1
  → settings/profile/layout: AM → /settings/avatar
      → 모바일: "데스크탑 전용" 폴백 카드  ❌ 데드엔드 #2
```

소셜 로그인 유저가 모바일에서 프로필 설정도 못 하고 어떤 파티에도 진입 못 해 **반드시 이탈**하는, 전환 깔때기 최악의 누수 지점이었습니다.

## 기획 결정 (잠금)

- **프로필만 강제** → 모바일 프로필 편집 화면 신규 구현
- **아바타는 서버 자동셋팅** → 모바일 아바타 강제 단계 불필요. 모바일 아바타 '편집' 클릭 시 "데스크탑 전용" 안내는 **의도된 동작으로 유지**(작업 없음)
- **모바일 AM은 프로필 완료 후 `/parties`로** (아바타 강제 단계 생략). 데스크탑 AM 은 기존대로 `/settings/avatar`

## 변경

1. **공유 훅 추출** `useEditProfileBioForm` — 데스크탑 `ProfileEditFormV1` 의 폼 로직(검증·submit·409)을 추출. 데스크탑 V1 은 **마크업 100% 불변**으로 훅 소비(#390 `useBeAHost` 패턴).
2. **모바일 폼** `MobileProfileEditForm`(`features-mobile/profile`) — 동일 훅 + 모바일 레이아웃(full-width 필드 + 하단 CTA).
3. **`/settings/profile` 모바일 분기** — 폴백 카드 → 온보딩 폼. `MobileOnlyDesktopFeatureCard` 의 미사용 `profile-edit` variant 제거(`avatar-edit` 유지).
4. **데드엔드 #2 fix** — `settings/profile/layout.tsx` 를 RSC 로 전환해 `x-pf-device` 를 읽고 client redirect-guard 에 전달 → **모바일 AM → `/parties`**. 그 외 분기(GT→/, FM→/parties, 데스크탑 AM→/settings/avatar) 전부 불변.

## 검증

- **단위/통합**: 전체 `vitest run` GREEN (신규 9: 공유 훅 2 + 모바일 폼 2 + redirect-guard 5분기), `tsc --noEmit` 0, `lint` 0.
- **로컬 풀스택 e2e**(`--project=mobile`, backend docker :8080 + `npx next dev` :3000): 신규 `e2e/mobile/profile-onboarding.spec.ts` — fresh AM(associate dev 로그인) → `/settings/profile` 모바일 폼 노출 → 제출 → **`/parties` 착지** = 데드엔드 2겹 해소 **실 백엔드 실증 PASS**.
- **코드리뷰**: tech-lead 리뷰어 ✅ Approve (6/6 준수, must-fix 0).

## 범위 밖
기존 회원 모바일 재편집 / 모바일 아바타 편집 화면 / 데스크탑 AM 동작.

> ⚠️ PR 체크의 "Vercel – pfplay-web: fail" 빨간 X 는 코드 무관(중복 Vercel 프로젝트). 머지 판단 시 무시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
