### PR TITLE
refactor(모바일): 디제잉 시트 정리 3건 — 캐스트 제거·onDismiss 분리·e2e poll (#373 #371 #374)

### DIFF
--- a/e2e/mobile/display-board.helpers.ts
+++ b/e2e/mobile/display-board.helpers.ts
@@ -18,6 +18,12 @@ export async function gotoMobileRoomAndWaitForVideo(page: Page, partyroomUrl: st
 export async function expectIframeToBeOnScreen(page: Page) {
   const iframe = page.locator('iframe[src*="youtube.com/embed"]');
   await expect(iframe).toBeVisible();
+  // toBeVisible() 는 element 존재 + display!=none 만 본다. boundingBox 는 layout 완료가
+  // 필요해 lazy 로드(react-player dynamic import) 직후엔 transient null/0 을 반환 → flake.
+  // layout 이 확정될 때까지(width>0) 폴링한 뒤 단언한다.
+  await expect
+    .poll(async () => (await iframe.boundingBox())?.width ?? 0, { timeout: 5_000 })
+    .toBeGreaterThan(0);
   const box = await iframe.boundingBox();
   expect(box).not.toBeNull();
   if (!box) return;

--- a/src/features-mobile/partyroom/select-playlist-for-djing/ui/use-mobile-select-playlist.hook.tsx
+++ b/src/features-mobile/partyroom/select-playlist-for-djing/ui/use-mobile-select-playlist.hook.tsx
@@ -46,17 +46,16 @@ export default function useMobileSelectPlaylist({
         node: (
           <SelectPlaylistSheet
             playlists={playlists}
-            // ⚠️ resolve 가 반드시 pop() 보다 먼저. useFullscreenSheet.pop() 의 setState
-            // updater 가 동기적으로 top.onClose?.() 를 호출 → onClose=()=>resolve(undefined)
-            // 가 winning. 본 hook 의 calling 순서에 따라 final resolve 값이 결정된다.
-            // (Promise resolve 는 idempotent — 첫 resolve 가 win, 그 후는 no-op.)
+            // confirm/cancel 은 자체 결과를 먼저 확정하고 programmatic 으로 닫는다.
+            // pop({ programmatic: true }) 가 onDismiss(=취소 resolve)를 skip 하므로
+            // resolve↔pop 호출 순서에 의존하지 않는다(과거 footgun 제거).
             onConfirm={(p) => {
               resolve(p);
-              pop();
+              pop({ programmatic: true });
             }}
             onCancel={() => {
               resolve(undefined);
-              pop();
+              pop({ programmatic: true });
             }}
             onAddTracksForEmpty={(p) => {
               push({
@@ -67,7 +66,8 @@ export default function useMobileSelectPlaylist({
             }}
           />
         ),
-        onClose: () => resolve(undefined),
+        // 사용자가 뒤로가기/×/Esc 로 닫으면 선택 취소(undefined).
+        onDismiss: () => resolve(undefined),
       });
     });
   }, [

--- a/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.test.tsx
+++ b/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.test.tsx
@@ -121,9 +121,15 @@ describe('MiniPlayer (mobile-bottom)', () => {
     expect(screen.getByTestId('mini-player-artist')).toHaveTextContent('Artist Name');
   });
 
-  test('[+ 추가] 클릭 시 onAdd(currentTrack) 호출', async () => {
+  test('[+ 추가] 클릭 시 onAdd() 호출 (인자 없음 — 추가 대상은 시트가 결정)', async () => {
     const onAdd = vi.fn();
-    const track = { name: 'A', artist: 'B', source: 'preview-search' as const };
+    const track = {
+      id: 'v1',
+      title: 'A',
+      thumbnailUrl: '',
+      videoUrl: '',
+      source: 'search-result' as const,
+    };
     useMusicPreviewMock.mockReturnValue({
       currentTrack: track,
       playState: 'playing',
@@ -132,7 +138,9 @@ describe('MiniPlayer (mobile-bottom)', () => {
     });
     render(<MiniPlayer onAdd={onAdd} addPending={false} />);
     await userEvent.click(screen.getByTestId('mini-player-add'));
-    expect(onAdd).toHaveBeenCalledWith(track);
+    // mini-player 의 currentTrack 은 lossy(duration 없음)라 추가 대상이 될 수 없다.
+    // 시트가 미리듣은 원본 Music 으로 추가하므로 onAdd 는 인자 없는 시그널.
+    expect(onAdd).toHaveBeenCalledWith();
   });
 
   test('addPending=true 시 [+ 추가] disabled', () => {

--- a/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.tsx
+++ b/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.tsx
@@ -10,7 +10,8 @@ import { Typography } from '@/shared/ui/components/typography';
 import { PFClose, PFPauseCircleFilled, PFPlayCircleFilled } from '@/shared/ui/icons';
 
 interface Props {
-  onAdd: (track: any) => void;
+  /** 추가 시그널. 대상 트랙은 시트가 결정한다(mini-player 의 currentTrack 은 duration 없는 lossy PreviewTrack). */
+  onAdd: () => void;
   addPending: boolean;
 }
 
@@ -77,7 +78,7 @@ const MiniPlayer: FC<Props> = ({ onAdd, addPending }) => {
           <Button
             size='sm'
             data-testid='mini-player-add'
-            onClick={() => onAdd(currentTrack)}
+            onClick={() => onAdd()}
             disabled={addPending}
           >
             {t.partyroom.queue.sheet_add_button}

--- a/src/widgets-mobile/partyroom-djing-sheet/lib/use-fullscreen-sheet.hook.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/lib/use-fullscreen-sheet.hook.test.tsx
@@ -41,47 +41,47 @@ describe('useFullscreenSheet', () => {
     expect(result.current.stack).toHaveLength(1);
   });
 
-  test('pop 호출 시 onClose 콜백 실행 + 스택에서 제거', () => {
-    const onClose = vi.fn();
+  test('pop 호출 시 onDismiss 콜백 실행 + 스택에서 제거', () => {
+    const onDismiss = vi.fn();
     const { result } = renderHook(() => useFullscreenSheet(), { wrapper: wrap });
     act(() => {
-      result.current.push({ key: 'select-playlist', node: <div />, onClose });
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss });
     });
     act(() => {
       result.current.pop();
     });
     expect(result.current.stack).toHaveLength(0);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   test('popstate 이벤트 시 스택 pop (1개일 때 close)', () => {
-    const onClose = vi.fn();
+    const onDismiss = vi.fn();
     const { result } = renderHook(() => useFullscreenSheet(), { wrapper: wrap });
     act(() => {
-      result.current.push({ key: 'select-playlist', node: <div />, onClose });
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss });
     });
     act(() => {
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
     expect(result.current.stack).toHaveLength(0);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   test('popstate 이벤트 시 다중 스택은 pop 만 (상위만 제거)', () => {
-    const onCloseA = vi.fn();
-    const onCloseB = vi.fn();
+    const onDismissA = vi.fn();
+    const onDismissB = vi.fn();
     const { result } = renderHook(() => useFullscreenSheet(), { wrapper: wrap });
     act(() => {
-      result.current.push({ key: 'select-playlist', node: <div />, onClose: onCloseA });
-      result.current.push({ key: 'add-tracks', node: <div />, onClose: onCloseB });
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss: onDismissA });
+      result.current.push({ key: 'add-tracks', node: <div />, onDismiss: onDismissB });
     });
     act(() => {
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
     expect(result.current.stack).toHaveLength(1);
     expect(result.current.stack[0].key).toBe('select-playlist');
-    expect(onCloseB).toHaveBeenCalledTimes(1);
-    expect(onCloseA).not.toHaveBeenCalled();
+    expect(onDismissB).toHaveBeenCalledTimes(1);
+    expect(onDismissA).not.toHaveBeenCalled();
   });
 
   test('ESC 키 입력 시 popstate 동일 동작 (history.back 호출)', () => {
@@ -97,23 +97,45 @@ describe('useFullscreenSheet', () => {
     backSpy.mockRestore();
   });
 
-  test('closeAll 호출 시 모든 onClose 콜백 + history.go(-N)', () => {
+  test('closeAll 호출 시 모든 onDismiss 콜백 + history.go(-N)', () => {
     const goSpy = vi.spyOn(window.history, 'go');
-    const onCloseA = vi.fn();
-    const onCloseB = vi.fn();
+    const onDismissA = vi.fn();
+    const onDismissB = vi.fn();
     const { result } = renderHook(() => useFullscreenSheet(), { wrapper: wrap });
     act(() => {
-      result.current.push({ key: 'select-playlist', node: <div />, onClose: onCloseA });
-      result.current.push({ key: 'add-tracks', node: <div />, onClose: onCloseB });
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss: onDismissA });
+      result.current.push({ key: 'add-tracks', node: <div />, onDismiss: onDismissB });
     });
     act(() => {
       result.current.closeAll();
     });
     expect(result.current.stack).toHaveLength(0);
-    expect(onCloseA).toHaveBeenCalledTimes(1);
-    expect(onCloseB).toHaveBeenCalledTimes(1);
+    expect(onDismissA).toHaveBeenCalledTimes(1);
+    expect(onDismissB).toHaveBeenCalledTimes(1);
     expect(goSpy).toHaveBeenCalledWith(-2);
     goSpy.mockRestore();
+  });
+
+  test('pop() 는 onDismiss 발화(user-driven), pop({ programmatic: true }) 는 미발화', () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() => useFullscreenSheet(), { wrapper: wrap });
+    // 1) programmatic close — 소비자가 자체 결과를 처리한 뒤 제거 → dismiss 콜백 미발화
+    act(() => {
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss });
+    });
+    act(() => {
+      result.current.pop({ programmatic: true });
+    });
+    expect(result.current.stack).toHaveLength(0);
+    expect(onDismiss).not.toHaveBeenCalled();
+    // 2) user-driven close(뒤로가기/×/Esc 경유 pop) → dismiss 콜백 발화
+    act(() => {
+      result.current.push({ key: 'select-playlist', node: <div />, onDismiss });
+    });
+    act(() => {
+      result.current.pop();
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   test('unmount 시 popstate/keydown listener cleanup', () => {

--- a/src/widgets-mobile/partyroom-djing-sheet/lib/use-fullscreen-sheet.hook.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/lib/use-fullscreen-sheet.hook.tsx
@@ -17,13 +17,19 @@ export interface SheetEntry {
   key: SheetKey;
   node: ReactNode;
   title?: string;
-  onClose?: () => void;
+  /**
+   * 사용자가 시트를 닫았을 때(뒤로가기/×/Esc 경유 pop)만 발화 = "취소" 신호.
+   * 소비자가 자체 결과를 처리한 뒤 호출하는 pop({ programmatic: true }) 에선 발화 안 함.
+   * (이 구분이 없으면 confirm 후 programmatic pop 이 취소 콜백까지 발화시키는 footgun.)
+   */
+  onDismiss?: () => void;
 }
 
 interface FullscreenSheetController {
   stack: SheetEntry[];
   push: (entry: SheetEntry) => void;
-  pop: () => void;
+  /** 기본(인자 없음) = user-driven dismiss → onDismiss 발화. programmatic=true → onDismiss skip. */
+  pop: (opts?: { programmatic?: boolean }) => void;
   closeAll: () => void;
 }
 
@@ -49,18 +55,19 @@ export const FullscreenSheetProvider: FC<{ children: ReactNode }> = ({ children 
     });
   }, []);
 
-  const pop = useCallback(() => {
+  const pop = useCallback((opts?: { programmatic?: boolean }) => {
     setStack((prev) => {
       if (prev.length === 0) return prev;
       const top = prev[prev.length - 1];
-      top.onClose?.();
+      if (!opts?.programmatic) top.onDismiss?.();
       return prev.slice(0, -1);
     });
   }, []);
 
   const closeAll = useCallback(() => {
+    // 강제 전체 닫힘(예: 라우트 이탈) = 미완 시트를 사용자가 떠난 것으로 간주 → dismiss 발화.
     const current = stackRef.current;
-    current.forEach((entry) => entry.onClose?.());
+    current.forEach((entry) => entry.onDismiss?.());
     if (current.length > 0) window.history.go(-current.length);
     setStack([]);
   }, []);

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/add-tracks-sheet.component.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/add-tracks-sheet.component.test.tsx
@@ -53,9 +53,9 @@ describe('AddTracksSheet', () => {
     expect(screen.getByTestId('music-search-input')).toBeInTheDocument();
   });
 
-  test('검색 결과 ▶ 클릭 → startPreview(music + source preview-search) 호출', async () => {
+  test('검색 결과 ▶ 클릭 → startPreview(정식 PreviewTrack: id/videoUrl/source=search-result)', async () => {
     useSearchMusicsMock.mockReturnValue({
-      data: [{ videoId: 'v1', videoTitle: 'A', thumbnailUrl: '', runningTime: '3:00' }],
+      data: [{ videoId: 'v1', videoTitle: 'A', thumbnailUrl: 'https://t', runningTime: '3:00' }],
       isLoading: false,
       error: null,
     });
@@ -63,9 +63,16 @@ describe('AddTracksSheet', () => {
     await userEvent.type(screen.getByTestId('music-search-input'), 'x');
     await waitFor(() => screen.getByTestId('search-item-preview-v1'));
     await userEvent.click(screen.getByTestId('search-item-preview-v1'));
-    expect(startPreviewMock).toHaveBeenCalledWith(
-      expect.objectContaining({ videoId: 'v1', source: 'preview-search' })
-    );
+    // 캐스트 우회(`{...music, source:'preview-search'} as unknown`) 제거: preview player 가
+    // 요구하는 id/videoUrl 이 채워진 정식 PreviewTrack 으로 매핑(convertSearchMusicToPreview).
+    // 이전엔 id/videoUrl 미설정 → youtube-preview-player 가 placeholder 만 띄우고 미재생.
+    expect(startPreviewMock).toHaveBeenCalledWith({
+      id: 'v1',
+      title: 'A',
+      thumbnailUrl: 'https://t',
+      videoUrl: 'https://www.youtube.com/watch?v=v1',
+      source: 'search-result',
+    });
   });
 
   test('currentTrack 있음 시 MiniPlayer (footer) 노출', () => {
@@ -80,24 +87,36 @@ describe('AddTracksSheet', () => {
     expect(screen.getByTestId('mini-player-name')).toBeInTheDocument();
   });
 
-  test('MiniPlayer [+ 추가] → useAddPlaylistTrack.mutate({ listId, linkId, name, duration, thumbnailImage })', async () => {
-    useSearchMusicsMock.mockReturnValue({ data: [], isLoading: false, error: null });
+  test('MiniPlayer [+ 추가] → 미리듣은 Music 의 duration(runningTime) 보존하여 mutate', async () => {
+    // PreviewTrack 은 duration 을 안 들고 다닌다(재생 관심사). add 는 duration(필수)이 필요하므로
+    // 시트가 미리듣은 원본 Music 을 추적해 그걸로 add → mini-player 의 lossy currentTrack 에 의존 안 함.
+    useSearchMusicsMock.mockReturnValue({
+      data: [
+        { videoId: 'v1', videoTitle: 'A', thumbnailUrl: 'https://thumb', runningTime: '3:00' },
+      ],
+      isLoading: false,
+      error: null,
+    });
     useMusicPreviewMock.mockReturnValue({
+      // 정식 PreviewTrack(= mini-player 렌더 트리거). duration 없음 — 일부러.
       currentTrack: {
-        videoId: 'v1',
-        videoTitle: 'A',
+        id: 'v1',
+        title: 'A',
         thumbnailUrl: 'https://thumb',
-        runningTime: '3:00',
-        source: 'preview-search',
+        videoUrl: 'https://www.youtube.com/watch?v=v1',
+        source: 'search-result',
       },
       playState: 'playing',
       startPreview: startPreviewMock,
       stopPreview: stopPreviewMock,
     });
     render(<AddTracksSheet playlistId={42} />);
+    // 미리듣기 클릭 → 시트가 원본 Music(runningTime 포함) 추적
+    await userEvent.type(screen.getByTestId('music-search-input'), 'x');
+    await waitFor(() => screen.getByTestId('search-item-preview-v1'));
+    await userEvent.click(screen.getByTestId('search-item-preview-v1'));
+    // mini-player [+ 추가] → 추적된 Music 의 runningTime 이 duration 으로 보존
     await userEvent.click(screen.getByTestId('mini-player-add'));
-    // 실제 mutation 시그니처: { listId, linkId, name, duration, thumbnailImage }
-    // playlistId(props) → listId, Music{videoId,videoTitle,thumbnailUrl,runningTime} → {linkId,name,thumbnailImage,duration}
     expect(addMutateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         listId: 42,

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/add-tracks-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/add-tracks-sheet.component.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { FC } from 'react';
-import { PreviewTrack } from '@/entities/music-preview/model/preview.model';
+import { FC, useRef } from 'react';
+import { convertSearchMusicToPreview } from '@/entities/music-preview/lib/preview-helpers';
 import { useAddPlaylistTrack } from '@/features/playlist/add-tracks/api/use-add-playlist-track.mutation';
 import MusicSearch from '@/features-mobile/playlist/add-tracks/ui/music-search.component';
 import { Music } from '@/shared/api/http/types/playlists';
@@ -16,54 +16,53 @@ interface Props {
  *
  * - body  = MusicSearch (검색 input + 결과 리스트)
  * - footer = MiniPlayer (currentTrack 있을 때만 자체 렌더, 없으면 null)
- * - ▶ click → startPreview({ ...music, source: 'preview-search' })
- *   (Music 의 videoId/videoTitle/thumbnailUrl/runningTime + source marker)
- * - [+ 추가] click (검색 결과 또는 MiniPlayer) → useAddPlaylistTrack.mutate({
- *     listId, linkId, name, duration, thumbnailImage
- *   })
- *   Music ↔ AddTrackToPlaylistRequestBody 매핑 위치는 sheet 하나로 일원화 (단일 책임).
- * - MiniPlayer 의 currentTrack 은 preview-search 출처라 Music 필드를 모두 보존 →
- *   동일 매핑 함수(toRequestBody) 재사용 가능.
+ * - ▶ click → startPreview(convertSearchMusicToPreview(music))
+ *   (Music → 정식 PreviewTrack. id/videoUrl 이 채워져 youtube-preview-player 가 실재생.)
+ * - [+ 추가] (검색 결과 행 또는 MiniPlayer) → useAddPlaylistTrack.mutate(...)
+ *
+ * 어휘 경계: 재생(PreviewTrack)과 추가(AddTrackToPlaylistRequestBody)는 서로 다른 관심사.
+ * PreviewTrack 은 duration 을 안 들고 다니므로, 추가가 필요로 하는 원본 Music 을
+ * `lastPreviewedMusicRef` 로 추적한다 → mini-player 의 lossy currentTrack 에 의존하지 않고
+ * duration(필수 필드)을 무손실 보존. (이전엔 Music 을 PreviewTrack 으로 캐스트해 흘려보냈음.)
  */
 const AddTracksSheet: FC<Props> = ({ playlistId }) => {
   const { useMusicPreview } = useStores();
   const { startPreview } = useMusicPreview();
   const { mutate: addTrack, isPending } = useAddPlaylistTrack();
 
-  const handlePreview = (music: Music) => {
-    // PreviewTrack 모델(id/title/videoUrl/source: 'playlist-track'|'search-result')과
-    // Music(videoId/videoTitle/thumbnailUrl/runningTime) 의 어휘 차이는 chunk 4 범위 밖.
-    // MiniPlayer 의 defensive aliasing(name ?? title) 패턴과 동일하게 모든 식별 필드를
-    // spread 로 같이 흘려보내고 source 는 spec 그대로 'preview-search' 마커를 부여한다.
-    // ⚠️ title 은 MiniPlayer 가 직접 읽으므로 명시적으로 videoTitle → title 매핑.
-    //   (spread 만으로는 title 키가 비어 displayName='' → mini-player-name DOM 가
-    //   zero-content 로 Playwright hidden 판정.)
-    startPreview({
-      ...music,
-      title: music.videoTitle,
-      source: 'preview-search',
-    } as unknown as PreviewTrack);
-  };
+  // 마지막으로 미리들은 원본 Music — mini-player 추가가 duration 까지 보존하기 위한 출처.
+  const lastPreviewedMusicRef = useRef<Music | null>(null);
 
-  const handleAdd = (music: Music | (PreviewTrack & Partial<Music>)) => {
-    // currentTrack(PreviewTrack & Music spread) 또는 검색결과(Music) 둘 다 videoId 보유.
-    // PreviewTrack 어휘로 들어온 경우 id/title 로 떨어질 수 있어 양방향 fallback.
-    const m = music as Music & PreviewTrack & { name?: string };
+  const addMusic = (music: Music) => {
     addTrack({
       listId: playlistId,
-      linkId: m.videoId ?? m.id,
-      name: m.videoTitle ?? m.name ?? m.title,
-      duration: m.runningTime,
-      thumbnailImage: m.thumbnailUrl,
+      linkId: music.videoId,
+      name: music.videoTitle,
+      duration: music.runningTime,
+      thumbnailImage: music.thumbnailUrl,
     });
+  };
+
+  const handlePreview = (music: Music) => {
+    lastPreviewedMusicRef.current = music;
+    startPreview(convertSearchMusicToPreview(music));
+  };
+
+  // 검색 결과 행의 [+]: 그 행의 Music 으로 바로 추가.
+  const handleAddFromSearch = (music: Music) => addMusic(music);
+
+  // mini-player 의 [+]: currentTrack 은 lossy 라 못 쓰고, 미리들은 원본 Music 으로 추가.
+  const handleAddFromMiniPlayer = () => {
+    const music = lastPreviewedMusicRef.current;
+    if (music) addMusic(music);
   };
 
   return (
     <div className='flex flex-col h-full'>
       <div className='flex-1 min-h-0'>
-        <MusicSearch onPreview={handlePreview} onAdd={handleAdd} addPending={isPending} />
+        <MusicSearch onPreview={handlePreview} onAdd={handleAddFromSearch} addPending={isPending} />
       </div>
-      <MiniPlayer onAdd={handleAdd} addPending={isPending} />
+      <MiniPlayer onAdd={handleAddFromMiniPlayer} addPending={isPending} />
     </div>
   );
 };

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/sheet-host.component.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/sheet-host.component.test.tsx
@@ -59,13 +59,11 @@ describe('SheetHost', () => {
     const cap = captureApi();
     render(<Trigger onMount={cap.onMount} />, { wrapper: wrap });
     act(() => {
-      cap
-        .get()
-        .push({
-          key: 'select-playlist',
-          title: '플레이리스트',
-          node: <div data-testid='a'>A</div>,
-        });
+      cap.get().push({
+        key: 'select-playlist',
+        title: '플레이리스트',
+        node: <div data-testid='a'>A</div>,
+      });
       cap.get().push({ key: 'add-tracks', title: '곡 추가', node: <div data-testid='b'>B</div> });
     });
     expect(screen.getByTestId('b')).toBeInTheDocument();
@@ -74,13 +72,13 @@ describe('SheetHost', () => {
     expect(screen.queryByTestId('fullscreen-sheet-close')).not.toBeInTheDocument();
   });
 
-  test('ESC 통합 시나리오 — 스택 1개 시 entry.onClose 1번만 발화 (double pop 없음)', () => {
+  test('ESC 통합 시나리오 — 스택 1개 시 entry.onDismiss 1번만 발화 (double pop 없음)', () => {
     const cap = captureApi();
-    const onClose = vi.fn();
+    const onDismiss = vi.fn();
     const backSpy = vi.spyOn(window.history, 'back');
     render(<Trigger onMount={cap.onMount} />, { wrapper: wrap });
     act(() => {
-      cap.get().push({ key: 'select-playlist', node: <div />, onClose });
+      cap.get().push({ key: 'select-playlist', node: <div />, onDismiss });
     });
     act(() => {
       fireEvent.keyDown(window, { key: 'Escape' });
@@ -89,7 +87,7 @@ describe('SheetHost', () => {
     act(() => {
       fireEvent.popState(window);
     });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
     backSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## 요약
모바일 디제잉 시트 영역의 PR #370(chunk4) 우회들을 근본 정리. 3개 독립 이슈를 단일 브랜치로 묶음(전부 pfplay-web, 작은 리팩토링).

## 변경 (커밋별)

### #373 Music→PreviewTrack 캐스트 우회 제거 + 미리듣기 실재생 복구 (`d66ccf6`)
- `add-tracks-sheet` 의 `startPreview({ ...music, source:'preview-search' } as unknown as PreviewTrack)` 캐스트를 기존 `convertSearchMusicToPreview` 매퍼로 교체.
- ⚠️ **잠복 버그 발견·수정**: 캐스트는 `id`/`videoUrl` 을 채우지 않았는데 `youtube-preview-player` 가 `currentTrack.id`·`videoUrl` 을 요구 → add-tracks 시트의 미리듣기가 placeholder 만 뜨고 **실제 재생이 안 되던 상태**. 매퍼가 둘을 채워 실재생 복구.
- 매퍼는 duration(재생 관심사 아님)을 안 들고 다니므로, 추가(duration 필수 필드)가 깨지지 않게 미리들은 원본 Music 을 `lastPreviewedMusicRef` 로 추적 → mini-player 추가에 무손실 공급. `handleAdd` 의 `any`·양방향 fallback 제거, `MiniPlayer.onAdd` 를 `() => void` 로 정직화.

### #371 FullscreenSheet onClose→onDismiss + pop programmatic 분리 (`60f0911`)
- `useFullscreenSheet.pop()` 이 user-driven 닫힘(뒤로가기/×/Esc)과 소비자 programmatic 닫힘을 같은 경로로 처리해 SheetEntry 콜백이 양쪽 발화하던 footgun 제거.
- `SheetEntry.onClose → onDismiss` 개명(='사용자가 닫음=취소' 신호). `pop(opts?: { programmatic?: boolean })`: 기본=user-driven→onDismiss 발화 / programmatic=true→skip.
- 유일 소비자 `useMobileSelectPlaylist`: onConfirm/onCancel 이 `pop({ programmatic: true })` 로 닫아 resolve↔pop 호출 순서 의존(과거 주석의 위태로운 의존) 제거.

### #374 e2e iframe boundingBox null race expect.poll 해소 (`4979d9b`)
- `display-board.tos` 의 `expectIframeToBeOnScreen` 이 `toBeVisible()` 직후 곧장 `boundingBox()` 를 읽어 lazy 로드 layout 미완 시점의 transient null 을 잡던 로컬 flake → `expect.poll(width>0, 5s)` 로 해소.

## 검증
- 전체 vitest **1578 passed + 1 todo**, `tsc` 0, `lint` 0.
- **로컬 docker-compose 풀스택 + 모바일 e2e**(backend :8080 + next dev webpack :3000): 각 spec 통과(add-tracks·playlist-management·dj-register·host-cta·profile-onboarding·display-board.tos **fresh 7 passed clean**). 단발 chat-scroll 실패는 환경 부하(reflow 타이밍) flake로 확정 — **clean base(origin/development)에서도 fresh면 통과**, 본 변경과 코드 경로 무겹침으로 격리 증명.

## 비고
- #375(24h+ Next dev HMR stale)는 upstream(webpack/Windows) 원인·우회법 즉효라 별도 won't-fix.
- mini-player 의 name/artist defensive aliasing 은 Phase 6 search-result 확장 anticipation 이라 의도적 유지(범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)