### PR TITLE
feat(모바일): 모바일 웹 뷰 데스크탑 디자인 언어 통일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ test-results/
 
 # yarn-only project — keep package-lock.json out
 package-lock.json
+
+# 모바일 디자인 검증/외주용 스크린샷 산출물 (대용량 바이너리) — 캡처 스크립트만 추적
+mobile-screenshots/
+mobile-screenshots.zip

--- a/docs/superpowers/plans/2026-06-09-mobile-design-language-alignment.md
+++ b/docs/superpowers/plans/2026-06-09-mobile-design-language-alignment.md
@@ -1,0 +1,810 @@
+# 모바일 디자인 언어 통일 — 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** pfplay-web 모바일 웹 뷰의 시각 디자인 언어를 데스크탑(PF 아이콘·Galmuri·마퀴·패널 크롬·여백 리듬)으로 통일한다 — 레이아웃·데스크탑 렌더는 불변.
+
+**Architecture:** 얇은 공용 프리미티브 2개(`TrackTitle`, `MobileSheetHeader`)를 먼저 추가/추출하고, 이를 화면(Room→Lobby→Sheets→Search)에 단계적으로 적용한다. 데스크탑 `VideoTitle`은 `TrackTitle`에 프레젠테이션을 위임하되 스토어/i18n 와이어링을 유지해 렌더 바이트 불변. 기존 단위 테스트가 회귀 가드.
+
+**Tech Stack:** Next.js(App Router) · React · TypeScript · Tailwind · vitest + @testing-library/react · react-fast-marquee · Galmuri local font.
+
+**스펙:** `docs/superpowers/specs/2026-06-09-mobile-design-language-alignment-design.md`
+**브랜치:** `feature/mobile-design-language-alignment` (origin/development 분기)
+
+---
+
+## 공통 규약 (모든 Task)
+
+- **JDK/도구 불필요** — 순수 프론트엔드. 명령은 레포 루트(`pfplay-web/`)에서 실행.
+- **테스트:** `yarn test` (vitest run, co-located `*.test.tsx`). 단건: `yarn test src/<path>/<file>.test.tsx`.
+- **타입:** `yarn test:type` (tsc --noEmit). **린트:** `yarn lint`.
+- **아이콘 API:** PF 아이콘은 `SVGProps<SVGSVGElement>`, 기본 24×24, `fill='currentColor'`. 색은 부모 `text-*`, 크기는 `width`/`height` prop. import는 배럴 `@/shared/ui/icons`.
+- **Typography:** `import { Typography } from '@/shared/ui/components/typography'`. `type` 토큰(`body3`/`detail2`/`caption1` 등). raw `<p>` 교체 시 동일 시각 토큰 선택.
+- **여백 리듬(A5) 기준값:** 모바일 컨테이너 가로 = `px-5`(20px, `px-app` 모바일과 일치). 헤더 높이 = `h-14`(56px, fullscreen-sheet와 일치). 리스트 행 = `px-5 py-3`. 섹션 간 = `gap-3`/`pt-3`. **px 복사 아님 — 화면별 스크린샷으로 미세조정**(D5).
+- **데스크탑 불변:** 데스크탑(`src/widgets/`, `src/features/`) 수정은 Task 1(VideoTitle 위임)뿐. 그 외 데스크탑 파일 0 수정.
+- **커밋:** Task별 1커밋. 메시지 한글, 푸터 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. lint-staged(prettier+eslint) 자동 실행됨.
+- **i18n 드리프트 금지:** 라벨을 raw→Typography로 옮길 때 텍스트/키 그대로. xlsx↔json 건드리지 말 것.
+
+---
+
+## Chunk 1: 공용 프리미티브 (Visual Kit)
+
+### Task 1: `TrackTitle` 추출 (A2) + 데스크탑 `VideoTitle` 위임
+
+데스크탑 `VideoTitle`의 프레젠테이션(Marquee + Typography + Galmuri)을 공용 `TrackTitle`로 추출. 데스크탑은 스토어/i18n을 유지한 채 위임 → 렌더 불변.
+
+**Files:**
+
+- Create: `src/shared/ui/components/track-title/track-title.component.tsx`
+- Create: `src/shared/ui/components/track-title/index.ts`
+- Create: `src/shared/ui/components/track-title/track-title.component.test.tsx`
+- Modify: `src/widgets/partyroom-display-board/ui/parts/video-title.component.tsx`
+- Guard(미수정 통과): `src/widgets/partyroom-display-board/ui/parts/video-title.component.test.tsx`
+
+- [ ] **Step 1: TrackTitle 실패 테스트 작성**
+
+`track-title.component.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('react-fast-marquee', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='marquee'>{children}</div>
+  ),
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({
+  galmuriFont: { className: 'font-galmuri' },
+}));
+
+import TrackTitle from './track-title.component';
+
+describe('TrackTitle', () => {
+  test('name 있으면 Marquee 안에 곡명 + data-testid=video-title', () => {
+    render(<TrackTitle name='Test Song' emptyText='없음' />);
+    expect(screen.getByTestId('marquee')).toBeTruthy();
+    const el = screen.getByTestId('video-title');
+    expect(el.textContent).toBe('Test Song');
+    expect(el.className).toMatch(/font-galmuri/);
+  });
+
+  test('name 없으면 emptyText + data-testid=video-title-empty (마퀴 없음)', () => {
+    render(<TrackTitle emptyText='현재 DJ가 없습니다' />);
+    expect(screen.queryByTestId('marquee')).toBeNull();
+    const el = screen.getByTestId('video-title-empty');
+    expect(el.textContent).toBe('현재 DJ가 없습니다');
+    expect(el.className).toMatch(/font-galmuri/);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/shared/ui/components/track-title/track-title.component.test.tsx`
+Expected: FAIL — `Cannot find module './track-title.component'`.
+
+- [ ] **Step 3: TrackTitle 구현**
+
+`track-title.component.tsx` (데스크탑 `VideoTitle`의 현재 프레젠테이션을 1:1 복제):
+
+```tsx
+'use client';
+import Marquee from 'react-fast-marquee';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+import { galmuriFont } from '@/shared/ui/foundation/fonts';
+
+interface Props {
+  /** 곡명. 없으면 emptyText 렌더 */
+  name?: string;
+  /** 곡 없을 때 표시 문구 */
+  emptyText: string;
+  className?: string;
+}
+
+/**
+ * 곡 제목 — Galmuri + 마퀴 프레젠테이션 (데스크탑 VideoTitle에서 추출).
+ * 스토어/i18n 와이어링은 호출자(VideoTitle/now-playing) 책임. 본 컴포넌트는 순수 표시.
+ */
+export default function TrackTitle({ name, emptyText, className }: Props) {
+  const typoClassName = cn(galmuriFont.className, 'text-white leading-none', className);
+
+  if (!name) {
+    return (
+      <Typography type='caption1' className={typoClassName} data-testid='video-title-empty'>
+        {emptyText}
+      </Typography>
+    );
+  }
+  return (
+    <Marquee delay={4} speed={20} gradientWidth={0} className='z-0'>
+      <Typography type='body3' className={typoClassName} data-testid='video-title'>
+        {name}
+      </Typography>
+    </Marquee>
+  );
+}
+```
+
+`index.ts`:
+
+```ts
+export { default as TrackTitle } from './track-title.component';
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn test src/shared/ui/components/track-title/track-title.component.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: 데스크탑 VideoTitle을 TrackTitle 위임으로 전환**
+
+`video-title.component.tsx` 전체 교체 (스토어/i18n 유지, 표시는 위임):
+
+```tsx
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { TrackTitle } from '@/shared/ui/components/track-title';
+
+export default function VideoTitle() {
+  const t = useI18n();
+  const { useCurrentPartyroom } = useStores();
+  const playback = useCurrentPartyroom((state) => state.playback);
+
+  return <TrackTitle name={playback?.name} emptyText={t.dj.para.empty_dj} />;
+}
+```
+
+- [ ] **Step 6: 데스크탑 회귀 테스트(미수정) 통과 확인**
+
+Run: `yarn test src/widgets/partyroom-display-board/ui/parts/video-title.component.test.tsx`
+Expected: PASS — 기존 테스트(빈 DJ 메시지 / Marquee+곡명) 무수정 통과. 통과 = 렌더 불변 1차 증명.
+
+- [ ] **Step 7: 타입 체크**
+
+Run: `yarn test:type`
+Expected: 에러 0.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add src/shared/ui/components/track-title src/widgets/partyroom-display-board/ui/parts/video-title.component.tsx
+git commit -m "feat(ui): TrackTitle 공용 컴포넌트 추출 — 데스크탑 VideoTitle 위임(렌더 불변)"
+```
+
+---
+
+### Task 2: `MobileSheetHeader` 추출 (A3) + fullscreen-sheet 채택
+
+`fullscreen-sheet`의 헤더 패턴(leading 슬롯 + 중앙 타이틀 + trailing 스페이서)을 공용 `MobileSheetHeader`로 추출. fullscreen-sheet가 먼저 채택해 재사용 검증.
+
+**Files:**
+
+- Create: `src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.tsx`
+- Create: `src/shared/ui/components/mobile-sheet-header/index.ts`
+- Create: `src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx`
+- Modify: `src/widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx`
+- Guard: `src/widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.test.tsx` (있으면 무수정 통과; 없으면 Step 7에서 fullscreen-sheet 동작 테스트 확인)
+
+- [ ] **Step 1: MobileSheetHeader 실패 테스트 작성**
+
+`mobile-sheet-header.component.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import MobileSheetHeader from './mobile-sheet-header.component';
+
+describe('MobileSheetHeader', () => {
+  test('leading/title/trailing 슬롯 렌더 + title은 Typography', () => {
+    render(
+      <MobileSheetHeader
+        leading={<button data-testid='lead'>L</button>}
+        title='제목'
+        trailing={<button data-testid='trail'>T</button>}
+      />
+    );
+    expect(screen.getByTestId('lead')).toBeTruthy();
+    expect(screen.getByTestId('trail')).toBeTruthy();
+    expect(screen.getByText('제목')).toBeTruthy();
+  });
+
+  test('trailing 미지정 시에도 leading/title 정상 (대칭 스페이서 유지)', () => {
+    const { container } = render(<MobileSheetHeader leading={<span>L</span>} title='T' />);
+    expect(container.querySelector('header')).toBeTruthy();
+    expect(screen.getByText('T')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx`
+Expected: FAIL — 모듈 없음.
+
+- [ ] **Step 3: MobileSheetHeader 구현**
+
+`mobile-sheet-header.component.tsx`:
+
+```tsx
+'use client';
+import { FC, ReactNode, useId } from 'react';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+
+interface Props {
+  /** 좌측 액션 (뒤로/닫기 등). 없으면 대칭 스페이서로 폭 보존 */
+  leading?: ReactNode;
+  title?: string;
+  /** 우측 액션 (메뉴 등). 없으면 대칭 스페이서 */
+  trailing?: ReactNode;
+  /** title element id 연결용 (dialog aria-labelledby) */
+  titleId?: string;
+  className?: string;
+}
+
+/**
+ * 모바일 시트/룸 상단 표준 헤더 (spec A3).
+ * 좌(leading) · 중앙 title(Typography) · 우(trailing) 3분할, 56px 높이, 하단 border-gray-800.
+ * leading/trailing 미지정 측은 동일 폭 스페이서로 중앙 정렬 보존.
+ */
+const MobileSheetHeader: FC<Props> = ({ leading, title, trailing, titleId, className }) => {
+  const autoId = useId();
+  const id = titleId ?? autoId;
+  return (
+    <header
+      className={cn(
+        'shrink-0 flex items-center gap-3 px-3 h-14 border-b border-gray-800',
+        className
+      )}
+    >
+      <div className='w-10 flex items-center justify-start'>{leading}</div>
+      {title && (
+        <Typography id={id} type='body3' overflow='ellipsis' className='flex-1 text-center'>
+          {title}
+        </Typography>
+      )}
+      <div className='w-10 flex items-center justify-end'>{trailing}</div>
+    </header>
+  );
+};
+
+export default MobileSheetHeader;
+```
+
+`index.ts`:
+
+```ts
+export { default as MobileSheetHeader } from './mobile-sheet-header.component';
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn test src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: fullscreen-sheet가 MobileSheetHeader 채택**
+
+`fullscreen-sheet.component.tsx`의 `<header>...</header>` 블록(현 62~92행)을 교체. 기존 `data-testid`(`fullscreen-sheet-back`/`fullscreen-sheet-close`)·ref·focus·aria 동작 보존:
+
+```tsx
+import { MobileSheetHeader } from '@/shared/ui/components/mobile-sheet-header';
+// ... (PFArrowLeft, PFClose import 유지)
+
+// return JSX 내부, 기존 <header> 블록 대신:
+<MobileSheetHeader
+  titleId={title ? titleId : undefined}
+  title={title}
+  leading={
+    onBack ? (
+      <button
+        ref={backRef}
+        type='button'
+        onClick={onBack}
+        data-testid='fullscreen-sheet-back'
+        aria-label='뒤로'
+        className='p-2 -ml-2'
+      >
+        <PFArrowLeft width={24} height={24} />
+      </button>
+    ) : (
+      <button
+        ref={closeRef}
+        type='button'
+        onClick={onClose}
+        data-testid='fullscreen-sheet-close'
+        aria-label='닫기'
+        className='p-2 -ml-2'
+      >
+        <PFClose width={24} height={24} />
+      </button>
+    )
+  }
+/>;
+```
+
+> 주: 기존 헤더의 `aria-labelledby={titleId}`는 dialog 컨테이너(`<div role='dialog'>`)에 그대로 두고, `MobileSheetHeader`에는 `titleId`를 넘겨 title element의 `id`만 연결한다. dialog div의 `aria-labelledby` 라인은 변경하지 않는다.
+
+- [ ] **Step 6: fullscreen-sheet 회귀 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-djing-sheet`
+Expected: PASS — back/close testid·focus·scroll-lock 동작 유지. (해당 테스트가 없으면 Step 7로.)
+
+- [ ] **Step 7: 타입 + 린트**
+
+Run: `yarn test:type && yarn lint`
+Expected: 에러 0.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add src/shared/ui/components/mobile-sheet-header src/widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx
+git commit -m "feat(ui): MobileSheetHeader 공용 컴포넌트 + fullscreen-sheet 채택(동작 보존)"
+```
+
+---
+
+### Chunk 1 검증 게이트
+
+- [ ] `yarn test` 전체 GREEN
+- [ ] `yarn test:type` 클린
+- [ ] `yarn lint` 클린
+- [ ] **plan-document-reviewer 통과 후 다음 Chunk** (실행 시)
+
+---
+
+## Chunk 2: Room 적용 (전광판·탭바·채팅)
+
+### Task 3: 룸 헤더 → MobileSheetHeader + PF 아이콘 (A1·A3)
+
+`partyroom-display-board` 헤더(현 60~77행, ASCII ←/⋮ raw)를 `MobileSheetHeader` + `PFArrowLeft`/`PFMoreVert`로 교체.
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`
+- Test: `src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+
+- [ ] **Step 1: 헤더 테스트 갱신/추가 (red)**
+
+`partyroom-display-board.component.test.tsx`에 추가(또는 기존 헤더 단언 갱신). 뒤로 버튼은 `aria-label='뒤로'` 유지, 메뉴는 `aria-label='메뉴'` 유지. PF 아이콘 SVG 존재 단언:
+
+```tsx
+test('헤더: 뒤로 버튼 클릭 시 /parties 라우팅 + PF 아이콘 렌더', () => {
+  const push = vi.fn();
+  // 기존 next/navigation useRouter mock 의 push 를 캡처 (기존 패턴 따름)
+  // ... render(<MobilePartyroomDisplayBoard partyroomId={1} />)
+  const back = screen.getByRole('button', { name: '뒤로' });
+  expect(back.querySelector('svg')).toBeTruthy(); // PFArrowLeft
+  fireEvent.click(back);
+  expect(push).toHaveBeenCalledWith('/parties');
+  const menu = screen.getByRole('button', { name: '메뉴' });
+  expect(menu.querySelector('svg')).toBeTruthy(); // PFMoreVert
+});
+```
+
+> 기존 테스트 파일의 mock 셋업(react-player, next/navigation, stores)을 그대로 재사용. push mock 캡처 방식은 파일 상단 기존 패턴을 따른다.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+Expected: FAIL — 현재 ASCII 텍스트라 `querySelector('svg')` null.
+
+- [ ] **Step 3: 헤더 교체 구현**
+
+import 추가: `import { MobileSheetHeader } from '@/shared/ui/components/mobile-sheet-header';` · `import { PFArrowLeft, PFMoreVert } from '@/shared/ui/icons';`
+
+현 `<header className='flex items-center justify-between px-4 h-12'>...</header>` 블록 교체:
+
+```tsx
+<MobileSheetHeader
+  title={partyroomTitle}
+  leading={
+    <button
+      type='button'
+      aria-label='뒤로'
+      className='w-10 h-10 flex items-center justify-center text-gray-300'
+      onClick={() => router.push('/parties')}
+    >
+      <PFArrowLeft width={24} height={24} />
+    </button>
+  }
+  trailing={
+    <button
+      type='button'
+      aria-label='메뉴'
+      className='w-10 h-10 flex items-center justify-center text-gray-300'
+    >
+      <PFMoreVert width={24} height={24} />
+    </button>
+  }
+/>
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+git commit -m "feat(모바일): 룸 헤더 MobileSheetHeader + PF 아이콘(←/⋮ → PFArrowLeft/PFMoreVert)"
+```
+
+---
+
+### Task 4: now-playing-meta → TrackTitle + PFHeadset (A1·A2·A5)
+
+트랙명 raw `<p>` → `TrackTitle`, DJ 🎧 이모지 → `PFHeadset`, duration `<p>` → `Typography`.
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx`
+- Test: `src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx`
+
+- [ ] **Step 1: 테스트 갱신 (red)**
+
+상단에 marquee 모킹 추가(TrackTitle 내부 Marquee 때문):
+
+```tsx
+vi.mock('react-fast-marquee', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({ galmuriFont: { className: 'font-galmuri' } }));
+```
+
+`djNickname=null` 테스트의 `queryByText(/🎧/)` 단언을 PFHeadset 아이콘 부재로 갱신, DJ 존재 시 헤드셋 아이콘 존재 단언 추가:
+
+```tsx
+test('djNickname 있으면 헤드셋 아이콘 + 닉네임', () => {
+  const { container } = render(
+    <NowPlayingMeta layout='column' trackName='T' djNickname='DJ Alpha' duration='3:45' />
+  );
+  expect(screen.getByText(/DJ Alpha/)).toBeTruthy();
+  expect(container.querySelector('[data-testid="now-playing-dj"] svg')).toBeTruthy();
+});
+
+test('djNickname=null 시 DJ 라인(헤드셋 포함) 미렌더', () => {
+  render(<NowPlayingMeta layout='column' trackName='T' djNickname={null} duration='1:00' />);
+  expect(screen.queryByTestId('now-playing-dj')).toBeNull();
+});
+```
+
+기존 트랙명/duration/flex-col·flex-row/parent-token-부재 테스트는 유지(통과해야 함).
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx`
+Expected: FAIL — `now-playing-dj` testid·svg 없음.
+
+- [ ] **Step 3: 구현**
+
+import: `import { TrackTitle } from '@/shared/ui/components/track-title';` · `import { PFHeadset } from '@/shared/ui/icons';` · `import { Typography } from '@/shared/ui/components/typography';`
+
+본문 `<div className={cn('flex', ...)}>` 내부 교체:
+
+```tsx
+<TrackTitle name={trackName} emptyText='' />;
+{
+  djNickname && (
+    <span data-testid='now-playing-dj' className='flex items-center gap-1 text-gray-500 min-w-0'>
+      <PFHeadset width={14} height={14} />
+      <Typography type='caption2' overflow='ellipsis' className='text-gray-500'>
+        {djNickname}
+      </Typography>
+    </span>
+  );
+}
+<Typography type='caption2' className='text-gray-600 shrink-0'>
+  {duration}
+</Typography>;
+```
+
+> `TrackTitle`은 항상 name이 있는 컨텍스트(부모가 `playback` 존재 시에만 렌더)이므로 `emptyText=''`. 트랙명 표시 = `getByText('T')` 그대로 통과(Marquee mock이 children 렌더).
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx`
+Expected: PASS (전체).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
+git commit -m "feat(모바일): now-playing 트랙명 TrackTitle(Galmuri+마퀴) + DJ PFHeadset"
+```
+
+---
+
+### Task 5: 탭바 리스타일 (A1·A4)
+
+이모지 라벨 → PF 아이콘 + `Typography`, 활성 = 레드 + 언더라인 결.
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx`
+- Test: `src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx`
+
+- [ ] **Step 1: 테스트 갱신 (red)**
+
+`큐 라벨 toMatch(/🎧/)` → 헤드셋 svg + 카운트로 갱신, 채팅/크루도 아이콘 단언 추가. 카운트 textContent 단언은 유지:
+
+```tsx
+test('각 탭 PF 아이콘 + 카운트 렌더', () => {
+  render(<TabBar activeTab='chat' crewCount={12} queueCount={4} onTabClick={vi.fn()} />);
+  expect(screen.getByTestId('mobile-tab-chat').querySelector('svg')).toBeTruthy();
+  const crew = screen.getByTestId('mobile-tab-crew');
+  expect(crew.querySelector('svg')).toBeTruthy();
+  expect(crew.textContent).toContain('12');
+  const queue = screen.getByTestId('mobile-tab-queue');
+  expect(queue.querySelector('svg')).toBeTruthy();
+  expect(queue.textContent).toContain('4');
+});
+
+test('활성 탭은 레드 강조 클래스', () => {
+  render(<TabBar activeTab='crew' crewCount={5} queueCount={0} onTabClick={vi.fn()} />);
+  expect(screen.getByTestId('mobile-tab-crew').className).toMatch(/text-red-/);
+});
+```
+
+기존 testid·aria-selected·onTabClick 테스트는 유지. `toMatch(/🎧/)` 단언은 제거(이모지 사라짐).
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx`
+Expected: FAIL — svg 없음 / text-red 없음.
+
+- [ ] **Step 3: 구현**
+
+import: `import { PFChatFilled, PFChatOutline, PFPersonFilled, PFPersonOutline, PFHeadset } from '@/shared/ui/icons';` · `import { Typography } from '@/shared/ui/components/typography';`
+
+`TabButton`을 아이콘+카운트 구조로 변경. `label: string` prop → `icon: ReactNode` + `count?: number` + `text?: string`로 교체. 각 탭은 활성/비활성 아이콘 변형 사용:
+
+```tsx
+const TabBar: FC<Props> = ({ activeTab, crewCount, queueCount, onTabClick }) => (
+  <nav
+    className={cn(
+      'shrink-0 grid grid-cols-3 bg-black border-t border-gray-800',
+      'pb-[env(safe-area-inset-bottom)]'
+    )}
+    role='tablist'
+    aria-label='파티룸 탭'
+  >
+    <TabButton
+      testId='mobile-tab-chat'
+      active={activeTab === 'chat'}
+      icon={
+        activeTab === 'chat' ? (
+          <PFChatFilled width={20} height={20} />
+        ) : (
+          <PFChatOutline width={20} height={20} />
+        )
+      }
+      text='채팅'
+      onClick={() => onTabClick('chat')}
+    />
+    <TabButton
+      testId='mobile-tab-crew'
+      active={activeTab === 'crew'}
+      icon={
+        activeTab === 'crew' ? (
+          <PFPersonFilled width={20} height={20} />
+        ) : (
+          <PFPersonOutline width={20} height={20} />
+        )
+      }
+      count={crewCount}
+      onClick={() => onTabClick('crew')}
+    />
+    <TabButton
+      testId='mobile-tab-queue'
+      active={activeTab === 'queue'}
+      icon={<PFHeadset width={20} height={20} />}
+      count={queueCount}
+      onClick={() => onTabClick('queue')}
+    />
+  </nav>
+);
+
+interface TabButtonProps {
+  testId: string;
+  active: boolean;
+  icon: ReactNode;
+  text?: string;
+  count?: number;
+  onClick: () => void;
+}
+
+const TabButton: FC<TabButtonProps> = ({ testId, active, icon, text, count, onClick }) => (
+  <button
+    type='button'
+    data-testid={testId}
+    role='tab'
+    aria-selected={active}
+    className={cn(
+      'min-h-[44px] py-2 flex flex-col items-center justify-center gap-0.5',
+      'border-t-2',
+      active ? 'text-red-400 border-red-400' : 'text-gray-400 border-transparent'
+    )}
+    onClick={onClick}
+  >
+    {icon}
+    <Typography type='caption2' className='leading-none'>
+      {text ?? count}
+    </Typography>
+  </button>
+);
+```
+
+(import `ReactNode` from 'react'. 활성 언더라인은 상단 border-t-2 레드로 구현 — 탭바가 하단 고정이라 상단 강조선이 자연스러움.)
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `yarn test src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx`
+Expected: PASS (전체).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx
+git commit -m "feat(모바일): 탭바 PF 아이콘 + Typography + 활성 레드 강조(이모지 제거)"
+```
+
+---
+
+### Task 6: 채팅 패널 크롬/여백 정합 (A5)
+
+채팅 패널은 이미 Typography·PFSend 사용. 여백 리듬만 기준값으로 정합(가로 `px-5`, 메시지 간격 일관).
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-chat-panel/partyroom-chat-panel.component.tsx` (필요 시 `ui/parts/chat-item.component.tsx`)
+- Test: 동일 디렉터리 기존 `*.test.tsx` (있으면)
+
+- [ ] **Step 1: 현재 여백 확인** — `partyroom-chat-panel.component.tsx`의 `px-3`/`py-4` 등을 읽고 기준값(`px-5`)과의 차이 식별. (시각 변경만이라 테스트 단언 추가는 선택)
+- [ ] **Step 2: 여백 클래스 정합** — 메시지 리스트/입력 영역 가로 패딩을 `px-5`로 통일. 색·구조 불변.
+- [ ] **Step 3: 회귀 확인** — `yarn test src/widgets-mobile/partyroom-chat-panel` Expected: PASS (기존 동작 불변).
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/widgets-mobile/partyroom-chat-panel
+git commit -m "style(모바일): 채팅 패널 여백 리듬 정합(px-5)"
+```
+
+---
+
+### Chunk 2 검증 게이트 (Room 단계)
+
+- [ ] `yarn test` 전체 GREEN · `yarn test:type` · `yarn lint` 클린
+- [ ] **로컬 풀스택 e2e 스크린샷 실측** — backend docker(:8080) + `npx next dev`(:3000) 기동 후
+      `E2E_BASE_URL=http://localhost:3000 E2E_API_BASE=http://localhost:8080/api/ node scripts/capture-mobile-screens.mjs`
+      로 룸 화면 캡처. 변경 전/후 비교(헤더·now-playing·탭바). 참조: `[[reference_pfplay_web_local_e2e_run]]`, `[[reference_pfplay_web_local_dev_http_webpack]]`(yarn dev 금지).
+- [ ] **데스크탑 회귀 스크린샷** — 데스크탑 룸 화면 캡처해 VideoTitle 렌더 불변 육안 확인.
+- [ ] plan-document-reviewer 통과 후 다음 Chunk (실행 시)
+
+---
+
+## Chunk 3: Lobby · Sheets · Search 적용
+
+### Task 7: 로비 리스트/카드 여백·썸네일 정합 (A1·A5)
+
+**Files:**
+
+- Modify: `src/features-mobile/partyroom/list/partyroom-card.component.tsx`, `partyroom-list.component.tsx`, `src/features-mobile/partyroom/create/ui/card.component.tsx`
+- Test: 동일 디렉터리 기존 `*.test.tsx`
+
+- [ ] **Step 1: 현재 카드 구조/여백 확인** — partyroom-card는 이미 Typography·BackdropBlurContainer 사용(보존). 갭/패딩을 기준값으로 정합.
+- [ ] **Step 2: 여백 리듬 정합** — 리스트 `gap`/카드 내부 패딩을 기준값(`px-5`/`gap-3`)으로 통일. 썸네일 비율은 스크린샷 보며 데스크탑 비례에 맞춤(예: 64×36→80×44, 화면 확인 후 확정).
+- [ ] **Step 3: 회귀 확인** — `yarn test src/features-mobile/partyroom` Expected: PASS.
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/features-mobile/partyroom
+git commit -m "style(모바일): 로비 리스트/카드 여백 리듬·썸네일 비율 정합"
+```
+
+---
+
+### Task 8: DJ/플레이리스트 시트 헤더·여백 정합 (A3·A5)
+
+fullscreen-sheet는 Task 2에서 `MobileSheetHeader` 채택 완료. 시트 본문 리스트(playlists-management / playlist-detail)의 여백 리듬만 정합.
+
+**Files:**
+
+- Modify: `src/widgets-mobile/partyroom-djing-sheet/ui/playlists-management-sheet.component.tsx`, `playlist-detail-sheet.component.tsx`
+- Test: 동일 디렉터리 기존 `*.test.tsx`
+
+- [ ] **Step 1: 현재 리스트 여백 확인** — `px-4 py-4`/`divide-gray-800` 등 확인.
+- [ ] **Step 2: 여백 정합** — 리스트 행 패딩을 기준값(`px-5 py-3`)으로 통일. divide/색 불변.
+- [ ] **Step 3: 회귀 확인** — `yarn test src/widgets-mobile/partyroom-djing-sheet` Expected: PASS.
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/widgets-mobile/partyroom-djing-sheet
+git commit -m "style(모바일): DJ/플레이리스트 시트 리스트 여백 리듬 정합"
+```
+
+---
+
+### Task 9: 검색 리스트 아이콘·여백 정합 (A1·A5)
+
+ASCII ▶/+ → `PFPlayCircleFilled`/`PFAdd`.
+
+**Files:**
+
+- Modify: `src/features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx` (필요 시 `music-search.component.tsx`)
+- Test: `src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx`
+
+> ⚠️ 이 파일은 #394의 1차 수정(썸네일 추가, 커밋 `6694c6b`)도 건드림. **현 development 기준엔 썸네일 없음** — 최종 머지 시 충돌 가능(Chunk 4 게이트 R-merge 참조). 본 Task는 development 기준 현 구조(썸네일 없음)에 PF 아이콘 적용.
+
+- [ ] **Step 1: 테스트 갱신 (red)** — 기존 testid(`search-item-preview-*`/`search-item-add-*`)·onPreview/onAdd/disabled 콜백 테스트는 유지. ▶/+ 텍스트 대신 아이콘 svg 존재 단언 추가:
+
+```tsx
+test('미리듣기/추가 버튼에 PF 아이콘 렌더', () => {
+  render(
+    <SearchListItem music={TRACK as never} onPreview={vi.fn()} onAdd={vi.fn()} addPending={false} />
+  );
+  expect(screen.getByTestId('search-item-preview-abc123').querySelector('svg')).toBeTruthy();
+  expect(screen.getByTestId('search-item-add-abc123').querySelector('svg')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: 실패 확인** — `yarn test src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx` Expected: FAIL(svg 없음).
+- [ ] **Step 3: 구현** — import `{ PFPlayCircleFilled, PFAdd } from '@/shared/ui/icons'`. `TextButton` children `▶`→`<PFPlayCircleFilled width={20} height={20} />`, `+`→`<PFAdd width={20} height={20} />`. aria-label·testid·disabled 유지. 행 패딩 `px-5`로.
+- [ ] **Step 4: 통과 확인** — Expected: PASS.
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx
+git commit -m "feat(모바일): 검색 리스트 ASCII ▶/+ → PFPlayCircleFilled/PFAdd + 여백 정합"
+```
+
+---
+
+### Chunk 3 검증 게이트
+
+- [ ] `yarn test` 전체 GREEN · `yarn test:type` · `yarn lint` 클린
+- [ ] 로컬 풀스택 e2e 스크린샷(로비·시트·검색) 변경 전/후 비교
+- [ ] plan-document-reviewer 통과 후 마감 (실행 시)
+
+---
+
+## Chunk 4: 마감 & 최종 검증
+
+### Task 10: 전체 회귀 + 스크린샷 일괄 + 정리
+
+- [ ] **Step 1: 전체 단위 테스트** — `yarn test` Expected: 전체 GREEN.
+- [ ] **Step 2: 타입** — `yarn test:type` Expected: 0.
+- [ ] **Step 3: 린트** — `yarn lint` Expected: 0.
+- [ ] **Step 4: 모바일 전체 스크린샷 재캡처** — `node scripts/capture-mobile-screens.mjs`(풀스택 기동 상태). 전 화면(룸·로비·시트·검색) 데스크탑 디자인 언어 정합 육안 확인.
+- [ ] **Step 5: 데스크탑 회귀 육안** — 데스크탑 룸 전광판(VideoTitle) 렌더 불변 확인(Task 1 위임의 최종 증명).
+- [ ] **Step 6: 스크린샷/스크립트 산출물 처리** — `mobile-screenshots/`·`.zip`은 .gitignore 추가(대용량 바이너리, 외주용). `scripts/capture-*.mjs`는 검증 도구로 커밋:
+
+```bash
+# .gitignore 에 mobile-screenshots/ 및 mobile-screenshots.zip 추가
+git add .gitignore scripts/capture-mobile-screens.mjs scripts/capture-fixes.mjs scripts/capture-supplement.mjs
+git commit -m "chore(모바일): 모바일 캡처 스크립트 추가 + 스크린샷 산출물 gitignore"
+```
+
+- [ ] **Step 7: 최종 커밋/정리** — 잔여 미커밋 없는지 `git status` 확인.
+
+---
+
+## 미해결 → 후속 (스펙 R 항목)
+
+- **R-merge (search-list-item·partyroom-display-board 충돌):** #394와 본 브랜치가 같은 파일 일부를 건드림. **#394 머지 후** 본 브랜치를 development(머지 반영) 위로 rebase하고 겹치는 파일 충돌을 양쪽 보존으로 해소(썸네일 + PF 아이콘 둘 다). dev 머지 = 사용자 게이트.
+- **프로필 폼 A5 (R1):** `features-mobile/profile/mobile-profile-edit-form`은 #394에서 생기는 파일 → #394 머지 후 후속 작업으로 라벨 Typography·여백 정합.
+- **prod 배포 안 함** — dev 머지조차 사용자 게이트.
+
+---
+
+## 실행 핸드오프
+
+저장 위치: `docs/superpowers/plans/2026-06-09-mobile-design-language-alignment.md`
+
+**실행:** subagent 사용 가능 환경이면 superpowers:subagent-driven-development (Task별 fresh subagent + 2단계 리뷰). 각 Chunk 경계에서 검증 게이트 통과 후 다음 진행.

