### PR TITLE
feat(폼): 모바일 폼 오버플로우 근본 차단 — 반응형 FormItem + 생성 다이얼로그 수정

### DIFF
--- a/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
+++ b/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
@@ -113,7 +113,7 @@ Expected: FAIL — 현재 horizontal은 `grid-cols-[max-content_1fr]`(접두사 
 
 ```tsx
 className={cn([
-  'grid gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
+  'grid grid-cols-1 gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
   layout === 'horizontal' && {
     'tablet:grid-cols-[max-content_1fr]': !fit,
     'tablet:grid-cols-[max-content_max-content]': fit,
@@ -122,7 +122,7 @@ className={cn([
 ])}
 ```
 
-(모바일: grid-cols 미지정 → 단일칼럼 stack. tablet+: 현행 2칼럼. vertical: 변화 없음 — 원래 grid-cols 미지정.)
+(모바일: 명시적 `grid-cols-1` → 단일칼럼 stack. tablet+: `tablet:grid-cols-[...]`가 현행 2칼럼으로 오버라이드(twMerge 별도 버킷). vertical: `grid-cols-1` 단일칼럼 — 기존 동작과 동일.)
 
 - [ ] **Step 4: 구현 — 라벨 정렬 반응형**
 

--- a/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
+++ b/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
@@ -4,7 +4,7 @@
 
 **Goal:** 모바일 뷰포트(360px)에서 공용 폼·모달의 가로 오버플로우를 공용 `FormItem`을 브레이크포인트 반응형으로 만들어 근본 차단한다. 데스크탑은 불변.
 
-**Architecture:** 주 작업은 공용 `FormItem`의 `horizontal` 레이아웃을 `tablet`(768px) 미만에서 세로 적층으로 자동 전환(CSS 브레이크포인트). 이후 각 모바일 폼/모달을 360px에서 실측해 잔여 오버플로우만 표면별로 보강하고, #394가 깔아둔 중복 per-form 핵을 정리한다.
+**Architecture:** 주 작업은 공용 `FormItem`의 `horizontal` 레이아웃을 `tablet`(768px) 미만에서 세로 적층으로 자동 전환(CSS 브레이크포인트). 이후 각 모바일 폼/모달을 360px에서 실측해 잔여 오버플로우만 표면별로 보강한다. (본 작업은 #394와 독립 — 정정 내역은 §공통 규약·§전제 참조.)
 
 **Tech Stack:** Next.js(App Router) · React · TypeScript · Tailwind(커스텀 screens: `tablet: 768px`) · vitest + @testing-library/react · Playwright(스크린샷 검증).
 
@@ -15,13 +15,13 @@
 
 ## 공통 규약 (모든 Task)
 
-- ⚠️ **하드 전제 — #394 머지+rebase 후 구현**: 본 브랜치를 #394 머지가 반영된 development 위로 rebase한 뒤 구현 시작. #394 미머지 상태로 `FormItem`을 손대면 #394의 `min-w-0` 변경과 충돌하는 diff가 난다. (스펙/플랜 문서만 선작성됨.)
+- ✅ **착수 가능 (2026-06-09 정정)**: #394·#395 dev 머지 완료, 본 브랜치는 development(`7fdbf90`) 위 rebase 완료. **#394와 파일 겹침 0** — 당초 "#394가 min-w-0을 깐다"는 전제는 사실이 아니었고(현 development에 form-item/input `min-w-0` 부재), 본 작업은 #394와 독립이다. 주 수정(반응형 FormItem 단일칼럼)은 `min-w-0` 없이도 모바일 오버플로우를 해소하므로 그대로 진행. (스펙 §전제 정정 참조.)
 - **순수 프론트엔드** — JDK 불필요. 명령은 레포 루트(`pfplay-web/`)에서.
 - **테스트:** `yarn test src/<path>/<file>.test.tsx` (vitest run). **타입:** `yarn test:type`. **린트:** `yarn lint`.
 - **브레이크포인트:** 모바일↔데스크탑 경계 = `tablet`(768px). 모바일 = `< tablet`(접두사 없는 기본값), 데스크탑 = `tablet:` 이상. **데스크탑 불변 = `tablet:` 이상 클래스가 현행과 동일**.
 - **데스크탑 불변 원칙:** 모든 변경은 `tablet:` 게이트로 데스크탑(≥768px) 렌더를 바꾸지 않는다. 검증은 데스크탑 1440px 스크린샷 전/후 비교.
 - **커밋:** Task별 1커밋. 메시지 한글, 푸터 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. lint-staged 자동 실행.
-- **스크린샷 검증:** backend docker(:8080) + `npx next dev`(:3000, http/webpack — `yarn dev` 금지). 모바일 컨텍스트 360px + 데스크탑 1440px. 캡처 스크립트는 #394 머지 후 development에 포함된 `scripts/capture-mobile-screens.mjs`를 재사용하거나, 360/1440 폼 전용 캡처를 임시 작성(비커밋).
+- **스크린샷 검증:** backend docker(:8080) + `npx next dev`(:3000, http/webpack — `yarn dev` 금지). 모바일 컨텍스트 360px + 데스크탑 1440px. 캡처 스크립트 `scripts/capture-mobile-screens.mjs`는 #395 머지로 development에 포함됨 — 재사용하거나 360/1440 폼 전용 캡처를 임시 작성(비커밋).
 
 ---
 
@@ -30,7 +30,7 @@
 - **수정(주):** `src/shared/ui/components/form-item/form-item.component.tsx` — 컨테이너 grid·라벨 정렬·에러 스페이서를 `tablet:` 반응형으로.
 - **수정(테스트):** `src/shared/ui/components/form-item/form-item.component.test.tsx` — 반응형 클래스 단언 추가.
 - **조건부 수정(표면 스윕):** `src/features/bug-report/ui/bug-report-dialog.component.tsx`, `src/shared/ui/components/dialog/dialog.component.tsx` 등 — 실측 후 진짜 패널 오버플로우 남는 곳만.
-- **조건부 정리(#394 핵):** `src/features/partyroom/create/lib/use-be-a-host.hook.tsx`, `src/entities/partyroom-info/ui/form.component.tsx`, `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx` — 공용 수정이 덮음을 확인 후에만.
+- **(정리 대상 없음):** 당초 가정한 #394 per-form 핵(use-be-a-host `max-w`·partyroom-info `flex-wrap`)은 현 development에 부재. `mobile-profile-edit-form`의 `layout='vertical'`은 모바일 전용이라 무해, 그대로 둠.
 
 ---
 
@@ -185,14 +185,14 @@ git commit -m "feat(폼): FormItem horizontal 레이아웃 tablet 반응형(모�
 
 ## Chunk 2: 증거 기반 표면 스윕 + 조건부 Dialog 클램프
 
-> 각 표면은 **360px 실측 → 근본원인 확인 → (필요시) 수정 → 재검**. Chunk 1 + #394의 `min-w-0`로 이미 해소되면 "변경 없음(확인됨)"으로 기록하고 넘어간다. **무분별한 코드 추가 금지** — 진짜 잔여 오버플로우만 수정.
+> 각 표면은 **360px 실측 → 근본원인 확인 → (필요시) 수정 → 재검**. Chunk 1(모바일 세로 전환)로 이미 해소되면 "변경 없음(확인됨)"으로 기록하고 넘어간다. **무분별한 코드 추가 금지** — 진짜 잔여 오버플로우만 수정.
 
 ### Task 2: 생성 다이얼로그(Create Party) 360px 실측 + 정리 확인
 
 **Files:** (실측용) `src/features/partyroom/create/...`, `src/entities/partyroom-info/ui/form.component.tsx`
 
 - [ ] **Step 1: 360px 스크린샷** — dev-login(full)→로비→Create Party 다이얼로그 열기, 360px 뷰포트로 캡처. 가로 오버플로우(입력칸 잘림) 여부 확인.
-- [ ] **Step 2: 판정** — Chunk1(세로 전환)+#394(min-w-0)로 오버플로우 0이면 "해소 확인"만 기록. 잔여 오버플로우 있으면 원인(어느 엘리먼트가 넘치는지) 특정.
+- [ ] **Step 2: 판정** — Chunk1(모바일 세로 전환)로 오버플로우 0이면 "해소 확인"만 기록. 잔여 오버플로우 있으면 원인(어느 엘리먼트가 넘치는지) 특정.
 - [ ] **Step 3: (조건부) 수정** — 잔여 시 해당 폼 컨테이너에 최소 수정(예: 특정 row `flex-wrap`/`min-w-0`). 데스크탑 불변 유지.
 - [ ] **Step 4: 데스크탑 1440px 캡처** — 다이얼로그 레이아웃 현행과 동일 확인.
 - [ ] **Step 5: (수정 시) 커밋** / 변경 없으면 다음 Task.
@@ -227,21 +227,11 @@ git commit -m "feat(폼): FormItem horizontal 레이아웃 tablet 반응형(모�
 
 ---
 
-## Chunk 3: #394 중복 핵 정리 + 최종 검증
+## Chunk 3: 최종 검증
 
-### Task 5: #394 per-form 핵 정리 (표면별 검증 게이트)
+> **2026-06-09 정정**: 당초 Task 5(#394 per-form 핵 정리)의 대상(use-be-a-host `max-w`·생성폼 `flex-wrap`)은 **현 development에 존재하지 않음**(#394에 안 들어감) → 제거할 게 없어 Task 5 삭제. `mobile-profile-edit-form`의 `layout='vertical'`은 모바일 전용 렌더라 무해 → 그대로 둠. Chunk 3은 최종 회귀만.
 
-> Chunk1(+#394 min-w-0)이 표면을 덮음을 Chunk2 스크린샷으로 이미 확인. 이제 중복 특수처리를 제거해 코드 더럽힘 회피. **각 핵 제거 후 그 표면 360px 재캡처로 회귀 0 확인.**
-
-**Files:** `src/features/partyroom/create/lib/use-be-a-host.hook.tsx`, `src/entities/partyroom-info/ui/form.component.tsx`, `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`
-
-- [ ] **Step 1: `use-be-a-host` 다이얼로그 `max-w`** — Dialog 베이스 클램프(있다면) 또는 Chunk1로 불필요해졌으면 제거. 제거 후 생성 다이얼로그 360px 재캡처 → 오버플로우 0 확인. (Dialog 클램프를 안 넣었고 이 max-w가 유일한 패널 가드면 남긴다.)
-- [ ] **Step 2: 생성폼 `flex-wrap`** (`form.component.tsx` 도메인/제한 row) — Chunk1 세로 전환으로 불필요하면 제거, 재캡처 확인.
-- [ ] **Step 3: `mobile-profile-edit-form layout='vertical'`** — FormItem이 모바일 자동 세로이므로 명시 prop 불필요 시 제거(단, 이 컴포넌트가 데스크탑에서도 렌더되면 데스크탑이 가로로 바뀌므로 **모바일 전용 렌더 여부 확인 후** 결정 — 모바일 전용이면 제거 안전, 공용이면 남김).
-- [ ] **Step 4: 각 제거마다 모바일/데스크탑 재캡처로 회귀 0 확인.**
-- [ ] **Step 5: 커밋** — `refactor(폼): FormItem 반응형으로 불필요해진 #394 per-form 오버플로우 핵 정리`
-
-### Task 6: 최종 회귀 + 스크린샷 일괄
+### Task 5: 최종 회귀 + 스크린샷 일괄
 
 - [ ] **Step 1: 전체 단위테스트** — `yarn test` Expected: 전체 GREEN.
 - [ ] **Step 2: 타입** — `yarn test:type` Expected: 0.
@@ -270,4 +260,4 @@ git commit -m "feat(폼): FormItem horizontal 레이아웃 tablet 반응형(모�
 
 저장 위치: `docs/superpowers/plans/2026-06-09-mobile-form-overflow.md`
 
-**실행:** ⚠️ **#394 머지+rebase 후** subagent-driven-development로 Task별 진행(Task별 fresh subagent + 2단계 리뷰). Chunk 경계에서 검증 게이트 통과 후 다음.
+**실행:** ✅ #394·#395 머지 완료 + rebase 완료 → **바로 착수 가능**. subagent-driven-development로 Task별 진행(Task별 fresh subagent + 2단계 리뷰). Chunk 경계에서 검증 게이트 통과 후 다음.

--- a/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
+++ b/docs/superpowers/plans/2026-06-09-mobile-form-overflow.md
@@ -1,0 +1,273 @@
+# 모바일 폼 오버플로우 근본 차단 — 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 모바일 뷰포트(360px)에서 공용 폼·모달의 가로 오버플로우를 공용 `FormItem`을 브레이크포인트 반응형으로 만들어 근본 차단한다. 데스크탑은 불변.
+
+**Architecture:** 주 작업은 공용 `FormItem`의 `horizontal` 레이아웃을 `tablet`(768px) 미만에서 세로 적층으로 자동 전환(CSS 브레이크포인트). 이후 각 모바일 폼/모달을 360px에서 실측해 잔여 오버플로우만 표면별로 보강하고, #394가 깔아둔 중복 per-form 핵을 정리한다.
+
+**Tech Stack:** Next.js(App Router) · React · TypeScript · Tailwind(커스텀 screens: `tablet: 768px`) · vitest + @testing-library/react · Playwright(스크린샷 검증).
+
+**스펙:** `docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md`
+**브랜치:** `feature/mobile-form-overflow` (origin/development 분기)
+
+---
+
+## 공통 규약 (모든 Task)
+
+- ⚠️ **하드 전제 — #394 머지+rebase 후 구현**: 본 브랜치를 #394 머지가 반영된 development 위로 rebase한 뒤 구현 시작. #394 미머지 상태로 `FormItem`을 손대면 #394의 `min-w-0` 변경과 충돌하는 diff가 난다. (스펙/플랜 문서만 선작성됨.)
+- **순수 프론트엔드** — JDK 불필요. 명령은 레포 루트(`pfplay-web/`)에서.
+- **테스트:** `yarn test src/<path>/<file>.test.tsx` (vitest run). **타입:** `yarn test:type`. **린트:** `yarn lint`.
+- **브레이크포인트:** 모바일↔데스크탑 경계 = `tablet`(768px). 모바일 = `< tablet`(접두사 없는 기본값), 데스크탑 = `tablet:` 이상. **데스크탑 불변 = `tablet:` 이상 클래스가 현행과 동일**.
+- **데스크탑 불변 원칙:** 모든 변경은 `tablet:` 게이트로 데스크탑(≥768px) 렌더를 바꾸지 않는다. 검증은 데스크탑 1440px 스크린샷 전/후 비교.
+- **커밋:** Task별 1커밋. 메시지 한글, 푸터 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. lint-staged 자동 실행.
+- **스크린샷 검증:** backend docker(:8080) + `npx next dev`(:3000, http/webpack — `yarn dev` 금지). 모바일 컨텍스트 360px + 데스크탑 1440px. 캡처 스크립트는 #394 머지 후 development에 포함된 `scripts/capture-mobile-screens.mjs`를 재사용하거나, 360/1440 폼 전용 캡처를 임시 작성(비커밋).
+
+---
+
+## File Structure
+
+- **수정(주):** `src/shared/ui/components/form-item/form-item.component.tsx` — 컨테이너 grid·라벨 정렬·에러 스페이서를 `tablet:` 반응형으로.
+- **수정(테스트):** `src/shared/ui/components/form-item/form-item.component.test.tsx` — 반응형 클래스 단언 추가.
+- **조건부 수정(표면 스윕):** `src/features/bug-report/ui/bug-report-dialog.component.tsx`, `src/shared/ui/components/dialog/dialog.component.tsx` 등 — 실측 후 진짜 패널 오버플로우 남는 곳만.
+- **조건부 정리(#394 핵):** `src/features/partyroom/create/lib/use-be-a-host.hook.tsx`, `src/entities/partyroom-info/ui/form.component.tsx`, `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx` — 공용 수정이 덮음을 확인 후에만.
+
+---
+
+## Chunk 1: 반응형 FormItem (핵심)
+
+### Task 1: `FormItem` horizontal 레이아웃 브레이크포인트 반응형
+
+데스크탑 `horizontal`(라벨좌/입력우 2칼럼)을 `tablet` 미만에서 세로 단일칼럼으로 자동 전환. `layout='vertical'` 호출자와 데스크탑(≥tablet)은 불변.
+
+**Files:**
+
+- Modify: `src/shared/ui/components/form-item/form-item.component.tsx`
+- Test: `src/shared/ui/components/form-item/form-item.component.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`form-item.component.test.tsx`에 추가(기존 테스트·Typography mock 유지):
+
+```tsx
+describe('FormItem 반응형 레이아웃', () => {
+  test('horizontal(기본): 모바일 단일칼럼 + tablet:부터 2칼럼 그리드', () => {
+    const { container } = render(
+      <FormItem label='이름'>
+        <input />
+      </FormItem>
+    );
+    const label = container.querySelector('label')!;
+    // tablet: 이상에서만 2칼럼 → 모바일은 단일칼럼(stack)
+    expect(label.className).toContain('tablet:grid-cols-[max-content_1fr]');
+    // 접두사 없는 상시 2칼럼 클래스는 없어야(=모바일에서 2칼럼 강제 금지)
+    expect(label.className).not.toMatch(/(^|\s)grid-cols-\[max-content_1fr\]/);
+  });
+
+  test('horizontal: 라벨 정렬이 모바일 text-start / tablet:text-right', () => {
+    const { container } = render(
+      <FormItem label='이름'>
+        <input />
+      </FormItem>
+    );
+    const labelText = container.querySelector('[data-custom-role="form-item-title"]')!;
+    expect(labelText.className).toContain('text-start');
+    expect(labelText.className).toContain('tablet:text-right');
+  });
+
+  test('vertical: 항상 세로(2칼럼 그리드 없음) + text-start, tablet:text-right 없음(불변)', () => {
+    const { container } = render(
+      <FormItem label='이름' layout='vertical'>
+        <input />
+      </FormItem>
+    );
+    const label = container.querySelector('label')!;
+    expect(label.className).not.toContain('grid-cols-[max-content');
+    const labelText = container.querySelector('[data-custom-role="form-item-title"]')!;
+    expect(labelText.className).toContain('text-start');
+    expect(labelText.className).not.toContain('tablet:text-right');
+  });
+
+  test('horizontal + error: 스페이서 div가 hidden tablet:block (모바일 빈 행 방지)', () => {
+    const { container } = render(
+      <FormItem label='이름' error='필수 항목입니다'>
+        <input />
+      </FormItem>
+    );
+    const spacer = Array.from(container.querySelectorAll('div')).find((d) =>
+      d.className.includes('tablet:block')
+    );
+    expect(spacer).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `yarn test src/shared/ui/components/form-item/form-item.component.test.tsx`
+Expected: FAIL — 현재 horizontal은 `grid-cols-[max-content_1fr]`(접두사 없음), 라벨은 `text-right`(text-start 없음), 스페이서는 `block`(tablet:block 아님).
+
+- [ ] **Step 3: 구현 — 컨테이너 grid 반응형**
+
+`form-item.component.tsx` 컨테이너 `<label>` className의 horizontal 분기를 `tablet:` 접두사로:
+
+```tsx
+className={cn([
+  'grid gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
+  layout === 'horizontal' && {
+    'tablet:grid-cols-[max-content_1fr]': !fit,
+    'tablet:grid-cols-[max-content_max-content]': fit,
+  },
+  classNames?.container,
+])}
+```
+
+(모바일: grid-cols 미지정 → 단일칼럼 stack. tablet+: 현행 2칼럼. vertical: 변화 없음 — 원래 grid-cols 미지정.)
+
+- [ ] **Step 4: 구현 — 라벨 정렬 반응형**
+
+`labelTextStyle`의 horizontal 정렬을 `text-start tablet:text-right`로:
+
+```tsx
+const labelTextStyle = (layout: Axis, required?: boolean) => {
+  return [
+    'relative pr-[12px]',
+    {
+      'text-start text-gray-300': layout === 'vertical',
+      'text-start tablet:text-right': layout === 'horizontal',
+    },
+    required &&
+      'after:content-["*"] after:absolute after:-right-[0.33em] after:top-[0.8em] after:transform after:-translate-x-1/2 after:-translate-y-1/2 after:text-red-300',
+  ];
+};
+```
+
+(라벨 타이포 `type`(body2/detail2) 분기는 **변경 안 함** — 스펙 결정.)
+
+- [ ] **Step 5: 구현 — 에러 스페이서 반응형**
+
+에러 스페이서 `<div>`를 모바일에서 숨김:
+
+```tsx
+<div
+  className={cn({
+    hidden: layout === 'vertical',
+    'hidden tablet:block': layout === 'horizontal',
+  })}
+/>
+```
+
+- [ ] **Step 6: 통과 확인**
+
+Run: `yarn test src/shared/ui/components/form-item/form-item.component.test.tsx`
+Expected: PASS (신규 4 + 기존 전부).
+
+- [ ] **Step 7: 타입 + 린트**
+
+Run: `yarn test:type && yarn lint`
+Expected: 에러 0.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add src/shared/ui/components/form-item/form-item.component.tsx src/shared/ui/components/form-item/form-item.component.test.tsx
+git commit -m "feat(폼): FormItem horizontal 레이아웃 tablet 반응형(모바일 세로/데스크탑 불변)"
+```
+
+---
+
+### Chunk 1 검증 게이트
+
+- [ ] `yarn test` 전체 GREEN · `yarn test:type` · `yarn lint` 클린
+- [ ] plan-document-reviewer 통과 후 다음 Chunk (실행 시)
+
+---
+
+## Chunk 2: 증거 기반 표면 스윕 + 조건부 Dialog 클램프
+
+> 각 표면은 **360px 실측 → 근본원인 확인 → (필요시) 수정 → 재검**. Chunk 1 + #394의 `min-w-0`로 이미 해소되면 "변경 없음(확인됨)"으로 기록하고 넘어간다. **무분별한 코드 추가 금지** — 진짜 잔여 오버플로우만 수정.
+
+### Task 2: 생성 다이얼로그(Create Party) 360px 실측 + 정리 확인
+
+**Files:** (실측용) `src/features/partyroom/create/...`, `src/entities/partyroom-info/ui/form.component.tsx`
+
+- [ ] **Step 1: 360px 스크린샷** — dev-login(full)→로비→Create Party 다이얼로그 열기, 360px 뷰포트로 캡처. 가로 오버플로우(입력칸 잘림) 여부 확인.
+- [ ] **Step 2: 판정** — Chunk1(세로 전환)+#394(min-w-0)로 오버플로우 0이면 "해소 확인"만 기록. 잔여 오버플로우 있으면 원인(어느 엘리먼트가 넘치는지) 특정.
+- [ ] **Step 3: (조건부) 수정** — 잔여 시 해당 폼 컨테이너에 최소 수정(예: 특정 row `flex-wrap`/`min-w-0`). 데스크탑 불변 유지.
+- [ ] **Step 4: 데스크탑 1440px 캡처** — 다이얼로그 레이아웃 현행과 동일 확인.
+- [ ] **Step 5: (수정 시) 커밋** / 변경 없으면 다음 Task.
+
+### Task 3: 버그신고 다이얼로그 360px 실측
+
+**Files:** `src/features/bug-report/ui/bug-report-dialog.component.tsx`(`w-[480px]`)
+
+- [ ] **Step 1: 360px 캡처** — Header 🐛 → 버그신고 모달. 패널이 뷰포트를 넘는지(패널 자체 오버플로우) 확인. (TextArea는 block이라 콘텐츠는 안전할 가능성.)
+- [ ] **Step 2: 판정** — 패널 `w-[480px]`이 `max-w-full`로 클램프되어 360px에 들어오면 "해소 확인". 패널이 뷰포트를 넘으면 → Step 3.
+- [ ] **Step 3: (조건부) Dialog 클램프** — 패널 오버플로우가 실재하면 **공용 `Dialog` 베이스**(`dialog.component.tsx` 패널 className)에 `max-w-[calc(100vw-2rem)]` 추가(모든 다이얼로그 일괄 안전, 데스크탑은 뷰포트가 넓어 무영향). 그 경우 Task 2의 생성 다이얼로그에도 동일 적용됨을 재검.
+- [ ] **Step 4: 데스크탑 1440px 캡처** — 모달 현행 동일 확인.
+- [ ] **Step 5: (수정 시) 커밋.**
+
+### Task 4: 프로필·사인인·도메인 등 잔여 폼 360px 실측
+
+**Files:** (실측) `src/features-mobile/profile/...`, `src/app/(auth)/sign-in/...`, 도메인 선택 컴포넌트, `src/features/edit-profile-bio/ui/v1.component.tsx`
+
+- [ ] **Step 1: 각 표면 360px 캡처** — 모바일 프로필 폼, 사인인, 도메인 선택. 데스크탑 ProfileEditForm V1(`w-[550px]`)은 **모바일 라우트에서 도달 가능한지 먼저 확인**(도달 불가면 범위 제외 기록).
+- [ ] **Step 2: 판정 + (조건부) 수정** — Chunk1으로 해소 안 되는 표면만 최소 수정. 사인인은 이미 `tablet:` 일부 사용 → 대개 자동 커버.
+- [ ] **Step 3: 데스크탑 1440px 캡처** — 각 표면 현행 동일 확인.
+- [ ] **Step 4: (수정 시) 커밋.**
+
+---
+
+### Chunk 2 검증 게이트
+
+- [ ] 대상 표면 전부 360px에서 가로 오버플로우 0 (스크린샷 근거)
+- [ ] 데스크탑 1440px 전부 현행 동일
+- [ ] `yarn test`/`test:type`/`lint` 클린
+- [ ] plan-document-reviewer 통과 후 다음 Chunk
+
+---
+
+## Chunk 3: #394 중복 핵 정리 + 최종 검증
+
+### Task 5: #394 per-form 핵 정리 (표면별 검증 게이트)
+
+> Chunk1(+#394 min-w-0)이 표면을 덮음을 Chunk2 스크린샷으로 이미 확인. 이제 중복 특수처리를 제거해 코드 더럽힘 회피. **각 핵 제거 후 그 표면 360px 재캡처로 회귀 0 확인.**
+
+**Files:** `src/features/partyroom/create/lib/use-be-a-host.hook.tsx`, `src/entities/partyroom-info/ui/form.component.tsx`, `src/features-mobile/profile/ui/mobile-profile-edit-form.component.tsx`
+
+- [ ] **Step 1: `use-be-a-host` 다이얼로그 `max-w`** — Dialog 베이스 클램프(있다면) 또는 Chunk1로 불필요해졌으면 제거. 제거 후 생성 다이얼로그 360px 재캡처 → 오버플로우 0 확인. (Dialog 클램프를 안 넣었고 이 max-w가 유일한 패널 가드면 남긴다.)
+- [ ] **Step 2: 생성폼 `flex-wrap`** (`form.component.tsx` 도메인/제한 row) — Chunk1 세로 전환으로 불필요하면 제거, 재캡처 확인.
+- [ ] **Step 3: `mobile-profile-edit-form layout='vertical'`** — FormItem이 모바일 자동 세로이므로 명시 prop 불필요 시 제거(단, 이 컴포넌트가 데스크탑에서도 렌더되면 데스크탑이 가로로 바뀌므로 **모바일 전용 렌더 여부 확인 후** 결정 — 모바일 전용이면 제거 안전, 공용이면 남김).
+- [ ] **Step 4: 각 제거마다 모바일/데스크탑 재캡처로 회귀 0 확인.**
+- [ ] **Step 5: 커밋** — `refactor(폼): FormItem 반응형으로 불필요해진 #394 per-form 오버플로우 핵 정리`
+
+### Task 6: 최종 회귀 + 스크린샷 일괄
+
+- [ ] **Step 1: 전체 단위테스트** — `yarn test` Expected: 전체 GREEN.
+- [ ] **Step 2: 타입** — `yarn test:type` Expected: 0.
+- [ ] **Step 3: 린트** — `yarn lint` Expected: 0.
+- [ ] **Step 4: 모바일 360px 폼 일괄 캡처** — 전 대상 폼/모달 가로 오버플로우 0 육안.
+- [ ] **Step 5: 데스크탑 1440px 일괄 캡처** — 전 대상 현행 불변 육안.
+- [ ] **Step 6: 잔여 미커밋 없는지 `git status` 확인.**
+
+---
+
+### Chunk 3 검증 게이트
+
+- [ ] 전체 test/type/lint GREEN · 모바일 오버플로우 0 · 데스크탑 불변
+- [ ] plan-document-reviewer 통과 후 마감
+
+---
+
+## 미해결 → 후속
+
+- dev 머지·prod 배포 = 사용자 게이트.
+- ProfileEditForm V1이 모바일 도달 불가로 범위 제외됐다면, 추후 데스크탑 프로필 모바일화 시 별도 처리.
+
+---
+
+## 실행 핸드오프
+
+저장 위치: `docs/superpowers/plans/2026-06-09-mobile-form-overflow.md`
+
+**실행:** ⚠️ **#394 머지+rebase 후** subagent-driven-development로 Task별 진행(Task별 fresh subagent + 2단계 리뷰). Chunk 경계에서 검증 게이트 통과 후 다음.

--- a/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
@@ -14,7 +14,8 @@
 
 - **#394·#395 dev 머지 완료. 본 작업은 #394와 독립** — 머지된 #394(`346ff20`)의 실제 변경은 모바일 프로필 온보딩 관련뿐(`mobile-profile-edit-form`·profile redirect guard·`edit-profile-bio/v1`·docs·e2e). **`form-item`/`input`/`use-be-a-host`/`partyroom-info`/`dialog`은 안 건드림** → 공유 파일 0, 충돌 없음.
 - ⚠️ **정정**: 초기 스펙은 "#394가 공용 프리미티브에 `min-w-0`을 깐다"를 전제했으나 **사실이 아님**(현 development에 `form-item`/`input` `min-w-0` 부재 확인). 그 1차 수정들(min-w-0·use-be-a-host max-w·partyroom-info flex-wrap)은 최종 #394에 들어가지 않았다.
-- **함의**: 주 수정(반응형 FormItem → 모바일 단일칼럼)은 단일칼럼에서 입력이 전체폭이라 `min-w-0` 없이도 오버플로우 해소(min-w-0는 desktop 가로용이고 desktop은 넓어 불필요 → YAGNI, 증거 없으면 추가 안 함). #394 유무와 무관하게 본 작업만으로 완결.
+- **함의**: 주 수정(반응형 FormItem → 모바일 단일칼럼)이 폼 레이아웃 오버플로우를 해소. #394 유무와 무관하게 본 작업만으로 완결.
+- **min-w-0 (Chunk2에서 추가됨)**: 단일칼럼 폼 자체엔 불필요하나, **`Input` 내부(`flex-1` input + 글자수 카운터 flex)에서 긴 placeholder가 input을 안 줄여 카운터(00/30)가 세로로 깨지는 케이스**가 360px 실측에서 발견됨 → `Input`의 input에 `min-w-0` 추가(원래 #394가 깔았어야 했던 그 수정). 데스크탑은 넓어 무영향.
 - 본 브랜치는 머지된 development(`7fdbf90`) 위로 rebase 완료. 바로 구현 가능.
 - dev 머지·prod 배포는 사용자 게이트.
 

--- a/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
@@ -1,0 +1,79 @@
+# 모바일 폼 오버플로우 근본 차단 — 설계
+
+## 배경 / 문제
+
+모바일 뷰포트에서 일부 폼·모달이 가로로 오버플로우한다. 디자인 언어 통일 작업의 e2e 리뷰 중 **생성 다이얼로그(Create Party)** 에서 확인됨: 입력칸이 화면 밖으로 잘림(스크린샷 근거).
+
+**근본 원인** (공용 레이어):
+
+- 공용 `FormItem`이 기본 `layout='horizontal'`로 `grid-cols-[max-content_1fr]` 가로 배치. `1fr` 입력 칼럼이 `min-w-0` 없이는 입력의 min-content 이하로 줄지 않아, 그리드가 패널 콘텐츠 박스 밖으로 visible overflow → 입력칸이 뷰포트 가장자리에서 잘림.
+- `Dialog` 패널은 `w-[440px] max-w-full`로 **패널 자체는 이미 뷰포트에 클램프**됨(`max-w-full`). 즉 패널이 아니라 **내부 콘텐츠 오버플로우**가 주범.
+- 이 패턴은 공용 `FormItem`을 쓰는 모든 폼(생성·도메인 등 — 모바일/데스크탑 공유)에서 재발 가능.
+
+## 전제 (하드 의존성)
+
+- **#394(모바일 프로필 온보딩) 먼저 dev 머지 후** 그 위에서 진행. #394가 공용 프리미티브에 `min-w-0`을 깔아둔다:
+  - `FormItem` children wrapper `min-w-0`
+  - `Input` 내부 input `min-w-0`
+  - `use-be-a-host` 다이얼로그 `max-w-[calc(100vw-32px)]`, 생성폼 `w-full`+`flex-wrap`, `mobile-profile-edit-form layout='vertical'`
+- 본 작업 브랜치는 #394 머지 반영된 development 위로 rebase 후 구현/검증한다. (스펙·플랜 문서는 선작성 가능)
+- dev 머지·prod 배포는 사용자 게이트.
+
+## 목표 / 성공 기준
+
+- **모바일 뷰포트(360px 기준)에서 어떤 폼·모달도 가로 오버플로우가 없다.**
+- **데스크탑(≥ tablet 브레이크포인트)은 픽셀 단위로 불변.**
+- 미래에 새 폼/다이얼로그를 추가해도 공용 프리미티브가 모바일 안전을 자동 보장(재발 0).
+
+## 비목표 (YAGNI)
+
+- 폼의 기능/검증/필드 변경 없음 — **레이아웃(오버플로우)만**.
+- 데스크탑 레이아웃 개선/리디자인 없음.
+- 모바일 디자인 언어 통일(별도 PR #395) 범위와 겹치지 않음.
+
+## 설계
+
+### ① 반응형 `FormItem` (주 작업)
+
+공용 `FormItem`의 `horizontal` 레이아웃을 **CSS 브레이크포인트 반응형**으로 전환:
+
+- **모바일(< tablet)**: 세로 적층 — 단일 칼럼(`grid-cols-1`), 라벨 좌측정렬(`text-start`), 라벨 아래 입력. (기존 `vertical` 레이아웃과 동일한 시각 형태)
+- **데스크탑(≥ tablet)**: 현재 `grid-cols-[max-content_1fr]`(또는 `fit` 시 `max-content`) 가로 배치 + 라벨 우측정렬 — **불변**.
+- 구현 방향(정확한 클래스는 플랜/TDD에서 확정):
+  - 컨테이너 grid: `grid-cols-1 tablet:grid-cols-[max-content_1fr]` (fit 분기 유지).
+  - 라벨 정렬: `text-start tablet:text-right`.
+  - `vertical`/`horizontal` 분기에서 가로만 반응형화. `layout='vertical'`을 명시한 호출자는 항상 세로(불변).
+- **라벨 타이포(`type`) 분기는 변경하지 않음** — `type`은 React prop이라 CSS 브레이크포인트로 못 바꿈. 모바일에서도 가로폼의 `body2` 유지(세로 배치에서 자연스러움, 차이 미미). 스크린샷에서 다른 모바일 폼(`detail2`)과 시각적으로 명확히 어긋나면, 그때만 라벨에 반응형 폰트사이즈 className 보정.
+- 효과: 공용 FormItem 사용 폼 전체가 모바일에서 자동 세로 → 오버플로우 소멸 + 깔끔한 모바일 레이아웃.
+
+### ② 증거 기반 표면 스윕 + 조건부 Dialog 클램프
+
+대상 표면을 **360px에서 실제 재현 → 근본 원인 확인 → 수정 → 재검**:
+
+- 대상: 생성 다이얼로그(Create Party), 버그신고 다이얼로그, 프로필(모바일 폼 + 데스크탑 ProfileEditForm V1의 모바일 도달 여부 확인), 사인인, 도메인 선택, 플레이리스트 폼(이미 `vertical`).
+- ①(반응형 FormItem) + #394(`min-w-0`)로 해소되면 해당 표면은 추가 작업 없음.
+- **패널 자체가 뷰포트를 초과하는 케이스가 남는 경우에만** 그 표면(또는 공용 `Dialog` 베이스)에 `max-w-[calc(100vw-2rem)]` 보강. 무분별한 전역 추가 금지.
+- 데스크탑 ProfileEditForm V1(`w-[550px]` 하드코딩 입력)이 모바일에서 도달 불가하면 범위 제외(확인 후 결정).
+
+### ③ #394 중복 핵 정리 (표면별 검증 게이트)
+
+①·#394로 불필요해진 per-form 핵을 정리(코드 더럽힘 회피):
+
+- 후보: `use-be-a-host` 다이얼로그 `max-w` / 생성폼 `flex-wrap` / `mobile-profile-edit-form layout='vertical'`.
+- **각 핵은 "그 표면을 공용 수정이 덮는다"를 모바일 스크린샷으로 확인한 뒤에만 제거.** 못 덮는 게 있으면 남기고 사유 기록.
+- (#394 머지 후 development 위에서 작업하므로 #394 코드 수정은 안전.)
+
+## 검증
+
+- **단위테스트**: `FormItem`이 반응형 클래스(`grid-cols-1 tablet:grid-cols-[...]`, `text-start tablet:text-right`)를 렌더하는지 단언. `layout='vertical'` 호출자는 세로 불변 단언. 기존 FormItem/Input 테스트 무수정 통과.
+- **e2e 스크린샷**: 백엔드 docker + `npx next dev`. 모바일(360px) + 데스크탑(1440px) 양쪽으로 각 폼 캡처:
+  - 모바일: 가로 오버플로우 0(입력칸 잘림 없음).
+  - 데스크탑: 변경 전/후 동일(불변 육안).
+- 전체 `yarn test` / `yarn test:type` / `yarn lint` GREEN.
+- [[feedback_local_e2e_before_dev_merge]] · [[feedback_elegant_no_code_dirtying]] · [[reference_pfplay_web_local_e2e_run]] · [[reference_pfplay_web_local_dev_http_webpack]] 준수.
+
+## 리스크 / 완화
+
+- **공용 컴포넌트(FormItem) 변경 → 회귀 범위 넓음**: 브레이크포인트 게이트로 데스크탑(≥tablet) 불변 보장 + 데스크탑 스크린샷으로 검증. FormItem을 쓰는 모든 폼을 모바일/데스크탑 양쪽 캡처로 확인.
+- **tablet 브레이크포인트 토큰 확인 필요**: `px-app`이 모바일 `px-20` / `tablet:px-40`을 쓰므로 tablet이 모바일↔데스크탑 경계. 플랜에서 정확한 토큰 재확인.
+- **#394 미머지 상태로 구현 착수 위험**: 구현은 #394 머지+rebase 후. 스펙/플랜만 선행.

--- a/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
@@ -10,14 +10,12 @@
 - `Dialog` 패널은 `w-[440px] max-w-full`로 **패널 자체는 이미 뷰포트에 클램프**됨(`max-w-full`). 즉 패널이 아니라 **내부 콘텐츠 오버플로우**가 주범.
 - 이 패턴은 공용 `FormItem`을 쓰는 모든 폼(생성·도메인 등 — 모바일/데스크탑 공유)에서 재발 가능.
 
-## 전제 (하드 의존성)
+## 전제 / 의존성 (2026-06-09 정정)
 
-- **#394(모바일 프로필 온보딩) 먼저 dev 머지 후** 그 위에서 진행. #394가 공용 프리미티브에 `min-w-0`을 깔아둔다:
-  - `FormItem` children wrapper `min-w-0`
-  - `Input` 내부 input `min-w-0`
-  - `use-be-a-host` 다이얼로그 `max-w-[calc(100vw-32px)]`, 생성폼 `w-full`+`flex-wrap`, `mobile-profile-edit-form layout='vertical'`
-- 본 작업 브랜치는 #394 머지 반영된 development 위로 rebase 후 구현/검증한다. (스펙·플랜 문서는 선작성 가능)
-- **플랜의 각 구현 Task 헤더에 "#394 머지+rebase 완료 전제"를 명시** — #394 미머지 상태로 FormItem을 손대면 #394의 `min-w-0` 변경과 충돌하는 diff가 생긴다.
+- **#394·#395 dev 머지 완료. 본 작업은 #394와 독립** — 머지된 #394(`346ff20`)의 실제 변경은 모바일 프로필 온보딩 관련뿐(`mobile-profile-edit-form`·profile redirect guard·`edit-profile-bio/v1`·docs·e2e). **`form-item`/`input`/`use-be-a-host`/`partyroom-info`/`dialog`은 안 건드림** → 공유 파일 0, 충돌 없음.
+- ⚠️ **정정**: 초기 스펙은 "#394가 공용 프리미티브에 `min-w-0`을 깐다"를 전제했으나 **사실이 아님**(현 development에 `form-item`/`input` `min-w-0` 부재 확인). 그 1차 수정들(min-w-0·use-be-a-host max-w·partyroom-info flex-wrap)은 최종 #394에 들어가지 않았다.
+- **함의**: 주 수정(반응형 FormItem → 모바일 단일칼럼)은 단일칼럼에서 입력이 전체폭이라 `min-w-0` 없이도 오버플로우 해소(min-w-0는 desktop 가로용이고 desktop은 넓어 불필요 → YAGNI, 증거 없으면 추가 안 함). #394 유무와 무관하게 본 작업만으로 완결.
+- 본 브랜치는 머지된 development(`7fdbf90`) 위로 rebase 완료. 바로 구현 가능.
 - dev 머지·prod 배포는 사용자 게이트.
 
 ## 목표 / 성공 기준
@@ -57,13 +55,12 @@
 - **패널 자체가 뷰포트를 초과하는 케이스가 남는 경우에만** 그 표면(또는 공용 `Dialog` 베이스)에 `max-w-[calc(100vw-2rem)]` 보강. 무분별한 전역 추가 금지.
 - 데스크탑 ProfileEditForm V1(`w-[550px]` 하드코딩 입력)이 모바일에서 도달 불가하면 범위 제외(확인 후 결정).
 
-### ③ #394 중복 핵 정리 (표면별 검증 게이트)
+### ③ 중복 핵 정리 (대폭 축소 — 2026-06-09 정정)
 
-①·#394로 불필요해진 per-form 핵을 정리(코드 더럽힘 회피):
+당초 #394가 깔았다고 가정한 per-form 핵(use-be-a-host `max-w` / 생성폼 `flex-wrap`)은 **현 development에 존재하지 않음**(#394에 안 들어감) → 정리할 게 없음.
 
-- 후보: `use-be-a-host` 다이얼로그 `max-w` / 생성폼 `flex-wrap` / `mobile-profile-edit-form layout='vertical'`.
-- **각 핵은 "그 표면을 공용 수정이 덮는다"를 모바일 스크린샷으로 확인한 뒤에만 제거.** 못 덮는 게 있으면 남기고 사유 기록.
-- (#394 머지 후 development 위에서 작업하므로 #394 코드 수정은 안전.)
+- 유일한 잔존 후보: `mobile-profile-edit-form`의 `layout='vertical'`. 반응형 FormItem이 모바일에서 자동 세로이므로 명시 prop은 **이론상 중복**이나, 이 컴포넌트는 **모바일 전용 렌더**라 항상 세로로 무해 → **그대로 둔다**(제거 이득 없음, 회귀 리스크만). 코드 더럽힘 아님.
+- 결론: 별도 정리 Task 불필요. 본 항목은 사실상 소멸하고 최종 검증으로 흡수.
 
 ## 검증
 
@@ -77,5 +74,5 @@
 ## 리스크 / 완화
 
 - **공용 컴포넌트(FormItem) 변경 → 회귀 범위 넓음**: 브레이크포인트 게이트로 데스크탑(≥tablet) 불변 보장 + 데스크탑 스크린샷으로 검증. FormItem을 쓰는 모든 폼을 모바일/데스크탑 양쪽 캡처로 확인.
-- **tablet 브레이크포인트 토큰 확인 필요**: `px-app`이 모바일 `px-20` / `tablet:px-40`을 쓰므로 tablet이 모바일↔데스크탑 경계. 플랜에서 정확한 토큰 재확인.
-- **#394 미머지 상태로 구현 착수 위험**: 구현은 #394 머지+rebase 후. 스펙/플랜만 선행.
+- **tablet 브레이크포인트 토큰 확인 필요**: `px-app`이 모바일 `px-20` / `tablet:px-40`을 쓰므로 tablet이 모바일↔데스크탑 경계. `theme.screens.tablet=768px` 확인됨.
+- ~~#394 미머지 착수 위험~~ → 해소: #394·#395 머지 완료, 본 작업 #394와 파일 겹침 0, development(`7fdbf90`) 위 rebase 완료. 바로 착수 가능.

--- a/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md
@@ -17,6 +17,7 @@
   - `Input` 내부 input `min-w-0`
   - `use-be-a-host` 다이얼로그 `max-w-[calc(100vw-32px)]`, 생성폼 `w-full`+`flex-wrap`, `mobile-profile-edit-form layout='vertical'`
 - 본 작업 브랜치는 #394 머지 반영된 development 위로 rebase 후 구현/검증한다. (스펙·플랜 문서는 선작성 가능)
+- **플랜의 각 구현 Task 헤더에 "#394 머지+rebase 완료 전제"를 명시** — #394 미머지 상태로 FormItem을 손대면 #394의 `min-w-0` 변경과 충돌하는 diff가 생긴다.
 - dev 머지·prod 배포는 사용자 게이트.
 
 ## 목표 / 성공 기준
@@ -43,6 +44,7 @@
   - 컨테이너 grid: `grid-cols-1 tablet:grid-cols-[max-content_1fr]` (fit 분기 유지).
   - 라벨 정렬: `text-start tablet:text-right`.
   - `vertical`/`horizontal` 분기에서 가로만 반응형화. `layout='vertical'`을 명시한 호출자는 항상 세로(불변).
+  - **에러 행 스페이서 처리**: 현재 `horizontal`+에러 시 빈 `<div>` 그리드 스페이서를 렌더(form-item 81~87행)한다. 단일 칼럼(모바일)에선 이 빈 div가 빈 행으로 보이므로 `hidden tablet:block`으로 모바일에서 숨긴다. 단위테스트 단언도 갱신.
 - **라벨 타이포(`type`) 분기는 변경하지 않음** — `type`은 React prop이라 CSS 브레이크포인트로 못 바꿈. 모바일에서도 가로폼의 `body2` 유지(세로 배치에서 자연스러움, 차이 미미). 스크린샷에서 다른 모바일 폼(`detail2`)과 시각적으로 명확히 어긋나면, 그때만 라벨에 반응형 폰트사이즈 className 보정.
 - 효과: 공용 FormItem 사용 폼 전체가 모바일에서 자동 세로 → 오버플로우 소멸 + 깔끔한 모바일 레이아웃.
 
@@ -51,7 +53,7 @@
 대상 표면을 **360px에서 실제 재현 → 근본 원인 확인 → 수정 → 재검**:
 
 - 대상: 생성 다이얼로그(Create Party), 버그신고 다이얼로그, 프로필(모바일 폼 + 데스크탑 ProfileEditForm V1의 모바일 도달 여부 확인), 사인인, 도메인 선택, 플레이리스트 폼(이미 `vertical`).
-- ①(반응형 FormItem) + #394(`min-w-0`)로 해소되면 해당 표면은 추가 작업 없음.
+- ①(반응형 FormItem) + #394(`min-w-0`)로 해소되면 해당 표면은 추가 작업 없음. (예: 사인인 페이지는 이미 `tablet:` 반응형 클래스를 일부 쓰므로 ①로 자동 커버될 가능성 높음 — 스윕 시 확인.)
 - **패널 자체가 뷰포트를 초과하는 케이스가 남는 경우에만** 그 표면(또는 공용 `Dialog` 베이스)에 `max-w-[calc(100vw-2rem)]` 보강. 무분별한 전역 추가 금지.
 - 데스크탑 ProfileEditForm V1(`w-[550px]` 하드코딩 입력)이 모바일에서 도달 불가하면 범위 제외(확인 후 결정).
 

--- a/src/entities/partyroom-info/ui/form.component.tsx
+++ b/src/entities/partyroom-info/ui/form.component.tsx
@@ -53,10 +53,13 @@ export default function PartyroomMutationForm({ defaultValues, onSubmit, submitT
   return (
     <form
       onSubmit={handleSubmit(() => onSubmit(form.getValues(), form))}
-      className={cn('flexCol items-center justify-between mx-auto pl-[26px] pr-[40px]', {
-        'child-form-labels:w-[100px]': lang === Language.Ko,
-        'child-form-labels:w-[128px]': lang === Language.En,
-      })}
+      className={cn(
+        'flexCol items-center justify-between mx-auto pl-5 pr-5 tablet:pl-[26px] tablet:pr-[40px]',
+        {
+          'child-form-labels:w-[100px]': lang === Language.Ko,
+          'child-form-labels:w-[128px]': lang === Language.En,
+        }
+      )}
     >
       <div className='w-full items-end gap-12 flexCol'>
         <FormItem
@@ -86,7 +89,7 @@ export default function PartyroomMutationForm({ defaultValues, onSubmit, submitT
           />
         </FormItem>
 
-        <div className='w-full flexRow items-center justify-between gap-8'>
+        <div className='w-full flexCol gap-8 tablet:flexRow tablet:items-center tablet:justify-between'>
           <FormItem
             label={
               <Typography as='span' type='body2' className='text-left'>
@@ -97,7 +100,7 @@ export default function PartyroomMutationForm({ defaultValues, onSubmit, submitT
               </Typography>
             }
             error={errors.domain?.message}
-            classNames={{ label: 'text-gray-200', container: 'flex-1' }}
+            classNames={{ label: 'text-gray-200', container: 'w-full tablet:flex-1' }}
           >
             <Input {...register('domain')} placeholder={t.onboard.para.domain_format} />
           </FormItem>
@@ -137,7 +140,7 @@ export default function PartyroomMutationForm({ defaultValues, onSubmit, submitT
             type='submit'
             variant='fill'
             size='lg'
-            className='px-[74px]'
+            className='px-8 tablet:px-[74px]'
             disabled={btnDisabled}
           >
             {submitText}

--- a/src/shared/ui/components/form-item/form-item.component.test.tsx
+++ b/src/shared/ui/components/form-item/form-item.component.test.tsx
@@ -90,3 +90,68 @@ describe('FormItemError', () => {
     expect(screen.getByText('오류가 발생했습니다')).toBeTruthy();
   });
 });
+
+describe('FormItem 반응형 레이아웃', () => {
+  test('horizontal(기본): 모바일 단일칼럼 + tablet:부터 2칼럼 그리드', () => {
+    const { container } = render(
+      <FormItem label='이름'>
+        <input />
+      </FormItem>
+    );
+    const label = container.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('tablet:grid-cols-[max-content_1fr]');
+    expect(label?.className).not.toMatch(/(^|\s)grid-cols-\[max-content_1fr\]/);
+  });
+
+  test('horizontal: 라벨 정렬이 모바일 text-start / tablet:text-right', () => {
+    const { container } = render(
+      <FormItem label='이름'>
+        <input />
+      </FormItem>
+    );
+    const labelText = container.querySelector('[data-custom-role="form-item-title"]');
+    expect(labelText).not.toBeNull();
+    expect(labelText?.className).toContain('text-start');
+    expect(labelText?.className).toContain('tablet:text-right');
+  });
+
+  test('vertical: 항상 세로(2칼럼 그리드 없음) + text-start, tablet:text-right 없음(불변)', () => {
+    const { container } = render(
+      <FormItem label='이름' layout='vertical'>
+        <input />
+      </FormItem>
+    );
+    const label = container.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label?.className).not.toContain('grid-cols-[max-content');
+    const labelText = container.querySelector('[data-custom-role="form-item-title"]');
+    expect(labelText).not.toBeNull();
+    expect(labelText?.className).toContain('text-start');
+    expect(labelText?.className).not.toContain('tablet:text-right');
+  });
+
+  test('fit=true horizontal: tablet:부터 max-content 2칼럼 (모바일 단일칼럼)', () => {
+    const { container } = render(
+      <FormItem label='이름' fit>
+        <input />
+      </FormItem>
+    );
+    const label = container.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('tablet:grid-cols-[max-content_max-content]');
+    expect(label?.className).not.toMatch(/(^|\s)grid-cols-\[max-content_max-content\]/);
+  });
+
+  test('horizontal + error: 스페이서 div가 hidden tablet:block (모바일 빈 행 방지)', () => {
+    const { container } = render(
+      <FormItem label='이름' error='필수 항목입니다'>
+        <input />
+      </FormItem>
+    );
+    const spacer = Array.from(container.querySelectorAll('div')).find((d) =>
+      d.className.includes('tablet:block')
+    );
+    expect(spacer).toBeTruthy();
+  });
+});

--- a/src/shared/ui/components/form-item/form-item.component.tsx
+++ b/src/shared/ui/components/form-item/form-item.component.tsx
@@ -29,10 +29,10 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
   return (
     <label
       className={cn([
-        'grid gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
+        'grid grid-cols-1 gap-x-[16px] gap-y-[8px] items-center grid-rows-max auto-rows-max',
         layout === 'horizontal' && {
-          'grid-cols-[max-content_1fr]': !fit,
-          'grid-cols-[max-content_max-content]': fit,
+          'tablet:grid-cols-[max-content_1fr]': !fit,
+          'tablet:grid-cols-[max-content_max-content]': fit,
         },
         classNames?.container,
       ])}
@@ -80,7 +80,7 @@ const FormItem: FC<PropsWithChildren<FormItemProps>> = ({
           <div
             className={cn({
               hidden: layout === 'vertical',
-              block: layout === 'horizontal',
+              'hidden tablet:block': layout === 'horizontal',
             })}
           />
 
@@ -108,7 +108,7 @@ const labelTextStyle = (layout: Axis, required?: boolean) => {
     'relative pr-[12px]',
     {
       'text-start text-gray-300': layout === 'vertical',
-      'text-right': layout === 'horizontal',
+      'text-start tablet:text-right': layout === 'horizontal',
     },
     required &&
       'after:content-["*"] after:absolute after:-right-[0.33em] after:top-[0.8em] after:transform after:-translate-x-1/2 after:-translate-y-1/2 after:text-red-300',

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -91,7 +91,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={combinedRef}
           type='text'
           className={cn(
-            'flex-1 bg-transparent placeholder:gray-400 text-gray-50 caret-red-300 focus:outline-none',
+            'flex-1 min-w-0 bg-transparent placeholder:gray-400 text-gray-50 caret-red-300 focus:outline-none',
             inputClassName
           )}
           value={value}


### PR DESCRIPTION
## 요약

모바일 뷰포트(360px)에서 공용 폼·모달의 가로 오버플로우를 **공용 `FormItem`을 `tablet`(768px) 브레이크포인트 반응형**으로 만들어 근본 차단한다. 데스크탑(≥tablet)은 픽셀 단위 불변. (디자인 언어 통일 PR #395의 e2e 리뷰에서 생성 다이얼로그 오버플로우 발견 → "전수 점검" 후속.)

## 변경

**Chunk 1 — 반응형 FormItem (공용 프리미티브)**
- `form-item.component.tsx`: horizontal 레이아웃을 모바일 단일칼럼 / `tablet:` 2칼럼으로. 컨테이너 `grid-cols-1 tablet:grid-cols-[max-content_1fr]`, 라벨 정렬 `text-start tablet:text-right`, 에러 스페이서 `hidden tablet:block`. 라벨 타이포·Props 불변. `layout='vertical'` 호출자 불변.
- 공용 `FormItem`을 쓰는 모든 폼이 모바일에서 자동 세로 → 오버플로우 소멸 + 미래 폼도 자동 안전.

**Chunk 2 — 생성 다이얼로그(Create Party) 360px 실측 수정**
- `input.component.tsx`: `flex-1` input에 `min-w-0` 추가 — 긴 placeholder가 input을 안 줄여 글자수 카운터(00/30)가 세로로 깨지던 문제 해소(데스크탑 무영향).
- `partyroom-info/form.component.tsx`: Domain+DJ세션제한 합성행 `flexRow` → 모바일 `flexCol`/데스크탑 `tablet:flexRow`(라벨 겹침 해소), Domain container `w-full tablet:flex-1`, 폼 패딩·submit 버튼 `tablet:` 반응형.

## 검증
- **단위테스트 289 files / 1577 passed (1 todo), EXIT 0** · `tsc` 클린 · `eslint` 클린.
- **로컬 e2e 스크린샷**: 생성 다이얼로그 360px(카운터 인라인 정상·합성행 세로 분리·가로 오버플로우 0) + 데스크탑 1440px(변경 전후 동일=불변). 사인인 360px 깨끗.
- FormItem 반응형 클래스 단언 테스트 추가(horizontal/vertical/fit/에러 스페이서).

## 비목표 / 후속
- 폼 기능·검증 변경 없음(레이아웃만). 데스크탑 리디자인 없음.
- 버그신고 다이얼로그는 모바일 로비 헤더에서 미도달(스코프 밖) — 모바일 룸 등에서 도달 가능 시 후속 점검.
- 데스크탑 ProfileEditForm V1은 모바일 미도달(모바일은 mobile-profile-edit-form 사용).
- dev 머지 = 자동 dev 배포. **prod 미반영**(별도 release 게이트).

스펙: `docs/superpowers/specs/2026-06-09-mobile-form-overflow-design.md`
플랜: `docs/superpowers/plans/2026-06-09-mobile-form-overflow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)