--- a/docs/superpowers/plans/2026-06-09-mobile-design-language-alignment.md
+++ b/docs/superpowers/plans/2026-06-09-mobile-design-language-alignment.md
@@ -371,21 +371,21 @@ git commit -m "feat(ui): MobileSheetHeader 공용 컴포넌트 + fullscreen-shee
 
 `partyroom-display-board.component.test.tsx`에 추가(또는 기존 헤더 단언 갱신). 뒤로 버튼은 `aria-label='뒤로'` 유지, 메뉴는 `aria-label='메뉴'` 유지. PF 아이콘 SVG 존재 단언:
 
+⚠️ 이 테스트 파일은 이미 모듈 레벨 `mockPush`를 가짐(`vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))`, `beforeEach`에서 clear). **로컬 `const push = vi.fn()` 만들지 말 것** — 라우터에 안 엮여 단언 실패. 기존 `mockPush`를 그대로 단언:
+
 ```tsx
 test('헤더: 뒤로 버튼 클릭 시 /parties 라우팅 + PF 아이콘 렌더', () => {
-  const push = vi.fn();
-  // 기존 next/navigation useRouter mock 의 push 를 캡처 (기존 패턴 따름)
-  // ... render(<MobilePartyroomDisplayBoard partyroomId={1} />)
+  render(<MobilePartyroomDisplayBoard partyroomId={1} />);
   const back = screen.getByRole('button', { name: '뒤로' });
   expect(back.querySelector('svg')).toBeTruthy(); // PFArrowLeft
   fireEvent.click(back);
-  expect(push).toHaveBeenCalledWith('/parties');
+  expect(mockPush).toHaveBeenCalledWith('/parties');
   const menu = screen.getByRole('button', { name: '메뉴' });
   expect(menu.querySelector('svg')).toBeTruthy(); // PFMoreVert
 });
 ```
 
-> 기존 테스트 파일의 mock 셋업(react-player, next/navigation, stores)을 그대로 재사용. push mock 캡처 방식은 파일 상단 기존 패턴을 따른다.
+> 기존 테스트 파일의 mock 셋업(react-player, next/navigation `mockPush`, stores)을 그대로 재사용. render 전 `detailSummary` 타이틀이 필요하면 기존 파일의 stores/summary mock 패턴을 따른다.
 
 - [ ] **Step 2: 실패 확인**
 
@@ -448,9 +448,11 @@ git commit -m "feat(모바일): 룸 헤더 MobileSheetHeader + PF 아이콘(←/
 
 - [ ] **Step 1: 테스트 갱신 (red)**
 
-상단에 marquee 모킹 추가(TrackTitle 내부 Marquee 때문):
+상단에 marquee 모킹 추가(TrackTitle 내부 Marquee 때문). ⚠️ 이 테스트 파일은 React를 import하지 않으므로 mock에서 `React.ReactNode`를 쓰면 `yarn test:type`이 `Cannot find name 'React'`로 실패 → **파일 최상단에 `import React from 'react';` 추가**(또는 타입을 `import('react').ReactNode`로):
 
 ```tsx
+import React from 'react'; // ← 파일 상단 import 블록에 추가 (mock 타입 참조용)
+
 vi.mock('react-fast-marquee', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -699,7 +701,7 @@ git commit -m "style(모바일): 채팅 패널 여백 리듬 정합(px-5)"
 - Test: 동일 디렉터리 기존 `*.test.tsx`
 
 - [ ] **Step 1: 현재 카드 구조/여백 확인** — partyroom-card는 이미 Typography·BackdropBlurContainer 사용(보존). 갭/패딩을 기준값으로 정합.
-- [ ] **Step 2: 여백 리듬 정합** — 리스트 `gap`/카드 내부 패딩을 기준값(`px-5`/`gap-3`)으로 통일. 썸네일 비율은 스크린샷 보며 데스크탑 비례에 맞춤(예: 64×36→80×44, 화면 확인 후 확정).
+- [ ] **Step 2: 여백 리듬 정합** — 리스트 `gap`/카드 내부 패딩을 기준값(`px-5`/`gap-3`)으로 통일. 썸네일 비율은 스크린샷 보며 데스크탑 비례에 맞춤(예: 64×36→80×44, 화면 확인 후 확정). ⚠️ 썸네일 변경 시 **래퍼 클래스(`w-[64px] h-[36px]`)와 `next/image`의 `width`/`height` props를 동반 수정**(불일치 시 왜곡/경고). 둘 다 같은 값으로.
 - [ ] **Step 3: 회귀 확인** — `yarn test src/features-mobile/partyroom` Expected: PASS.
 - [ ] **Step 4: 커밋**
 
@@ -721,12 +723,13 @@ fullscreen-sheet는 Task 2에서 `MobileSheetHeader` 채택 완료. 시트 본�
 
 - [ ] **Step 1: 현재 리스트 여백 확인** — `px-4 py-4`/`divide-gray-800` 등 확인.
 - [ ] **Step 2: 여백 정합** — 리스트 행 패딩을 기준값(`px-5 py-3`)으로 통일. divide/색 불변.
-- [ ] **Step 3: 회귀 확인** — `yarn test src/widgets-mobile/partyroom-djing-sheet` Expected: PASS.
-- [ ] **Step 4: 커밋**
+- [ ] **Step 3: 잔여 ASCII 글리프 처리 (A1)** — `playlist-detail-sheet.component.tsx`의 곡 제거 버튼 raw `×`(약 59행)를 `PFClose`로 교체(import `{ PFClose } from '@/shared/ui/icons'`, `<PFClose width={20} height={20} />`). 기존 onClick·aria-label·testid 유지. 해당 버튼 테스트가 텍스트 `×`를 단언하면 svg 존재로 갱신(red→green).
+- [ ] **Step 4: 회귀 확인** — `yarn test src/widgets-mobile/partyroom-djing-sheet` Expected: PASS.
+- [ ] **Step 5: 커밋**
 
 ```bash
 git add src/widgets-mobile/partyroom-djing-sheet
-git commit -m "style(모바일): DJ/플레이리스트 시트 리스트 여백 리듬 정합"
+git commit -m "style(모바일): DJ/플레이리스트 시트 여백 리듬 정합 + 곡 제거 × → PFClose"
 ```
 
 ---
@@ -755,7 +758,26 @@ test('미리듣기/추가 버튼에 PF 아이콘 렌더', () => {
 ```
 
 - [ ] **Step 2: 실패 확인** — `yarn test src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx` Expected: FAIL(svg 없음).
-- [ ] **Step 3: 구현** — import `{ PFPlayCircleFilled, PFAdd } from '@/shared/ui/icons'`. `TextButton` children `▶`→`<PFPlayCircleFilled width={20} height={20} />`, `+`→`<PFAdd width={20} height={20} />`. aria-label·testid·disabled 유지. 행 패딩 `px-5`로.
+- [ ] **Step 3: 구현** — import `{ PFPlayCircleFilled, PFAdd } from '@/shared/ui/icons'`. ⚠️ `TextButton`은 `children?: string`(내부에서 Typography로 래핑)이라 **React 엘리먼트를 children으로 넘기면 tsc 실패** — 아이콘은 반드시 `Icon` prop으로(children 제거). 아이콘은 직접 렌더됨(Typography 래핑 안 함):
+
+```tsx
+<TextButton
+  data-testid={`search-item-preview-${music.videoId}`}
+  onClick={() => onPreview(music)}
+  aria-label={`${music.videoTitle} 미리듣기`}
+  Icon={<PFPlayCircleFilled width={20} height={20} />}
+/>
+<TextButton
+  data-testid={`search-item-add-${music.videoId}`}
+  onClick={() => onAdd(music)}
+  disabled={addPending}
+  aria-label={`${music.videoTitle} 추가`}
+  Icon={<PFAdd width={20} height={20} />}
+/>
+```
+
+aria-label·testid·disabled 유지. 행 패딩 `px-5`로.
+
 - [ ] **Step 4: 통과 확인** — Expected: PASS.
 - [ ] **Step 5: 커밋**
 

--- a/docs/superpowers/specs/2026-06-09-mobile-design-language-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-design-language-alignment-design.md
@@ -38,8 +38,8 @@ pfplay-web의 모바일 웹 뷰(`src/widgets-mobile/`, `src/features-mobile/`)�
 
 실측(2026-06-09) 기준:
 
-1. **탭바** `widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx` — 이모지(💬 📥 🎧) + raw 텍스트 라벨, PF 아이콘 없음
-2. **now-playing** `widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx` — 트랙명 raw `<p>`(text-base font-semibold), DJ는 🎧 이모지 + xs 텍스트. 데스크탑은 Galmuri 세리프 + 마퀴
+1. **탭바** `widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx` — 3버튼 `💬 채팅` / `👥 {crewCount}` / `🎧 {queueCount}`, 이모지 프리픽스 + raw 텍스트 라벨, PF 아이콘 없음
+2. **now-playing** `widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx` — **prop 구동**(`trackName`/`djNickname`/`duration` props, parent 책임). 트랙명 raw `<p>`(text-base font-semibold), DJ는 🎧 이모지 + xs 텍스트. 데스크탑 `VideoTitle`은 Galmuri + 마퀴(스토어 직독)
 3. **룸 헤더** `widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx:60-77` — ASCII ←/⋮ raw 텍스트, `<h1>` raw
 4. **검색 리스트** `features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx` — ASCII ▶ / [+] TextButton, 아이콘 없음
 5. **시트 헤더** `widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx` — **이미 `PFArrowLeft`/`PFClose` 사용**(모바일 유일 PF 적용처). 타이틀은 raw `<h2>`. → 이 패턴을 표준 컴포넌트로 승격
@@ -57,9 +57,10 @@ pfplay-web의 모바일 웹 뷰(`src/widgets-mobile/`, `src/features-mobile/`)�
 ### A1 — 아이콘 일괄 교체 (이모지/ASCII → PF)
 
 - 탭바·헤더·시트·검색의 이모지/raw 글리프를 기존 PF 컴포넌트로 교체.
-- 매핑: 💬→`PFChatFilled`/`PFChatOutline`, 📥→`PFPlaylistAdd`, 🎧→`PFHeadset`,
-  ←→`PFArrowLeft`, ⋮→`PFMoreVert`, ▶→`PFPlayCircleFilled`, [+]→`PFAdd`, ✕→`PFClose`.
-- 전부 `src/shared/ui/icons/`에 존재 확인됨. 신규 제작 0.
+- 매핑: 💬(탭 채팅)→`PFChatFilled`/`PFChatOutline`, 👥(탭 크루)→`PFPersonFilled`/`PFPersonOutline`,
+  🎧(탭 큐)→`PFHeadset`, ←→`PFArrowLeft`, ⋮→`PFMoreVert`, ▶(검색 재생)→`PFPlayCircleFilled`,
+  [+](검색 추가)→`PFAdd`, ✕→`PFClose`. (🎧 now-playing DJ 프리픽스도 `PFHeadset`)
+- 전부 `src/shared/ui/icons/`에 존재 확인됨. 신규 제작 0. (📥/`PFPlaylistAdd`는 현재 탭바에 없음 — 매핑 제외)
 
 ### A2 — `TrackTitle` 공용 컴포넌트 (Galmuri + 마퀴)
 
@@ -67,11 +68,14 @@ pfplay-web의 모바일 웹 뷰(`src/widgets-mobile/`, `src/features-mobile/`)�
   **프레젠테이션**(`Marquee delay=4 speed=20 gradientWidth=0` + `Typography type='body3'`
   - `cn(galmuriFont.className, 'text-white leading-none')`, empty 시 `caption1`)을
     `src/shared/ui/components/track-title/`로 추출한다.
-- **데스크탑 렌더 불변 보장 방식**: `TrackTitle`은 순수 프레젠테이션(props: `name?: string`, `emptyText: string`,
-  `data-testid` 등). 데스크탑 `VideoTitle`은 **스토어 와이어링과 i18n을 그대로 유지**한 채
-  `TrackTitle`에 위임 → DOM/클래스 바이트 동일. 기존 `video-title` 테스트가 회귀 가드.
-- 모바일 `now-playing-meta`도 동일 스토어(`useCurrentPartyroom().playback`)를 쓰므로
-  `TrackTitle`을 동일하게 붙인다.
+- **데스크탑 렌더 불변 보장 방식**: `TrackTitle`은 순수 프레젠테이션(props: `name?: string`, `emptyText: string`).
+  데스크탑 `VideoTitle`은 **스토어 와이어링과 i18n을 그대로 유지**한 채 `TrackTitle`에 위임 → DOM/클래스 바이트 동일.
+  기존 `video-title` 테스트가 회귀 가드.
+- **양 분기 모두 보존 필수**: filled = `Marquee className='z-0'` 안 `Typography type='body3'` + `data-testid='video-title'`,
+  empty = `Typography type='caption1'` + `data-testid='video-title-empty'`. 두 `data-testid`가 다르므로
+  `TrackTitle`이 분기별 testid를 그대로 출력해야 기존 데스크탑 테스트가 무수정 통과.
+- 모바일 `now-playing-meta`는 **prop 구동**(스토어 직독 아님)이므로 `TrackTitle name={trackName}`로
+  연결한다(데스크탑처럼 스토어로 재배선하지 않음 — prop 형태 유지). 결과 비주얼은 동일.
 
 ### A3 — `MobileSheetHeader` / 룸 헤더 표준화
 

--- a/docs/superpowers/specs/2026-06-09-mobile-design-language-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-design-language-alignment-design.md
@@ -1,0 +1,157 @@
+# 모바일 디자인 언어 통일 (Mobile Design-Language Alignment) — 설계
+
+- 날짜: 2026-06-09
+- 상태: 설계 확정 대기 (brainstorming 산출물)
+- 레포: `pfplay-web`
+- 관련: 모바일 반응형 chunk 1~6 (#340 계열), 모바일 강제 프로필 온보딩 (#394, 별개 PR)
+
+## 1. 목표
+
+pfplay-web의 모바일 웹 뷰(`src/widgets-mobile/`, `src/features-mobile/`)를
+데스크탑(브라우저) 버전의 **시각 디자인 언어**로 통일한다. 사용자가 웹과 모바일을
+오갈 때 "같은 서비스"라는 일관된 인상을 받도록, 모바일에 남아 있는 기능적 축소판
+느낌(이모지/ASCII 아이콘, raw `<p>`, 비례 없는 빡빡한 여백)을 데스크탑의
+정제된 비주얼(PF 아이콘 · Galmuri 타이포 · 마퀴 · 패널 크롬 · 여백 리듬)로 끌어올린다.
+
+## 2. 비목표 (Non-goals)
+
+- **레이아웃 재설계 아님.** 데스크탑 룸은 시네마 레이아웃(중앙 전광판 + 좌 사이드바 +
+  우 400px 채팅 패널)이라 폰에 그대로 못 올린다. 모바일은 **네이티브 레이아웃(탭·시트)을 유지**하고,
+  옮기는 것은 **시각 언어(아이콘·타이포·색·크롬·여백)뿐**이다.
+- **데스크탑 동작/렌더 변경 아님.** 공용 프리미티브는 재사용/추가만. 데스크탑 출력은 불변.
+- **신규 기능 아님.** 새 화면/플로우/엔드포인트 없음. 순수 시각 리터치.
+- **prod 배포 아님.** dev 머지조차 사용자 게이트.
+- **신규 아이콘 제작 아님.** 필요한 PF 글리프는 전부 `src/shared/ui/icons/`에 이미 존재.
+
+## 3. 잠긴 결정 (brainstorming)
+
+| #   | 결정                                                                                            | 근거                             |
+| --- | ----------------------------------------------------------------------------------------------- | -------------------------------- |
+| D1  | 충실도 = **디자인 언어만 이식**, 레이아웃은 모바일 네이티브 유지                                | 시네마 레이아웃은 폰 폭에 부적합 |
+| D2  | 범위 = **전 화면 홀리스틱 리터치** (룸·로비·시트·검색·폼)                                       | 사용자 "전부 다 리터치"          |
+| D3  | 시그니처 요소 **전부 채택**: ①PF 아이콘 ②Galmuri 타이포 ③긴 제목 마퀴 ④패널 크롬 + 여백·색 정합 | 데스크탑 정체성                  |
+| D4  | 실행 = **얇은 모바일 비주얼 킷(A1~A5) + 단계적 적용** (Room→Lobby→Sheets→Forms)                 | 위험 분산, 단계별 실측           |
+| D5  | 여백 = 데스크탑 px 복사 ❌, **같은 비율을 모바일 폭에 맞게 환산**                               | 폭이 다름                        |
+| D6  | 데스크탑 렌더 불변, 단위테스트 GREEN + 로컬 풀스택 e2e 스크린샷, prod 배포 안 함                | 표준 게이트                      |
+
+## 4. 현재 상태 (갭, 시각 영향 순)
+
+실측(2026-06-09) 기준:
+
+1. **탭바** `widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx` — 이모지(💬 📥 🎧) + raw 텍스트 라벨, PF 아이콘 없음
+2. **now-playing** `widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx` — 트랙명 raw `<p>`(text-base font-semibold), DJ는 🎧 이모지 + xs 텍스트. 데스크탑은 Galmuri 세리프 + 마퀴
+3. **룸 헤더** `widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx:60-77` — ASCII ←/⋮ raw 텍스트, `<h1>` raw
+4. **검색 리스트** `features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx` — ASCII ▶ / [+] TextButton, 아이콘 없음
+5. **시트 헤더** `widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx` — **이미 `PFArrowLeft`/`PFClose` 사용**(모바일 유일 PF 적용처). 타이틀은 raw `<h2>`. → 이 패턴을 표준 컴포넌트로 승격
+6. **여백** 전반적으로 비례 없이 빡빡 (px-3~4 / gap-3 vs 데스크탑 px-7/py-6/gap-24의 비례)
+7. **로비 카드** `features-mobile/partyroom/list/partyroom-card.component.tsx` — 일부 Typography 사용(유지), 썸네일 비율·여백 정합 대상
+
+> 요지: 모바일 = 데스크탑 디자인 언어가 벗겨진 "기능적 축소판".
+
+## 5. 섹션 A — 모바일 비주얼 킷
+
+데스크탑 시각 언어를 모바일에 이식하는 **얇은 공용 레이어**. 전부 "추가 또는 재사용",
+데스크탑 렌더 불변. 신규 공용 컴포넌트는 `src/shared/ui/components/<name>/`에
+(`index.ts` + `<name>.component.tsx` + `<name>.component.test.tsx`) 패턴으로 둔다.
+
+### A1 — 아이콘 일괄 교체 (이모지/ASCII → PF)
+
+- 탭바·헤더·시트·검색의 이모지/raw 글리프를 기존 PF 컴포넌트로 교체.
+- 매핑: 💬→`PFChatFilled`/`PFChatOutline`, 📥→`PFPlaylistAdd`, 🎧→`PFHeadset`,
+  ←→`PFArrowLeft`, ⋮→`PFMoreVert`, ▶→`PFPlayCircleFilled`, [+]→`PFAdd`, ✕→`PFClose`.
+- 전부 `src/shared/ui/icons/`에 존재 확인됨. 신규 제작 0.
+
+### A2 — `TrackTitle` 공용 컴포넌트 (Galmuri + 마퀴)
+
+- 데스크탑 `widgets/partyroom-display-board/ui/parts/video-title.component.tsx`의
+  **프레젠테이션**(`Marquee delay=4 speed=20 gradientWidth=0` + `Typography type='body3'`
+  - `cn(galmuriFont.className, 'text-white leading-none')`, empty 시 `caption1`)을
+    `src/shared/ui/components/track-title/`로 추출한다.
+- **데스크탑 렌더 불변 보장 방식**: `TrackTitle`은 순수 프레젠테이션(props: `name?: string`, `emptyText: string`,
+  `data-testid` 등). 데스크탑 `VideoTitle`은 **스토어 와이어링과 i18n을 그대로 유지**한 채
+  `TrackTitle`에 위임 → DOM/클래스 바이트 동일. 기존 `video-title` 테스트가 회귀 가드.
+- 모바일 `now-playing-meta`도 동일 스토어(`useCurrentPartyroom().playback`)를 쓰므로
+  `TrackTitle`을 동일하게 붙인다.
+
+### A3 — `MobileSheetHeader` / 룸 헤더 표준화
+
+- 시트·룸 상단 헤더 표준 컴포넌트: 좌측 leading 슬롯(`PFArrowLeft`|`PFClose`),
+  중앙 `Typography` 타이틀, 우측 trailing 슬롯(`PFMoreVert` 등).
+- **기준 패턴 = 이미 존재하는 `fullscreen-sheet`의 헤더**(PF 아이콘 + `h-[56px]` +
+  `border-b border-gray-800`). 이를 컴포넌트로 승격해 룸 디스플레이보드 헤더와 통일.
+- 위치: `src/shared/ui/components/mobile-sheet-header/` (모바일 전용이나 공용 디렉터리 컨벤션 따름).
+
+### A4 — `MobileTabBar` 리스타일
+
+- PF 아이콘 + `Typography` 라벨. 활성 = 레드 강조 + 언더라인 결(데스크탑 강조 체계),
+  비활성 = `text-gray-400`. iOS HIG(`min-h-[44px]`, `pb-[env(safe-area-inset-bottom)]`) 유지.
+- 기존 `tab-bar.component.tsx`를 리스타일(구조 유지, 시각만 교체).
+
+### A5 — 패널 크롬 토큰 + 여백 리듬
+
+- 데스크탑 패널 프레이밍(`bg-black` + `border border-gray-800` + 라운드/프레이밍)과
+  모바일 여백 리듬을 정합. raw `<p>` → `Typography` 정리.
+- 여백은 px 복사가 아니라 **비율 환산**(D5). 모바일 표준 리듬을 정의(예: 컨테이너 가로
+  `px-app`, 섹션 간 `gap`/`py`를 데스크탑 비례에 맞춰 한 벌로 통일). Tailwind 네이티브 클래스 사용
+  (theme는 색만 토큰, 여백은 native scale).
+
+## 6. 섹션 B — 화면별 적용
+
+| 화면                 | 파일                                                                                   | 적용 킷 | 변경                                                          |
+| -------------------- | -------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------- |
+| 탭바                 | `widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx`                    | A1·A4   | 이모지→PF, raw→Typography, 활성 레드+언더라인                 |
+| 룸 헤더              | `widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx`         | A1·A3   | ASCII ←/⋮→PF, `<h1>`→Typography, `MobileSheetHeader` 적용     |
+| now-playing          | `widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx`       | A1·A2   | 트랙명→`TrackTitle`, 🎧→`PFHeadset`                           |
+| 채팅 패널            | `widgets-mobile/partyroom-chat-panel/**`                                               | A5      | 크롬/여백 정합(이미 Typography·PFSend 사용분 유지)            |
+| 로비 리스트/카드     | `features-mobile/partyroom/list/*`, `create/ui/card.component.tsx`                     | A1·A5   | 썸네일 비율·여백 리듬·카드 크롬                               |
+| DJ/플레이리스트 시트 | `widgets-mobile/partyroom-djing-sheet/ui/*`                                            | A3·A5   | 헤더 `MobileSheetHeader` 추출 적용(기존 PF 보존), 리스트 여백 |
+| add-tracks 검색      | `features-mobile/playlist/add-tracks/ui/{music-search,search-list-item}.component.tsx` | A1·A5   | ASCII ▶/[+]→PF, 여백 정합                                    |
+| 폼                   | `features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`                    | A5      | 라벨 Typography·여백 리듬(기능 불변)                          |
+
+## 7. 섹션 C — 단계 & 검증
+
+### 단계
+
+1. **킷 우선** — A1~A5 공용 컴포넌트/토큰 추가. 데스크탑 영향 0 (단, A2는 데스크탑
+   `VideoTitle` → `TrackTitle` 위임 추출이라 기존 테스트로 렌더 불변 검증).
+2. **Room → Lobby → Sheets → Forms** 순으로 단계 적용.
+3. 각 단계마다: co-located vitest GREEN + 로컬 풀스택 e2e 스크린샷 실측.
+
+### 검증 게이트 (각 단계 + 최종)
+
+- `yarn test` (vitest, co-located `*.test.tsx`) 전부 GREEN
+- `yarn test:type` (tsc --noEmit) 클린
+- lint 클린
+- **데스크탑 회귀**: A2 등 공용 추출분은 데스크탑 화면 스크린샷 전/후 대조로 렌더 불변 확인
+- **모바일 실측**: `scripts/capture-mobile-screens.mjs`로 단계별 스크린샷(iPhone13 컨텍스트),
+  변경 전/후 시각 비교
+- 로컬 풀스택 e2e: backend docker(:8080) + `npx next dev`(:3000) — `[[reference_pfplay_web_local_e2e_run]]`,
+  `[[reference_pfplay_web_local_dev_http_webpack]]` (yarn dev 금지)
+- 최종: dev 머지 = **사용자 게이트**, prod 배포 안 함
+
+### 테스트 전략
+
+- 신규 공용 컴포넌트(`TrackTitle`/`MobileSheetHeader`/`MobileTabBar`)는 co-located vitest로
+  렌더·prop·접근성(아이콘 aria/label) 단위 테스트.
+- 기존 데스크탑 `video-title` 테스트는 A2 추출의 회귀 가드로 유지(수정 없이 통과해야 함).
+- 시각 자체는 자동 단언 불가 → 스크린샷 실측이 1차 검증(스냅샷 테스트는 도입하지 않음, 노이즈 큼).
+
+## 8. 위험 & 미해결 (구현/플랜 단계에서 결정)
+
+- **R1 브랜치 전략**: 현재 워킹트리는 `feature/mobile-profile-onboarding-393`(PR #394, 별개 관심사,
+  dev 머지 대기) 위에 미커밋 1차 수정(모바일 폼 오버플로우/썸네일/버튼 중앙 7파일)이 얹혀 있음.
+  디자인 리터치는 **별개 feature 브랜치를 origin/develop에서 분기**해야 한다
+  (`[[feedback_branch_from_origin_develop]]`). → **플랜 단계 첫 결정**: 1차 수정의 귀속
+  (#394에 합칠지 / 디자인 브랜치로 가져올지 / 별도 처리)과 새 브랜치 분기를 확정.
+- **R2 A2 렌더 불변**: 데스크탑 `VideoTitle` 추출 시 클래스/DOM 한 글자라도 바뀌면 안 됨.
+  추출은 "프레젠테이션만 분리 + 데스크탑은 위임" 형태로 제한.
+- **R3 여백 비율 환산(D5)**: "같은 비율"의 구체 수치는 화면별 실측 스크린샷 보며 조정.
+  플랜에서 모바일 표준 리듬 1벌을 먼저 정의하고 화면에 적용.
+- **R4 i18n**: 라벨을 raw 텍스트→Typography로 옮길 때 기존 i18n 키 유지(드리프트 금지,
+  `[[feedback_pfplay_web_i18n_drift]]`).
+
+## 9. 영향 받는 주요 경로 (요약)
+
+- 신규: `src/shared/ui/components/{track-title,mobile-sheet-header,mobile-tab-bar}/`
+- 수정(데스크탑, 렌더 불변): `src/widgets/partyroom-display-board/ui/parts/video-title.component.tsx`
+- 수정(모바일): 섹션 B 표의 파일들

--- a/scripts/capture-fixes.mjs
+++ b/scripts/capture-fixes.mjs
@@ -1,0 +1,186 @@
+// 수정 반영 재캡처: 폼 오버플로우 fix(07/19) + 썸네일(15) + 트랙 추가 후 상세(13) +
+// 등록된 DJ 상태 큐 탭(10) + 중앙정렬 액션버튼(08/09/10) + 선택 시트(16) + 플리관리(11).
+// 기존 final 세트의 해당 파일만 덮어쓴다.
+import { chromium, devices } from '@playwright/test';
+import path from 'path';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3000';
+const API = process.env.E2E_API_BASE || 'http://localhost:8080/api/';
+const OUT = path.join(process.cwd(), 'mobile-screenshots');
+const iPhone = devices['iPhone 13'];
+const log = (m) => console.log(`[fix] ${m}`);
+const HIDE = `.tsqd-parent-container,#__next-build-watcher,nextjs-portal,[data-nextjs-toast],[data-next-badge-root]{display:none!important;}`;
+
+async function shot(page, file, full = false) {
+  await page.addStyleTag({ content: HIDE }).catch(() => null);
+  await page.waitForLoadState('networkidle', { timeout: 6000 }).catch(() => null);
+  await page.waitForTimeout(700);
+  await page.screenshot({ path: path.join(OUT, file), fullPage: full });
+  log(`✓ ${file}`);
+}
+async function safe(label, fn) {
+  try { await fn(); } catch (e) { log(`✗ SKIP ${label}: ${e.message.split('\n')[0]}`); }
+}
+async function devLogin(page, variant) {
+  await page.goto(`${BASE}/sign-in`, { waitUntil: 'domcontentloaded' });
+  const open = page.locator('[data-testid="dev-sign-in-button"]');
+  await open.waitFor({ state: 'visible', timeout: 45000 });
+  await open.click({ force: true });
+  const tid = variant === 'full' ? 'dev-sign-in-full' : 'dev-sign-in-associate';
+  const dialog = page.locator('[data-testid="dialog-panel"]').filter({ has: page.locator(`[data-testid="${tid}"]`) }).first();
+  await dialog.waitFor({ state: 'visible', timeout: 30000 });
+  if (variant === 'full') {
+    const me = page.waitForResponse((r) => r.url().includes('/users/me/info') && r.request().method() === 'GET' && r.status() === 200, { timeout: 30000 });
+    await dialog.locator(`[data-testid="${tid}"]`).click({ force: true });
+    await me;
+  } else {
+    await dialog.locator(`[data-testid="${tid}"]`).click({ force: true });
+  }
+}
+
+(async () => {
+  const browser = await chromium.launch();
+  const member = await browser.newContext({ ...iPhone, ignoreHTTPSErrors: true });
+  const mp = await member.newPage();
+  mp.on('console', (m) => m.type() === 'error' && log(`  [err] ${m.text().slice(0, 100)}`));
+
+  let roomUrl = null;
+
+  await safe('login', () => devLogin(mp, 'full'));
+
+  // stale cap 룸 정리
+  await safe('cleanup', async () => {
+    const res = await member.request.get(new URL('v1/partyrooms', API).toString());
+    if (res.ok()) {
+      const body = await res.json();
+      const list = Array.isArray(body) ? body : body?.data ?? body?.content ?? [];
+      for (const r of list) if (/^cap|screenshot|capture|디자인/i.test(r.title || ''))
+        await member.request.delete(new URL(`v1/partyrooms/${r.partyroomId}`, API).toString()).catch(() => null);
+    }
+  });
+
+  // 07: 파티 개설 다이얼로그 (오버플로우 fix 확인)
+  await safe('create-dialog(07)', async () => {
+    await mp.goto(`${BASE}/parties`, { waitUntil: 'domcontentloaded' });
+    await mp.getByTestId('mobile-create-partyroom-button').click();
+    await mp.locator('input[name="name"]').waitFor({ timeout: 15000 });
+    await shot(mp, '07-member-create-party-dialog.png');
+  });
+
+  // 룸 생성은 API 로 직접 (UI 제출 경로는 캡처 안정성과 무관 — 룸 내부 화면 확보가 목적)
+  await safe('create-room(api)', async () => {
+    const res = await member.request.post(new URL('v1/partyrooms', API).toString(), {
+      data: {
+        title: `cap${Date.now().toString(36).slice(-6)}`,
+        introduction: '디자인 외주용 캡처 룸',
+        playbackTimeLimit: 7,
+      },
+    });
+    if (!res.ok()) throw new Error(`create HTTP ${res.status()}: ${(await res.text()).slice(0, 120)}`);
+    const body = await res.json();
+    const id = body?.data?.partyroomId ?? body?.partyroomId; // 응답은 { data: { partyroomId } } 봉투
+    if (!id) throw new Error(`partyroomId 없음: ${JSON.stringify(body).slice(0, 120)}`);
+    roomUrl = `${BASE}/parties/${id}`;
+    log(`room ${roomUrl}`);
+  });
+
+  if (roomUrl) {
+    await safe('enter', async () => {
+      await mp.goto(roomUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await mp.getByTestId('mobile-tab-queue').waitFor({ timeout: 60000 });
+      await mp.addStyleTag({ content: HIDE }).catch(() => null);
+      await mp.waitForTimeout(3000);
+    });
+
+    // 플리 관리 → 카드 열기 → 곡 추가(검색 15) → 상세(13, 트랙+썸네일)
+    await safe('playlist + add track', async () => {
+      await mp.getByTestId('mobile-tab-queue').click();
+      await mp.getByTestId('member-action-manage-playlists').click();
+      await mp.getByTestId('manage-create-cta').waitFor({ timeout: 15000 });
+      await shot(mp, '11-playlist-manage.png');
+
+      const card = mp.locator('[data-testid^="manage-playlist-card-"]').first();
+      await card.waitFor({ timeout: 10000 });
+      await card.click();
+      await mp.getByTestId('detail-add-tracks').waitFor({ timeout: 15000 });
+
+      // L3 검색 → 썸네일 확인(15) → 첫 곡 추가
+      await mp.getByTestId('detail-add-tracks').click();
+      const search = mp.getByTestId('music-search-input');
+      await search.waitFor({ timeout: 10000 });
+      await search.fill('test song');
+      await mp.getByTestId(/^search-item-add-/).first().waitFor({ timeout: 15000 });
+      await mp.waitForTimeout(1200);
+      await shot(mp, '15-add-tracks-search-results.png');
+      await mp.getByTestId(/^search-item-add-/).first().click();
+      await mp.waitForTimeout(1500);
+
+      // 뒤로 → 상세에 트랙 노출(13)
+      await mp.getByTestId('fullscreen-sheet-back').click();
+      await mp.getByTestId(/^detail-track-remove-/).first().waitFor({ timeout: 15000 });
+      await shot(mp, '13-playlist-detail.png');
+    });
+
+    // 시트 닫고 DJ 등록 → 선택 시트(16) → 확정 → 가이드 dismiss → DJ 활성
+    await safe('register dj', async () => {
+      await mp.goto(roomUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await mp.getByTestId('mobile-tab-queue').waitFor({ timeout: 30000 });
+      await mp.addStyleTag({ content: HIDE }).catch(() => null);
+      await mp.getByTestId('mobile-tab-queue').click();
+      await mp.getByTestId('member-action-register').click();
+      await mp.locator('[data-testid^="mobile-playlist-card-"]').first().waitFor({ timeout: 15000 });
+      await shot(mp, '16-dj-register-select-playlist.png');
+
+      const enabled = mp.locator('[data-testid^="mobile-playlist-card-"]:not([data-testid$="-add-tracks"]):not([disabled])').first();
+      await enabled.click();
+      const confirm = mp.getByTestId('select-playlist-confirm');
+      await confirm.waitFor({ timeout: 10000 });
+      if (await confirm.isEnabled()) {
+        await confirm.click();
+        await safe('guide', async () => {
+          await mp.getByTestId('guide-start').waitFor({ timeout: 15000 });
+          await mp.getByTestId('guide-start').click();
+        });
+        await mp.getByTestId('member-action-unregister').waitFor({ timeout: 20000 }).catch(() => null);
+        await mp.waitForTimeout(3000);
+      }
+    });
+
+    // 10: DJ 등록된 상태 큐 탭 (중앙정렬 액션버튼 포함)
+    await safe('queue(10)', async () => {
+      await mp.getByTestId('mobile-tab-queue').click();
+      await mp.waitForTimeout(1500);
+      await shot(mp, '10-room-queue-tab.png');
+    });
+    // 08/09: 채팅·크루 탭 (중앙정렬 확인)
+    await safe('chat(08)', async () => {
+      await mp.getByTestId('mobile-tab-chat').click();
+      await mp.waitForTimeout(1200);
+      await shot(mp, '08-room-chat-tab.png');
+    });
+    await safe('crew(09)', async () => {
+      await mp.getByTestId('mobile-tab-crew').click();
+      await mp.waitForTimeout(1200);
+      await shot(mp, '09-room-crew-tab.png');
+    });
+  }
+
+  // 19: 프로필 온보딩 (vertical fix)
+  const am = await browser.newContext({ ...iPhone, ignoreHTTPSErrors: true });
+  const ap = await am.newPage();
+  await safe('profile(19)', async () => {
+    await devLogin(ap, 'associate');
+    await ap.waitForURL(/\/settings\/profile/, { timeout: 30000 });
+    await ap.getByTestId('mobile-profile-form').waitFor({ timeout: 30000 });
+    await shot(ap, '19-profile-onboarding-new-member.png', true);
+  });
+
+  // 룸 정리
+  if (roomUrl) await safe('cleanup-room', async () => {
+    const id = roomUrl.match(/\/parties\/(\d+)/)?.[1];
+    if (id) await member.request.delete(new URL(`v1/partyrooms/${id}`, API).toString()).catch(() => null);
+  });
+
+  await browser.close();
+  log('완료');
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/scripts/capture-mobile-screens.mjs
+++ b/scripts/capture-mobile-screens.mjs
@@ -1,0 +1,345 @@
+// 모바일 웹 뷰 전체 화면 스크린샷 캡처 (디자인 외주용).
+// iPhone 13 device descriptor 로 진짜 모바일 UA → middleware x-pf-device=mobile 보장.
+// 게스트 / 정회원(full crew) / 신규 준회원(AM 온보딩) 3 상태 + 룸 내부 시트/모달까지.
+//
+// 실행: BASE / API inline 후 node scripts/capture-mobile-screens.mjs
+import { chromium, devices } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3000';
+const API = process.env.E2E_API_BASE || 'http://localhost:8080/api/';
+const OUT = path.join(process.cwd(), 'mobile-screenshots');
+fs.mkdirSync(OUT, { recursive: true });
+
+const iPhone = devices['iPhone 13'];
+let n = 0;
+const log = (m) => console.log(`[capture] ${m}`);
+
+// dev 전용 오버레이(React Query Devtools / Next dev indicator) 가리기 — prod 빌드엔 없음.
+const HIDE_DEV_OVERLAYS = `
+  .tsqd-parent-container, #__next-build-watcher, nextjs-portal,
+  [data-nextjs-toast], [data-next-badge-root], #__next-dev-overlay { display:none !important; }
+`;
+
+async function prep(page) {
+  await page.addStyleTag({ content: HIDE_DEV_OVERLAYS }).catch(() => null);
+  // 폰트/이미지 안정화 대기
+  await page.waitForLoadState('networkidle', { timeout: 8000 }).catch(() => null);
+  await page.addStyleTag({ content: HIDE_DEV_OVERLAYS }).catch(() => null);
+}
+
+async function shot(page, name, { full = true } = {}) {
+  n += 1;
+  const id = String(n).padStart(2, '0');
+  const file = path.join(OUT, `${id}-${name}.png`);
+  await prep(page);
+  await page.waitForTimeout(600);
+  await page.screenshot({ path: file, fullPage: full }).catch(async (e) => {
+    log(`  ! fullPage 실패(${name}) → viewport 폴백: ${e.message}`);
+    await page.screenshot({ path: file, fullPage: false }).catch(() => null);
+  });
+  log(`✓ ${id}-${name}.png`);
+}
+
+async function safe(label, fn) {
+  try {
+    await fn();
+  } catch (e) {
+    log(`✗ SKIP ${label}: ${e.message.split('\n')[0]}`);
+  }
+}
+
+// dev 로그인 (sign-in 다이얼로그). variant: 'full' | 'associate'
+async function devLogin(page, variant) {
+  await page.goto(`${BASE}/sign-in`, { waitUntil: 'domcontentloaded' });
+  const openBtn = page.locator('[data-testid="dev-sign-in-button"]');
+  await openBtn.waitFor({ state: 'visible', timeout: 45000 });
+  await openBtn.click({ force: true });
+  const itemTestId = variant === 'full' ? 'dev-sign-in-full' : 'dev-sign-in-associate';
+  const dialog = page
+    .locator('[data-testid="dialog-panel"]')
+    .filter({ has: page.locator(`[data-testid="${itemTestId}"]`) })
+    .first();
+  await dialog.waitFor({ state: 'visible', timeout: 30000 });
+  if (variant === 'full') {
+    const me200 = page.waitForResponse(
+      (r) => r.url().includes('/users/me/info') && r.request().method() === 'GET' && r.status() === 200,
+      { timeout: 30000 }
+    );
+    await dialog.locator(`[data-testid="${itemTestId}"]`).click({ force: true });
+    await me200;
+  } else {
+    await dialog.locator(`[data-testid="${itemTestId}"]`).click({ force: true });
+  }
+}
+
+async function newMobileContext(browser) {
+  const ctx = await browser.newContext({ ...iPhone, ignoreHTTPSErrors: true });
+  return ctx;
+}
+
+(async () => {
+  const browser = await chromium.launch();
+
+  // ---------- 워밍 (next dev lazy compile) ----------
+  log('워밍 라우트 컴파일...');
+  {
+    const warm = await newMobileContext(browser);
+    const p = await warm.newPage();
+    for (const r of ['/sign-in', '/parties', '/docs/terms-of-service']) {
+      await p.goto(`${BASE}${r}`, { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => null);
+    }
+    await warm.close();
+  }
+
+  let roomUrl = null;
+
+  // ================= 정회원(full crew) =================
+  log('=== 정회원(full crew) 세션 ===');
+  const member = await newMobileContext(browser);
+  const mp = await member.newPage();
+  mp.on('console', (m) => m.type() === 'error' && log(`  [console.error] ${m.text().slice(0, 120)}`));
+
+  await safe('member-login', async () => {
+    await devLogin(mp, 'full');
+  });
+
+  // stale e2e 룸 정리 (1 user 1 host 제약)
+  await safe('cleanup-stale-rooms', async () => {
+    const res = await member.request.get(new URL('v1/partyrooms', API).toString());
+    if (res.ok()) {
+      const body = await res.json();
+      const list = Array.isArray(body) ? body : body?.data ?? body?.content ?? body?.partyrooms ?? [];
+      for (const r of list) {
+        const title = r.title || '';
+        if (/screenshot|capture|^cap|e2e|MPM|MDJ|MAT|chunk|디자인/i.test(title)) {
+          await member.request.delete(new URL(`v1/partyrooms/${r.partyroomId}`, API).toString()).catch(() => null);
+        }
+      }
+    }
+  });
+
+  await safe('lobby-member', async () => {
+    await mp.goto(`${BASE}/parties`, { waitUntil: 'domcontentloaded' });
+    await mp.getByTestId('mobile-create-partyroom-button').waitFor({ timeout: 30000 });
+    await shot(mp, 'lobby-member');
+  });
+
+  // 언어 변경 메뉴 (헤더) — best effort
+  await safe('language-menu', async () => {
+    const langBtn = mp.locator('header button, [aria-haspopup]').filter({ has: mp.locator('svg') });
+    // PFLanguage 아이콘 버튼: 헤더 우측 버튼들 중 하나. 마지막 후보 시도.
+    const candidates = mp.locator('header button');
+    const count = await candidates.count();
+    if (count > 0) {
+      await candidates.nth(count - 1).click({ force: true });
+      await mp.waitForTimeout(500);
+      await shot(mp, 'language-menu', { full: false });
+      await mp.keyboard.press('Escape').catch(() => null);
+    }
+  });
+
+  // host CTA → 파티 생성 다이얼로그
+  await safe('create-dialog', async () => {
+    await mp.goto(`${BASE}/parties`, { waitUntil: 'domcontentloaded' });
+    await mp.getByTestId('mobile-create-partyroom-button').click();
+    await mp.locator('input[name="name"]').waitFor({ timeout: 15000 });
+    await shot(mp, 'create-partyroom-dialog', { full: false });
+  });
+
+  // 실제 룸 생성 → roomUrl 확보
+  await safe('create-room', async () => {
+    // ⚠️ Party Name 은 12자 제한 — 초과 시 form invalid → submit 버튼 disabled.
+    await mp.locator('input[name="name"]').fill(`cap${Date.now().toString(36).slice(-6)}`);
+    await mp.locator('textarea[name="introduce"]').fill('디자인 외주용 캡처 룸');
+    // submit 버튼이 활성화될 때까지 대기 (btnDisabled = !isValid).
+    const submit = mp.locator('button[type="submit"]').first();
+    await submit.waitFor({ state: 'visible', timeout: 10000 });
+    // 생성 POST 응답에서 partyroomId 직접 확보 (dev RSC 네비 flake 우회).
+    const createResp = mp.waitForResponse(
+      (r) => /\/v1\/partyrooms$/.test(new URL(r.url()).pathname) && r.request().method() === 'POST',
+      { timeout: 20000 }
+    );
+    await submit.click();
+    const resp = await createResp;
+    const body = await resp.json().catch(() => null);
+    const id = body?.partyroomId ?? body?.data?.partyroomId;
+    if (!id) throw new Error(`partyroomId 파싱 실패: ${JSON.stringify(body)?.slice(0, 120)}`);
+    roomUrl = `${BASE}/parties/${id}`;
+    log(`룸 생성됨(id=${id}): ${roomUrl}`);
+  });
+
+  if (roomUrl) {
+    // 룸 진입 + 구독 대기
+    await safe('room-enter', async () => {
+      await mp.goto(roomUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await mp.getByTestId('mobile-tab-queue').waitFor({ timeout: 60000 });
+      await mp.waitForTimeout(3000);
+    });
+
+    await safe('room-chat', async () => {
+      await mp.getByTestId('mobile-tab-chat').click();
+      await mp.waitForTimeout(1000);
+      await shot(mp, 'room-chat-tab', { full: false });
+    });
+    await safe('room-crew', async () => {
+      await mp.getByTestId('mobile-tab-crew').click();
+      await mp.waitForTimeout(1000);
+      await shot(mp, 'room-crew-tab', { full: false });
+    });
+    await safe('room-queue', async () => {
+      await mp.getByTestId('mobile-tab-queue').click();
+      await mp.waitForTimeout(1000);
+      await shot(mp, 'room-queue-tab', { full: false });
+    });
+
+    // 버그 신고 다이얼로그 (헤더에 있으면)
+    await safe('bug-report', async () => {
+      const bug = mp.getByTestId('bug-report-button');
+      if (await bug.isVisible().catch(() => false)) {
+        await bug.click();
+        await mp.waitForTimeout(800);
+        await shot(mp, 'bug-report-dialog', { full: false });
+        await mp.keyboard.press('Escape').catch(() => null);
+      } else {
+        log('  (룸 헤더에 bug-report-button 없음 — 로비에서 시도)');
+      }
+    });
+
+    // 플레이리스트 관리 시트 (L1)
+    await safe('manage-playlists-L1', async () => {
+      await mp.getByTestId('mobile-tab-queue').click();
+      await mp.getByTestId('member-action-manage-playlists').click();
+      await mp.getByTestId('manage-create-cta').waitFor({ timeout: 15000 });
+      await shot(mp, 'playlist-manage-L1', { full: false });
+    });
+    // 생성 폼
+    await safe('manage-create', async () => {
+      await mp.getByTestId('manage-create-cta').click();
+      await mp.getByTestId('manage-create-input').waitFor({ timeout: 10000 });
+      await shot(mp, 'playlist-create-form', { full: false });
+      // 생성하지 않고 닫기
+      const back = mp.getByTestId('fullscreen-sheet-back');
+      if (await back.isVisible().catch(() => false)) await back.click().catch(() => null);
+    });
+    // L2 상세 (기존 카드가 있으면)
+    await safe('playlist-detail-L2', async () => {
+      const card = mp.locator('[data-testid^="manage-playlist-card-"]').first();
+      if (await card.isVisible().catch(() => false)) {
+        await card.click();
+        await mp.getByTestId('detail-add-tracks').waitFor({ timeout: 15000 });
+        await shot(mp, 'playlist-detail-L2', { full: false });
+        // L3 곡 추가/검색
+        await safe('add-tracks-L3', async () => {
+          await mp.getByTestId('detail-add-tracks').click();
+          const search = mp.getByTestId('music-search-input');
+          await search.waitFor({ timeout: 10000 });
+          await shot(mp, 'add-tracks-search-empty-L3', { full: false });
+          await search.fill('test song');
+          await mp.getByTestId(/^search-item-(add|preview)-/).first().waitFor({ timeout: 15000 }).catch(() => null);
+          await mp.waitForTimeout(1200);
+          await shot(mp, 'add-tracks-search-results-L3', { full: false });
+        });
+      } else {
+        log('  (기존 플레이리스트 카드 없음 — L2/L3 생략)');
+      }
+    });
+    // 시트 닫기 (해시 리셋)
+    await safe('reset-room', async () => {
+      await mp.goto(roomUrl, { waitUntil: 'domcontentloaded' });
+      await mp.getByTestId('mobile-tab-queue').waitFor({ timeout: 20000 });
+      await mp.getByTestId('mobile-tab-queue').click();
+    });
+
+    // DJ 등록 → SelectPlaylistSheet → (선택 시) DJ 가이드
+    await safe('select-playlist-sheet', async () => {
+      await mp.getByTestId('member-action-register').click();
+      await mp.locator('[data-testid^="mobile-playlist-card-"]').first().waitFor({ timeout: 15000 });
+      await shot(mp, 'dj-register-select-playlist', { full: false });
+      const enabled = mp.locator(
+        '[data-testid^="mobile-playlist-card-"]:not([data-testid$="-add-tracks"]):not([disabled])'
+      ).first();
+      if (await enabled.isVisible().catch(() => false)) {
+        await enabled.click();
+        const confirm = mp.getByTestId('select-playlist-confirm');
+        if (await confirm.isEnabled().catch(() => false)) {
+          await confirm.click();
+          // 첫 디제잉 가이드 모달
+          await safe('dj-guide', async () => {
+            await mp.getByTestId('guide-start').waitFor({ timeout: 15000 });
+            await shot(mp, 'dj-guide-modal', { full: false });
+            await mp.getByTestId('guide-start').click();
+          });
+          // DJ 활성 상태 큐 탭
+          await safe('room-dj-active', async () => {
+            await mp.waitForTimeout(2000);
+            await shot(mp, 'room-queue-dj-active', { full: false });
+          });
+        }
+      }
+    });
+  }
+
+  // 아바타 설정 (모바일 = desktop-only 폴백 카드)
+  await safe('settings-avatar', async () => {
+    await mp.goto(`${BASE}/settings/avatar`, { waitUntil: 'domcontentloaded' });
+    await mp.waitForTimeout(1500);
+    await shot(mp, 'settings-avatar-mobile-fallback');
+  });
+
+  // ================= 게스트 =================
+  log('=== 게스트 세션 ===');
+  const guest = await newMobileContext(browser);
+  const gp = await guest.newPage();
+
+  const guestRoutes = [
+    ['/', 'home'],
+    ['/sign-in', 'sign-in'],
+    ['/parties', 'lobby-guest'],
+    ['/docs/terms-of-service', 'terms-of-service'],
+    ['/docs/privacy-policy', 'privacy-policy'],
+    ['/maintenance', 'maintenance'],
+    ['/mobile-notice', 'mobile-notice'],
+  ];
+  for (const [route, name] of guestRoutes) {
+    await safe(`guest ${name}`, async () => {
+      await gp.goto(`${BASE}${route}`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      await gp.waitForTimeout(1500);
+      await shot(gp, `guest-${name}`);
+    });
+  }
+  // 게스트 룸 뷰
+  if (roomUrl) {
+    await safe('guest room', async () => {
+      await gp.goto(roomUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      await gp.waitForTimeout(2500);
+      await shot(gp, 'guest-room', { full: false });
+    });
+  }
+
+  // ================= 신규 준회원(AM) 강제 프로필 온보딩 =================
+  log('=== 신규 준회원(AM) 프로필 온보딩 ===');
+  const am = await newMobileContext(browser);
+  const ap = await am.newPage();
+  await safe('AM-onboarding', async () => {
+    await devLogin(ap, 'associate');
+    await ap.waitForURL(/\/settings\/profile/, { timeout: 30000 });
+    await ap.getByTestId('mobile-profile-form').waitFor({ timeout: 30000 });
+    await shot(ap, 'profile-onboarding-form-AM');
+  });
+
+  // ---------- 룸 정리 ----------
+  if (roomUrl) {
+    await safe('cleanup-room', async () => {
+      const id = roomUrl.match(/\/parties\/(\d+)/)?.[1];
+      if (id) await member.request.delete(new URL(`v1/partyrooms/${id}`, API).toString()).catch(() => null);
+    });
+  }
+
+  await browser.close();
+  log(`\n완료. 총 ${n}장 → ${OUT}`);
+})().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/capture-supplement.mjs
+++ b/scripts/capture-supplement.mjs
@@ -1,0 +1,76 @@
+// 보충 캡처: 버그 신고 다이얼로그 + 언어 변경 메뉴 (헤더 아이콘이 직접 보이는 settings 헤더 이용).
+import { chromium, devices } from '@playwright/test';
+import path from 'path';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3000';
+const OUT = path.join(process.cwd(), 'mobile-screenshots');
+const iPhone = devices['iPhone 13'];
+const log = (m) => console.log(`[supp] ${m}`);
+const HIDE = `.tsqd-parent-container,#__next-build-watcher,nextjs-portal,[data-nextjs-toast],[data-next-badge-root]{display:none!important;}`;
+
+async function shot(page, file, full = false) {
+  await page.addStyleTag({ content: HIDE }).catch(() => null);
+  await page.waitForTimeout(700);
+  await page.screenshot({ path: path.join(OUT, file), fullPage: full });
+  log(`✓ ${file}`);
+}
+
+(async () => {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ ...iPhone, ignoreHTTPSErrors: true });
+  const page = await ctx.newPage();
+
+  // associate(AM) dev 로그인 → /settings/profile (globe + 🐛 헤더 노출 확인됨)
+  await page.goto(`${BASE}/sign-in`, { waitUntil: 'domcontentloaded' });
+  await page.locator('[data-testid="dev-sign-in-button"]').click({ force: true });
+  const dialog = page.locator('[data-testid="dialog-panel"]')
+    .filter({ has: page.locator('[data-testid="dev-sign-in-associate"]') }).first();
+  await dialog.waitFor({ state: 'visible', timeout: 30000 });
+  await dialog.locator('[data-testid="dev-sign-in-associate"]').click({ force: true });
+  await page.waitForURL(/\/settings\/profile/, { timeout: 30000 });
+  await page.getByTestId('mobile-profile-form').waitFor({ timeout: 30000 });
+  await page.addStyleTag({ content: HIDE }).catch(() => null);
+
+  // 1) 버그 신고 다이얼로그
+  try {
+    await page.getByTestId('bug-report-button').click({ force: true });
+    await page.waitForTimeout(1000);
+    await shot(page, '23-bug-report-dialog.png');
+    await page.keyboard.press('Escape').catch(() => null);
+    await page.waitForTimeout(500);
+  } catch (e) {
+    log(`✗ bug-report: ${e.message.split('\n')[0]}`);
+  }
+
+  // 2) 언어 변경 메뉴 (헤더에서 bug 버튼이 아닌 globe 버튼 클릭)
+  try {
+    // 헤더 영역 버튼들 중 bug-report-button 직전 버튼이 globe(LanguageChangeMenu).
+    const headerButtons = page.locator('header button, [class*="header"] button, [class*="Header"] button');
+    const cnt = await headerButtons.count();
+    log(`header buttons: ${cnt}`);
+    // bug-report-button 의 형제/인접 — 모든 버튼 순회하며 testid 가 bug 가 아니고 svg 포함한 것 클릭
+    let clicked = false;
+    for (let i = 0; i < cnt; i++) {
+      const b = headerButtons.nth(i);
+      const tid = await b.getAttribute('data-testid').catch(() => null);
+      if (tid === 'bug-report-button') continue;
+      const hasSvg = await b.locator('svg').count().catch(() => 0);
+      if (hasSvg > 0) {
+        await b.click({ force: true });
+        clicked = true;
+        break;
+      }
+    }
+    if (clicked) {
+      await page.waitForTimeout(900);
+      await shot(page, '24-language-menu.png');
+    } else {
+      log('globe 버튼 못 찾음');
+    }
+  } catch (e) {
+    log(`✗ language-menu: ${e.message.split('\n')[0]}`);
+  }
+
+  await browser.close();
+  log('완료');
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/src/features-mobile/partyroom/list/partyroom-card.component.tsx
+++ b/src/features-mobile/partyroom/list/partyroom-card.component.tsx
@@ -63,13 +63,13 @@ const MobilePartyroomCard: FC<Props> = ({ roomId, summary, onClose, isMain }) =>
         <div className='gap-3 flexCol max-w-full'>
           {summary.playback && (
             <div className='flex-1 max-w-full min-w-0 flexRowCenter gap-3 rounded'>
-              <div className='w-[64px] h-[36px] bg-gray-700 shrink-0'>
+              <div className='w-[80px] h-[44px] bg-gray-700 shrink-0'>
                 <Image
                   priority
                   src={summary.playback.thumbnailImage}
                   alt='playback thumbnail'
-                  width={64}
-                  height={36}
+                  width={80}
+                  height={44}
                   className='w-full h-full object-contain select-none'
                 />
               </div>

--- a/src/features-mobile/playlist/add-tracks/ui/music-search.component.tsx
+++ b/src/features-mobile/playlist/add-tracks/ui/music-search.component.tsx
@@ -29,7 +29,7 @@ const MusicSearch: FC<Props> = ({ onPreview, onAdd, addPending }) => {
 
   return (
     <div className='flex flex-col h-full'>
-      <div className='shrink-0 px-4 py-3 border-b border-gray-800'>
+      <div className='shrink-0 px-5 py-3 border-b border-gray-800'>
         <Input
           data-testid='music-search-input'
           value={query}

--- a/src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx
+++ b/src/features-mobile/playlist/add-tracks/ui/search-list-item.component.test.tsx
@@ -61,4 +61,17 @@ describe('SearchListItem', () => {
     );
     expect(screen.getByTestId('search-item-add-abc123')).toBeDisabled();
   });
+
+  test('미리듣기/추가 버튼에 PF 아이콘 렌더', () => {
+    render(
+      <SearchListItem
+        music={TRACK as never}
+        onPreview={vi.fn()}
+        onAdd={vi.fn()}
+        addPending={false}
+      />
+    );
+    expect(screen.getByTestId('search-item-preview-abc123').querySelector('svg')).toBeTruthy();
+    expect(screen.getByTestId('search-item-add-abc123').querySelector('svg')).toBeTruthy();
+  });
 });

--- a/src/features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx
+++ b/src/features-mobile/playlist/add-tracks/ui/search-list-item.component.tsx
@@ -4,6 +4,7 @@ import { Music } from '@/shared/api/http/types/playlists';
 import { safeDecodeURI } from '@/shared/lib/functions/safe-decode-uri';
 import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
+import { PFPlayCircleFilled, PFAdd } from '@/shared/ui/icons';
 
 interface Props {
   music: Music;
@@ -19,7 +20,7 @@ interface Props {
  */
 const SearchListItem: FC<Props> = ({ music, onPreview, onAdd, addPending }) => {
   return (
-    <li className='flex items-center gap-3 px-4 py-3 border-b border-gray-800'>
+    <li className='flex items-center gap-3 px-5 py-3 border-b border-gray-800'>
       <div className='flex-1 min-w-0'>
         <Typography type='body3' className='truncate'>
           {safeDecodeURI(music.videoTitle)}
@@ -32,17 +33,15 @@ const SearchListItem: FC<Props> = ({ music, onPreview, onAdd, addPending }) => {
         data-testid={`search-item-preview-${music.videoId}`}
         onClick={() => onPreview(music)}
         aria-label={`${music.videoTitle} 미리듣기`}
-      >
-        ▶
-      </TextButton>
+        Icon={<PFPlayCircleFilled width={20} height={20} aria-hidden='true' />}
+      />
       <TextButton
         data-testid={`search-item-add-${music.videoId}`}
         onClick={() => onAdd(music)}
         disabled={addPending}
         aria-label={`${music.videoTitle} 추가`}
-      >
-        +
-      </TextButton>
+        Icon={<PFAdd width={20} height={20} aria-hidden='true' />}
+      />
     </li>
   );
 };

--- a/src/shared/ui/components/mobile-sheet-header/index.ts
+++ b/src/shared/ui/components/mobile-sheet-header/index.ts
@@ -1,0 +1,1 @@
+export { default as MobileSheetHeader } from './mobile-sheet-header.component';

--- a/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx
+++ b/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx
@@ -21,4 +21,22 @@ describe('MobileSheetHeader', () => {
     expect(container.querySelector('header')).toBeTruthy();
     expect(screen.getByText('T')).toBeTruthy();
   });
+
+  test('대칭 스페이서: header 직계 자식에 w-10 div가 정확히 2개', () => {
+    const { container } = render(
+      <MobileSheetHeader leading={<button>L</button>} title='제목' trailing={<button>R</button>} />
+    );
+    expect(container.querySelectorAll('header > div.w-10').length).toBe(2);
+  });
+
+  test('titleId prop이 title 엘리먼트 id에 연결된다', () => {
+    render(<MobileSheetHeader title='T' titleId='x' />);
+    expect(screen.getByText('T').id).toBe('x');
+  });
+
+  test('title은 h2 헤딩 엘리먼트로 렌더된다', () => {
+    render(<MobileSheetHeader title='제목' />);
+    expect(screen.getByRole('heading', { level: 2, name: '제목' })).toBeTruthy();
+    expect(screen.getByText('제목').tagName).toBe('H2');
+  });
 });

--- a/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx
+++ b/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import MobileSheetHeader from './mobile-sheet-header.component';
+
+describe('MobileSheetHeader', () => {
+  test('leading/title/trailing 슬롯 렌더 + title은 Typography', () => {
+    render(
+      <MobileSheetHeader
+        leading={<button data-testid='lead'>L</button>}
+        title='제목'
+        trailing={<button data-testid='trail'>T</button>}
+      />
+    );
+    expect(screen.getByTestId('lead')).toBeTruthy();
+    expect(screen.getByTestId('trail')).toBeTruthy();
+    expect(screen.getByText('제목')).toBeTruthy();
+  });
+
+  test('trailing 미지정 시에도 leading/title 정상 (대칭 스페이서 유지)', () => {
+    const { container } = render(<MobileSheetHeader leading={<span>L</span>} title='T' />);
+    expect(container.querySelector('header')).toBeTruthy();
+    expect(screen.getByText('T')).toBeTruthy();
+  });
+});

--- a/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.tsx
+++ b/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { FC, ReactNode, useId } from 'react';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+
+interface Props {
+  /** 좌측 액션 (뒤로/닫기 등). 없으면 대칭 스페이서로 폭 보존 */
+  leading?: ReactNode;
+  title?: string;
+  /** 우측 액션 (메뉴 등). 없으면 대칭 스페이서 */
+  trailing?: ReactNode;
+  /** title element id 연결용 (dialog aria-labelledby) */
+  titleId?: string;
+  className?: string;
+}
+
+/**
+ * 모바일 시트/룸 상단 표준 헤더 (spec A3).
+ * 좌(leading) · 중앙 title(Typography) · 우(trailing) 3분할, 56px 높이, 하단 border-gray-800.
+ * leading/trailing 미지정 측은 동일 폭 스페이서로 중앙 정렬 보존.
+ */
+const MobileSheetHeader: FC<Props> = ({ leading, title, trailing, titleId, className }) => {
+  const autoId = useId();
+  const id = titleId ?? autoId;
+  return (
+    <header
+      className={cn(
+        'shrink-0 flex items-center gap-3 px-3 h-14 border-b border-gray-800',
+        className
+      )}
+    >
+      <div className='w-10 flex items-center justify-start'>{leading}</div>
+      {title && (
+        <Typography id={id} type='body3' overflow='ellipsis' className='flex-1 text-center'>
+          {title}
+        </Typography>
+      )}
+      <div className='w-10 flex items-center justify-end'>{trailing}</div>
+    </header>
+  );
+};
+
+export default MobileSheetHeader;

--- a/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.tsx
+++ b/src/shared/ui/components/mobile-sheet-header/mobile-sheet-header.component.tsx
@@ -31,7 +31,7 @@ const MobileSheetHeader: FC<Props> = ({ leading, title, trailing, titleId, class
     >
       <div className='w-10 flex items-center justify-start'>{leading}</div>
       {title && (
-        <Typography id={id} type='body3' overflow='ellipsis' className='flex-1 text-center'>
+        <Typography id={id} as='h2' type='body3' overflow='ellipsis' className='flex-1 text-center'>
           {title}
         </Typography>
       )}

--- a/src/shared/ui/components/track-title/index.ts
+++ b/src/shared/ui/components/track-title/index.ts
@@ -1,0 +1,1 @@
+export { default as TrackTitle } from './track-title.component';

--- a/src/shared/ui/components/track-title/track-title.component.test.tsx
+++ b/src/shared/ui/components/track-title/track-title.component.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('react-fast-marquee', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='marquee'>{children}</div>
+  ),
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({
+  galmuriFont: { className: 'font-galmuri' },
+}));
+
+import TrackTitle from './track-title.component';
+
+describe('TrackTitle', () => {
+  test('name 있으면 Marquee 안에 곡명 + data-testid=video-title', () => {
+    render(<TrackTitle name='Test Song' emptyText='없음' />);
+    expect(screen.getByTestId('marquee')).toBeTruthy();
+    const el = screen.getByTestId('video-title');
+    expect(el.textContent).toBe('Test Song');
+    expect(el.className).toMatch(/font-galmuri/);
+  });
+
+  test('name 없으면 emptyText + data-testid=video-title-empty (마퀴 없음)', () => {
+    render(<TrackTitle emptyText='현재 DJ가 없습니다' />);
+    expect(screen.queryByTestId('marquee')).toBeNull();
+    const el = screen.getByTestId('video-title-empty');
+    expect(el.textContent).toBe('현재 DJ가 없습니다');
+    expect(el.className).toMatch(/font-galmuri/);
+  });
+});

--- a/src/shared/ui/components/track-title/track-title.component.tsx
+++ b/src/shared/ui/components/track-title/track-title.component.tsx
@@ -1,0 +1,36 @@
+'use client';
+import Marquee from 'react-fast-marquee';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+import { galmuriFont } from '@/shared/ui/foundation/fonts';
+
+interface Props {
+  /** 곡명. 없으면 emptyText 렌더 */
+  name?: string;
+  /** 곡 없을 때 표시 문구 */
+  emptyText: string;
+  className?: string;
+}
+
+/**
+ * 곡 제목 — Galmuri + 마퀴 프레젠테이션 (데스크탑 VideoTitle에서 추출).
+ * 스토어/i18n 와이어링은 호출자(VideoTitle/now-playing) 책임. 본 컴포넌트는 순수 표시.
+ */
+export default function TrackTitle({ name, emptyText, className }: Props) {
+  const typoClassName = cn(galmuriFont.className, 'text-white leading-none', className);
+
+  if (!name) {
+    return (
+      <Typography type='caption1' className={typoClassName} data-testid='video-title-empty'>
+        {emptyText}
+      </Typography>
+    );
+  }
+  return (
+    <Marquee delay={4} speed={20} gradientWidth={0} className='z-0'>
+      <Typography type='body3' className={typoClassName} data-testid='video-title'>
+        {name}
+      </Typography>
+    </Marquee>
+  );
+}

--- a/src/widgets-mobile/partyroom-chat-panel/partyroom-chat-panel.component.tsx
+++ b/src/widgets-mobile/partyroom-chat-panel/partyroom-chat-panel.component.tsx
@@ -41,7 +41,7 @@ export default function MobilePartyroomChatPanel() {
     <div className='flexCol h-full'>
       <div
         ref={scrollContainerRef}
-        className='flex-[1_0_0] flexCol gap-4 overflow-y-auto py-4 px-3'
+        className='flex-[1_0_0] flexCol gap-4 overflow-y-auto py-4 px-5'
       >
         {chatMessages.map((message, i) => {
           if (message.from === 'system') {
@@ -69,7 +69,7 @@ export default function MobilePartyroomChatPanel() {
         })}
       </div>
 
-      <div className='shrink-0 px-3 pb-3 pt-2 bg-black border-t border-gray-900'>
+      <div className='shrink-0 px-5 pb-3 pt-2 bg-black border-t border-gray-900'>
         <SendChatMessage>
           {({ message, setMessage, send, canSend }) => (
             <Input

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -1,8 +1,18 @@
 /**
  * @vitest-environment jsdom
  */
+import type { ReactNode } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// NowPlayingMeta → TrackTitle 이 react-fast-marquee + galmuriFont(next/font/local) 를
+// transitive import 한다. next/font/local 은 vitest SSR 에서 함수가 아니라 모듈 로드 시
+// throw → 본 스위트가 0 test 로 죽는다. video-title/now-playing-meta 테스트와 동일 패턴으로 mock.
+vi.mock('react-fast-marquee', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({ galmuriFont: { className: 'font-galmuri' } }));
 
 const youtubePlayerCalls: Array<Record<string, unknown>> = [];
 vi.mock('react-player/youtube', () => ({

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -250,6 +250,18 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
   });
 });
 
+describe('MobilePartyroomDisplayBoard · 헤더', () => {
+  test('헤더: 뒤로 버튼 클릭 시 /parties 라우팅 + PF 아이콘 렌더', () => {
+    render(<MobilePartyroomDisplayBoard partyroomId={1} />);
+    const back = screen.getByRole('button', { name: '뒤로' });
+    expect(back.querySelector('svg')).toBeTruthy(); // PFArrowLeft
+    fireEvent.click(back);
+    expect(mockPush).toHaveBeenCalledWith('/parties');
+    const menu = screen.getByRole('button', { name: '메뉴' });
+    expect(menu.querySelector('svg')).toBeTruthy(); // PFMoreVert
+  });
+});
+
 describe('MobilePartyroomDisplayBoard · cross-component single source', () => {
   test('#11 Mode B + autoplay 차단: NowPlayingRow 안에 TapToPlayButton 렌더, overlay 미렌더', () => {
     const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.tsx
@@ -6,6 +6,8 @@ import type TReactPlayer from 'react-player';
 import { useFetchPartyroomDetailSummary } from '@/features/partyroom/get-summary';
 import { cn } from '@/shared/lib/functions/cn';
 import { useStores } from '@/shared/lib/store/stores.context';
+import { MobileSheetHeader } from '@/shared/ui/components/mobile-sheet-header';
+import { PFArrowLeft, PFMoreVert } from '@/shared/ui/icons';
 import useAutoplayGestureGate from './lib/use-autoplay-gesture-gate.hook';
 import ActionButtons from './ui/parts/action-buttons.component';
 import NowPlayingMeta from './ui/parts/now-playing-meta.component';
@@ -57,24 +59,28 @@ const MobilePartyroomDisplayBoard: FC<Props> = ({ partyroomId }) => {
 
   return (
     <div className={cn('sticky top-0 z-20 w-full bg-black border-b border-gray-800')}>
-      <header className='flex items-center justify-between px-4 h-12'>
-        <button
-          aria-label='뒤로'
-          className='w-11 h-11 flex items-center justify-center text-gray-300'
-          onClick={() => router.push('/parties')}
-        >
-          ←
-        </button>
-        <h1 className='flex-1 text-center text-base font-semibold text-white truncate px-2'>
-          {partyroomTitle}
-        </h1>
-        <button
-          aria-label='메뉴'
-          className='w-11 h-11 flex items-center justify-center text-gray-300'
-        >
-          ⋮
-        </button>
-      </header>
+      <MobileSheetHeader
+        title={partyroomTitle}
+        leading={
+          <button
+            type='button'
+            aria-label='뒤로'
+            className='w-10 h-10 flex items-center justify-center text-gray-300'
+            onClick={() => router.push('/parties')}
+          >
+            <PFArrowLeft width={24} height={24} />
+          </button>
+        }
+        trailing={
+          <button
+            type='button'
+            aria-label='메뉴'
+            className='w-10 h-10 flex items-center justify-center text-gray-300'
+          >
+            <PFMoreVert width={24} height={24} />
+          </button>
+        }
+      />
 
       <div className='px-4 pt-3'>
         <VideoFrame

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.test.tsx
@@ -1,9 +1,16 @@
 /**
  * @vitest-environment jsdom
  */
+import React from 'react'; // mock 타입 참조용
 import { render, screen } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import NowPlayingMeta from './now-playing-meta.component';
+
+vi.mock('react-fast-marquee', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({ galmuriFont: { className: 'font-galmuri' } }));
 
 describe('NowPlayingMeta', () => {
   test('layout="column": 트랙명·DJ·duration 3 라인 렌더', () => {
@@ -29,13 +36,17 @@ describe('NowPlayingMeta', () => {
     expect(screen.getByText('2:10')).toBeTruthy();
   });
 
-  test('djNickname=null 시 DJ 라인 미렌더', () => {
-    render(
-      <NowPlayingMeta layout='column' trackName='Solo Track' djNickname={null} duration='1:00' />
+  test('djNickname 있으면 헤드셋 아이콘 + 닉네임', () => {
+    const { container } = render(
+      <NowPlayingMeta layout='column' trackName='T' djNickname='DJ Alpha' duration='3:45' />
     );
-    expect(screen.getByText('Solo Track')).toBeTruthy();
-    expect(screen.queryByText(/🎧/)).toBeNull();
-    expect(screen.getByText('1:00')).toBeTruthy();
+    expect(screen.getByText(/DJ Alpha/)).toBeTruthy();
+    expect(container.querySelector('[data-testid="now-playing-dj"] svg')).toBeTruthy();
+  });
+
+  test('djNickname=null 시 DJ 라인(헤드셋 포함) 미렌더', () => {
+    render(<NowPlayingMeta layout='column' trackName='T' djNickname={null} duration='1:00' />);
+    expect(screen.queryByTestId('now-playing-dj')).toBeNull();
   });
 
   test('layout 분기 root class — column 은 flex-col, row 는 flex-row', () => {

--- a/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx
+++ b/src/widgets-mobile/partyroom-display-board/ui/parts/now-playing-meta.component.tsx
@@ -1,5 +1,8 @@
 import { FC } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { TrackTitle } from '@/shared/ui/components/track-title';
+import { Typography } from '@/shared/ui/components/typography';
+import { PFHeadset } from '@/shared/ui/icons';
 
 interface Props {
   layout: 'column' | 'row';
@@ -26,9 +29,21 @@ const NowPlayingMeta: FC<Props> = ({ layout, trackName, djNickname, duration }) 
         layout === 'column' ? 'flex-col space-y-1' : 'flex-row items-center gap-2'
       )}
     >
-      <p className='text-base font-semibold text-white truncate'>{trackName}</p>
-      {djNickname && <p className='text-xs text-gray-500 truncate'>🎧 {djNickname}</p>}
-      <p className='text-xs text-gray-600 shrink-0'>{duration}</p>
+      <TrackTitle name={trackName} emptyText='' />
+      {djNickname && (
+        <span
+          data-testid='now-playing-dj'
+          className='flex items-center gap-1 text-gray-500 min-w-0'
+        >
+          <PFHeadset width={14} height={14} aria-hidden='true' />
+          <Typography type='caption2' overflow='ellipsis' className='text-gray-500'>
+            {djNickname}
+          </Typography>
+        </span>
+      )}
+      <Typography type='caption2' className='text-gray-600 shrink-0'>
+        {duration}
+      </Typography>
     </div>
   );
 };

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/fullscreen-sheet.component.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { FC, ReactNode, useEffect, useId, useRef } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { MobileSheetHeader } from '@/shared/ui/components/mobile-sheet-header';
 import { PFArrowLeft, PFClose } from '@/shared/ui/icons';
 
 interface Props {
@@ -59,37 +60,35 @@ const FullscreenSheet: FC<Props> = ({ open, title, onClose, onBack, children, fo
       )}
     >
       {/* header sticky-top */}
-      <header className='shrink-0 flex items-center gap-3 px-3 h-[56px] border-b border-gray-800'>
-        {onBack ? (
-          <button
-            ref={backRef}
-            type='button'
-            onClick={onBack}
-            data-testid='fullscreen-sheet-back'
-            aria-label='뒤로'
-            className='p-2 -ml-2'
-          >
-            <PFArrowLeft width={24} height={24} />
-          </button>
-        ) : (
-          <button
-            ref={closeRef}
-            type='button'
-            onClick={onClose}
-            data-testid='fullscreen-sheet-close'
-            aria-label='닫기'
-            className='p-2 -ml-2'
-          >
-            <PFClose width={24} height={24} />
-          </button>
-        )}
-        {title && (
-          <h2 id={titleId} className='flex-1 text-center text-base font-medium m-0'>
-            {title}
-          </h2>
-        )}
-        <div className='w-[40px]' aria-hidden='true' />
-      </header>
+      <MobileSheetHeader
+        titleId={title ? titleId : undefined}
+        title={title}
+        leading={
+          onBack ? (
+            <button
+              ref={backRef}
+              type='button'
+              onClick={onBack}
+              data-testid='fullscreen-sheet-back'
+              aria-label='뒤로'
+              className='p-2 -ml-2'
+            >
+              <PFArrowLeft width={24} height={24} />
+            </button>
+          ) : (
+            <button
+              ref={closeRef}
+              type='button'
+              onClick={onClose}
+              data-testid='fullscreen-sheet-close'
+              aria-label='닫기'
+              className='p-2 -ml-2'
+            >
+              <PFClose width={24} height={24} />
+            </button>
+          )
+        }
+      />
 
       {/* body scrollable */}
       <div className='flex-1 overflow-y-auto'>{children}</div>

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
@@ -75,4 +75,10 @@ describe('PlaylistDetailSheet', () => {
     expect(screen.getByText('아직 곡이 없어요')).toBeInTheDocument();
     expect(screen.getByTestId('detail-add-tracks')).toBeInTheDocument();
   });
+
+  test('곡 제거 버튼은 PFClose 아이콘(svg) 렌더', () => {
+    useFetchPlaylistTracksMock.mockReturnValue({ data: { content: [TRACK] } });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+    expect(screen.getByTestId('detail-track-remove-11').querySelector('svg')).toBeTruthy();
+  });
 });

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
@@ -6,6 +6,7 @@ import { Playlist } from '@/shared/api/http/types/playlists';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import { Typography } from '@/shared/ui/components/typography';
+import { PFClose } from '@/shared/ui/icons';
 import { useFullscreenSheet } from '@/widgets-mobile/partyroom-djing-sheet';
 import AddTracksSheet from './add-tracks-sheet.component';
 
@@ -31,7 +32,7 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
     <div className='flex flex-col h-full'>
       <div className='flex-1 overflow-y-auto'>
         {tracks.length === 0 ? (
-          <div className='flex h-full items-center justify-center px-4'>
+          <div className='flex h-full items-center justify-center px-5'>
             <Typography type='body3' className='text-gray-400'>
               {t.partyroom.queue.playlist_tracks_empty}
             </Typography>
@@ -39,7 +40,7 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
         ) : (
           <ul className='flex flex-col divide-y divide-gray-800'>
             {tracks.map((track) => (
-              <li key={track.trackId} className='flex items-center gap-3 px-4 py-3'>
+              <li key={track.trackId} className='flex items-center gap-3 px-5 py-3'>
                 <img
                   src={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
                   alt={track.name}
@@ -55,7 +56,7 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
                   className='shrink-0 px-2 py-1 text-gray-400'
                   aria-label={t.partyroom.queue.remove_track_label}
                 >
-                  ×
+                  <PFClose width={20} height={20} aria-hidden='true' />
                 </button>
               </li>
             ))}

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlists-management-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlists-management-sheet.component.tsx
@@ -54,7 +54,7 @@ const PlaylistsManagementSheet: FC = () => {
     <div className='flex flex-col h-full'>
       <div className='flex-1 overflow-y-auto'>
         {playlists.length === 0 ? (
-          <div className='flex h-full items-center justify-center px-4'>
+          <div className='flex h-full items-center justify-center px-5'>
             <Typography type='body3' className='text-gray-400'>
               {t.partyroom.queue.playlists_empty}
             </Typography>
@@ -64,7 +64,7 @@ const PlaylistsManagementSheet: FC = () => {
             {playlists.map((p) => {
               const isGrab = p.type === PlaylistType.GRABLIST;
               return (
-                <li key={p.id} className='flex items-center justify-between gap-3 px-4 py-4'>
+                <li key={p.id} className='flex items-center justify-between gap-3 px-5 py-3'>
                   <button
                     type='button'
                     data-testid={`manage-playlist-card-${p.id}`}

--- a/src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx
+++ b/src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.test.tsx
@@ -11,16 +11,20 @@ describe('mobile TabBar', () => {
     expect(screen.getByTestId('mobile-tab-queue')).toBeTruthy();
   });
 
-  test('크루 라벨에 인원 카운트 표시', () => {
-    render(<TabBar activeTab='chat' crewCount={12} queueCount={0} onTabClick={vi.fn()} />);
-    expect(screen.getByTestId('mobile-tab-crew').textContent).toContain('12');
+  test('각 탭 PF 아이콘 + 카운트 렌더', () => {
+    render(<TabBar activeTab='chat' crewCount={12} queueCount={4} onTabClick={vi.fn()} />);
+    expect(screen.getByTestId('mobile-tab-chat').querySelector('svg')).toBeTruthy();
+    const crew = screen.getByTestId('mobile-tab-crew');
+    expect(crew.querySelector('svg')).toBeTruthy();
+    expect(crew.textContent).toContain('12');
+    const queue = screen.getByTestId('mobile-tab-queue');
+    expect(queue.querySelector('svg')).toBeTruthy();
+    expect(queue.textContent).toContain('4');
   });
 
-  test('큐 라벨에 DJ 큐 카운트 표시 (chunk 4 wiring)', () => {
-    render(<TabBar activeTab='chat' crewCount={5} queueCount={4} onTabClick={vi.fn()} />);
-    const queueBtn = screen.getByTestId('mobile-tab-queue');
-    expect(queueBtn.textContent).toMatch(/🎧/);
-    expect(queueBtn.textContent).toContain('4');
+  test('활성 탭은 레드 강조 클래스', () => {
+    render(<TabBar activeTab='crew' crewCount={5} queueCount={0} onTabClick={vi.fn()} />);
+    expect(screen.getByTestId('mobile-tab-crew').className).toMatch(/text-red-/);
   });
 
   test('활성 탭은 aria-selected=true', () => {
@@ -34,5 +38,15 @@ describe('mobile TabBar', () => {
     render(<TabBar activeTab='chat' crewCount={5} queueCount={0} onTabClick={onTabClick} />);
     fireEvent.click(screen.getByTestId('mobile-tab-crew'));
     expect(onTabClick).toHaveBeenCalledWith('crew');
+  });
+
+  test('카운트만 보이는 탭(크루·큐)은 aria-label 로 의미 전달 + 아이콘은 aria-hidden', () => {
+    render(<TabBar activeTab='chat' crewCount={12} queueCount={4} onTabClick={vi.fn()} />);
+    const crew = screen.getByTestId('mobile-tab-crew');
+    const queue = screen.getByTestId('mobile-tab-queue');
+    expect(crew.getAttribute('aria-label')).toBe('크루 12');
+    expect(queue.getAttribute('aria-label')).toBe('DJ 큐 4');
+    expect(crew.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(queue.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx
+++ b/src/widgets-mobile/partyroom-room-tabs/ui/parts/tab-bar.component.tsx
@@ -1,6 +1,14 @@
 'use client';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+import {
+  PFChatFilled,
+  PFChatOutline,
+  PFPersonFilled,
+  PFPersonOutline,
+  PFHeadset,
+} from '@/shared/ui/icons';
 import { TabKey } from '../../lib/use-tab-hash.hook';
 
 interface Props {
@@ -11,66 +19,98 @@ interface Props {
 }
 
 /**
- * 모바일 룸 탭바 (§4.2 ASCII 디자인 56px 높이).
+ * 모바일 룸 탭바 — PF 아이콘 + Typography, 활성 탭 = 레드 강조 + 상단 언더라인.
  *
- * - 3 버튼: 💬 채팅 · 👥 N · 🎧 N (chunk 4 에서 큐 카운트 활성화)
- * - 활성 탭 = bg-gray-900 + text-white, 비활성 = text-gray-400
+ * - 3 버튼: 채팅(Chat) · 크루 인원 N · DJ 큐 N
+ * - 활성 = text-red-400 + border-t-2 border-red-400, 비활성 = text-gray-400
  * - 터치 타겟 min-h-[44px] (iOS HIG, spec §4.1)
  * - safe-area-inset-bottom 은 본 탭바 자체 padding 으로 흡수
- * - 라벨은 inline 한글 (chunk 2 의 "{N}명 청취 중" 과 동일 정책, v1 다국어화 OUT)
  */
-const TabBar: FC<Props> = ({ activeTab, crewCount, queueCount, onTabClick }) => {
-  return (
-    <nav
-      className={cn(
-        'shrink-0 grid grid-cols-3 bg-black border-t border-gray-800',
-        'pb-[env(safe-area-inset-bottom)]'
-      )}
-      role='tablist'
-      aria-label='파티룸 탭'
-    >
-      <TabButton
-        testId='mobile-tab-chat'
-        active={activeTab === 'chat'}
-        label='💬 채팅'
-        onClick={() => onTabClick('chat')}
-      />
-      <TabButton
-        testId='mobile-tab-crew'
-        active={activeTab === 'crew'}
-        label={`👥 ${crewCount}`}
-        onClick={() => onTabClick('crew')}
-      />
-      <TabButton
-        testId='mobile-tab-queue'
-        active={activeTab === 'queue'}
-        label={`🎧 ${queueCount}`}
-        onClick={() => onTabClick('queue')}
-      />
-    </nav>
-  );
-};
+const TabBar: FC<Props> = ({ activeTab, crewCount, queueCount, onTabClick }) => (
+  <nav
+    className={cn(
+      'shrink-0 grid grid-cols-3 bg-black border-t border-gray-800',
+      'pb-[env(safe-area-inset-bottom)]'
+    )}
+    role='tablist'
+    aria-label='파티룸 탭'
+  >
+    <TabButton
+      testId='mobile-tab-chat'
+      active={activeTab === 'chat'}
+      ariaLabel='채팅'
+      icon={
+        activeTab === 'chat' ? (
+          <PFChatFilled width={20} height={20} aria-hidden='true' />
+        ) : (
+          <PFChatOutline width={20} height={20} aria-hidden='true' />
+        )
+      }
+      text='채팅'
+      onClick={() => onTabClick('chat')}
+    />
+    <TabButton
+      testId='mobile-tab-crew'
+      active={activeTab === 'crew'}
+      ariaLabel={`크루 ${crewCount}`}
+      icon={
+        activeTab === 'crew' ? (
+          <PFPersonFilled width={20} height={20} aria-hidden='true' />
+        ) : (
+          <PFPersonOutline width={20} height={20} aria-hidden='true' />
+        )
+      }
+      count={crewCount}
+      onClick={() => onTabClick('crew')}
+    />
+    <TabButton
+      testId='mobile-tab-queue'
+      active={activeTab === 'queue'}
+      ariaLabel={`DJ 큐 ${queueCount}`}
+      icon={<PFHeadset width={20} height={20} aria-hidden='true' />}
+      count={queueCount}
+      onClick={() => onTabClick('queue')}
+    />
+  </nav>
+);
 
 interface TabButtonProps {
   testId: string;
   active: boolean;
-  label: string;
+  /** 버튼 접근성 이름. 카운트만 보이는 탭(크루/큐)의 의미를 스크린리더에 전달 (아이콘은 aria-hidden). */
+  ariaLabel: string;
+  icon: ReactNode;
+  text?: string;
+  count?: number;
   onClick: () => void;
 }
 
-const TabButton: FC<TabButtonProps> = ({ testId, active, label, onClick }) => (
+const TabButton: FC<TabButtonProps> = ({
+  testId,
+  active,
+  ariaLabel,
+  icon,
+  text,
+  count,
+  onClick,
+}) => (
   <button
     type='button'
     data-testid={testId}
     role='tab'
     aria-selected={active}
+    aria-label={ariaLabel}
     className={cn(
-      'min-h-[44px] py-3 text-sm font-medium',
-      active ? 'bg-gray-900 text-white' : 'text-gray-400'
+      'min-h-[44px] py-2 flex flex-col items-center justify-center gap-0.5',
+      'border-t-2',
+      active ? 'text-red-400 border-red-400' : 'text-gray-400 border-transparent'
     )}
     onClick={onClick}
   >
-    {label}
+    {icon}
+    <Typography type='caption2' className='leading-none'>
+      {text ?? count}
+    </Typography>
   </button>
 );
 

--- a/src/widgets/partyroom-display-board/ui/parts/video-title.component.tsx
+++ b/src/widgets/partyroom-display-board/ui/parts/video-title.component.tsx
@@ -1,28 +1,11 @@
-import Marquee from 'react-fast-marquee';
-import { cn } from '@/shared/lib/functions/cn';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
-import { Typography } from '@/shared/ui/components/typography';
-import { galmuriFont } from '@/shared/ui/foundation/fonts';
+import { TrackTitle } from '@/shared/ui/components/track-title';
 
 export default function VideoTitle() {
   const t = useI18n();
   const { useCurrentPartyroom } = useStores();
   const playback = useCurrentPartyroom((state) => state.playback);
-  const typoClassName = cn(galmuriFont.className, 'text-white leading-none');
 
-  if (!playback) {
-    return (
-      <Typography type='caption1' className={typoClassName} data-testid='video-title-empty'>
-        {t.dj.para.empty_dj}
-      </Typography>
-    );
-  }
-  return (
-    <Marquee delay={4} speed={20} gradientWidth={0} className='z-0'>
-      <Typography type='body3' className={typoClassName} data-testid='video-title'>
-        {playback.name}
-      </Typography>
-    </Marquee>
-  );
+  return <TrackTitle name={playback?.name} emptyText={t.dj.para.empty_dj} />;
 }


### PR DESCRIPTION
## 요약

모바일 웹 뷰(`widgets-mobile`/`features-mobile`)의 시각 디자인 언어를 데스크탑(브라우저) 버전으로 통일해 "웹·모바일이 같은 서비스"라는 일관된 인상을 만든다. **레이아웃은 모바일 네이티브(탭·시트·1열) 유지, 시각 언어(PF 아이콘·Galmuri+마퀴·패널 크롬·여백 리듬·레드 강조)만 이식**한다.

핵심은 표면적 모방이 아니라 **데스크탑 프리미티브의 구조적 공유**다:
- `TrackTitle` = 데스크탑 `VideoTitle`에서 추출한 동일 컴포넌트(Galmuri+react-fast-marquee). 데스크탑은 이걸로 위임 → **렌더 불변**(가드 테스트 무수정 통과로 증명).
- `MobileSheetHeader` = 56px·하단 border-gray-800·중앙 h2 타이틀 표준 헤더(룸·시트·검색 공통).

## 변경 (Chunk별)

- **Chunk 1 — 공용 프리미티브**: `TrackTitle` 추출+데스크탑 위임 / `MobileSheetHeader` 추출+fullscreen-sheet 채택(h2 시맨틱·대칭 스페이서).
- **Chunk 2 — Room**: 룸 헤더 `←/⋮`→`PFArrowLeft/PFMoreVert` / now-playing 트랙명 `TrackTitle`+DJ `PFHeadset` / 탭바 이모지→PF 아이콘+`Typography`+활성 레드 상단 언더라인(+aria-label·aria-hidden 접근성) / 채팅 패널 `px-5` 정합.
- **Chunk 3 — Lobby/Sheets/Search**: 로비 카드 썸네일 `64×36→80×44`(데스크탑 비례) / DJ·플레이리스트 시트 `px-5 py-3`+곡 제거 `×`→`PFClose` / 검색 결과 `▶/+`→`PFPlayCircleFilled/PFAdd`+검색바·행 `px-5`.
- **Chunk 4 — 마감**: 모바일 캡처 스크립트 추가 + 스크린샷 산출물 gitignore.

## 검증

- 전체 단위테스트 **286 files / 1563 passed (1 todo), EXIT 0** · `tsc --noEmit` 클린 · `eslint` 클린.
- 로컬 풀스택 e2e 스크린샷(iPhone13, backend docker + next dev) + **데스크탑 side-by-side**로 시각 언어 통일 육안 확인(로비 카드·룸 평점 아이콘·채팅·색 일치).
- 데스크탑 `VideoTitle` 가드 테스트 무수정 통과 = 데스크탑 렌더 불변 1차 증명.
- 각 Task spec 준수 + 코드 품질 2단계 리뷰 통과(now-playing·탭바 접근성 보강 반영).

## 후속 / 주의

- **#394(모바일 강제 프로필 온보딩) 머지 후 R-merge 필요**: `search-list-item`·`partyroom-display-board`가 #394와 겹침 → 양쪽 보존(썸네일 + PF 아이콘) 해소. 프로필 폼 A5 정합도 #394 후 후속.
- **생성 다이얼로그 모바일 오버플로우는 본 PR 범위 밖** — 공용 데스크탑 모달 미적응이며 별도 작업으로 개선 예정.
- 게이트 플래그(비차단): 헤더 히트타깃 `w-10`(40px<iOS HIG 44px) · 큐 탭 `PFHeadsetFilled` 부재(디자인언어 갭).
- dev 머지 = 자동 dev 배포 트리거. **prod 미반영**(별도 release 게이트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)