### PR TITLE
fix(auth): OAuth 콜백 뒤로가기 PKCE 모달 제거 (#347)

### DIFF
--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.test.tsx
@@ -3,9 +3,14 @@ import { QueryKeys } from '@/shared/api/http/query-keys';
 import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import useOAuth2Callback from './use-social-sign-in-callback.hook';
 
-const push = vi.fn();
+const replace = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push }),
+  useRouter: () => ({ replace }),
+}));
+
+const getStoredCodeVerifier = vi.fn();
+vi.mock('@/shared/lib/functions/pkce', () => ({
+  getStoredCodeVerifier: () => getStoredCodeVerifier(),
 }));
 
 const callbackLogin = vi.fn();
@@ -41,6 +46,8 @@ function meModel(overrides: Record<string, unknown> = {}) {
 describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // 기본: 정상 콜백 진입(codeVerifier 존재). 재진입 테스트만 부재로 override.
+    getStoredCodeVerifier.mockReturnValue('verifier-present');
   });
 
   test('옵션2: isNewUser=true 면 profileUpdated=true(좀비 me) 여도 /settings/profile 강제', async () => {
@@ -50,7 +57,7 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
     const { result } = renderWithClient(() => useOAuth2Callback());
     await result.current('google');
 
-    expect(push).toHaveBeenCalledWith('/settings/profile');
+    expect(replace).toHaveBeenCalledWith('/settings/profile');
   });
 
   test('isNewUser=false + profileUpdated=true → /parties (기존 회귀)', async () => {
@@ -60,7 +67,7 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
     const { result } = renderWithClient(() => useOAuth2Callback());
     await result.current('google');
 
-    expect(push).toHaveBeenCalledWith('/parties');
+    expect(replace).toHaveBeenCalledWith('/parties');
   });
 
   test('옵션1: callback 후 [Me] 캐시 cancel+remove 를 fetchMeAsync 이전에 수행', async () => {
@@ -136,6 +143,19 @@ describe('useOAuth2Callback (D/#7+#9 Phase1)', () => {
     const { result } = renderWithClient(() => useOAuth2Callback());
     await result.current('google');
 
-    expect(push).toHaveBeenCalledWith('/sign-in');
+    expect(replace).toHaveBeenCalledWith('/sign-in');
+  });
+
+  test('#347 재진입(codeVerifier 부재): callbackLogin 미호출 + replace(/sign-in)', async () => {
+    // 콜백 URL 재진입(뒤로가기/새로고침)은 이미 1회용 PKCE 교환이 끝나 codeVerifier 가
+    // 삭제된 상태. 재교환을 시도하면 throw → 전역 MutationCache.onError 가 모달을 띄운다.
+    // 교환 전 codeVerifier 부재를 감지해 조용히 sign-in 으로 보낸다(모달 없음).
+    getStoredCodeVerifier.mockReturnValue(undefined);
+
+    const { result } = renderWithClient(() => useOAuth2Callback());
+    await result.current('google');
+
+    expect(callbackLogin).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith('/sign-in');
   });
 });

--- a/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
+++ b/src/features/sign-in/by-social/lib/use-social-sign-in-callback.hook.tsx
@@ -12,6 +12,7 @@ import {
   trackSignedIn,
   trackSignedUp,
 } from '@/shared/lib/analytics/auth-tracking';
+import { getStoredCodeVerifier } from '@/shared/lib/functions/pkce';
 import useCallbackLogin from '../api/use-callback-login';
 
 export default function useOAuth2Callback() {
@@ -22,6 +23,14 @@ export default function useOAuth2Callback() {
 
   return useCallback(
     async (oauth2Provider: OAuth2Provider) => {
+      // #347: 콜백 URL 재진입(뒤로가기/새로고침) 방어. PKCE codeVerifier 는 최초 교환 성공 시
+      // 삭제되므로, 부재 = 이미 교환됨(재진입) 또는 무효 접근. 재교환은 1회용이라 throw →
+      // 전역 MutationCache.onError 가 "Code verifier not found" 모달을 띄운다. 교환을 시도하지
+      // 않고 조용히 sign-in 으로 보낸다(인증된 사용자면 sign-in 이 다시 /parties 로 바운스).
+      if (!getStoredCodeVerifier()) {
+        router.replace('/sign-in');
+        return;
+      }
       try {
         const tokenResponse = await callbackLogin(oauth2Provider);
 
@@ -55,9 +64,11 @@ export default function useOAuth2Callback() {
         }
 
         // 옵션2(#7): 신규 가입자는 좀비 me 와 무관하게 프로필 설정 강제.
-        router.push(Me.serviceEntry(me, tokenResponse.isNewUser));
+        // #347: redirect-only 콜백 페이지라 replace — push 면 콜백 URL 이 히스토리에 남아
+        // 뒤로가기로 재진입 → 1회용 PKCE 재교환 throw → 에러 모달.
+        router.replace(Me.serviceEntry(me, tokenResponse.isNewUser));
       } catch {
-        router.push('/sign-in');
+        router.replace('/sign-in');
       }
     },
     [callbackLogin, fetchMeAsync, queryClient, router]


### PR DESCRIPTION
## 요약
quick-win — 소셜 로그인 콜백 후 **뒤로가기 시 "Code verifier not found in storage" 에러 모달** 제거. 이슈 #347.

## 원인
콜백 핸들러가 `router.push` 라 콜백 URL(`/auth/callback/*?code=&state=`)이 히스토리에 잔존 → 프로필 설정 화면에서 뒤로가기 → 콜백 페이지 재마운트(페이지의 `called` ref 는 마운트 내부만 가드) → 1회용 PKCE 재교환 시도. 최초 성공 시 `clearStoredCodeVerifier()` 로 verifier 삭제됨 → `throw "Code verifier not found"` → 전역 `MutationCache.onError` 가 모달 발사.

## 수정
- **push → replace** (성공·실패 양쪽): redirect-only 콜백 페이지라 히스토리에서 콜백 URL 제거 → 뒤로가기 재진입 자체 차단.
- **재진입 가드**(새로고침 등 다른 경로 방어): 교환 전 `getStoredCodeVerifier()` 부재 감지 시 `callbackLogin` 미호출 + 조용히 `replace('/sign-in')`. throw→전역모달 경로를 원천 제거(인증된 사용자면 sign-in 이 /parties 로 바운스).
- google·twitter 콜백이 공유하는 훅이라 양쪽 동시 적용.

## 검증
- 콜백 훅 단위테스트 **9 GREEN**(push→replace 8건 + 재진입 신규 1건). tsc 0 · lint 0.
- ⚠️ 실제 OAuth 콜백은 실 Google 인증이 필요해 로컬 e2e 로 커버 불가 — 로직은 단위테스트로, 빌드/앱헬스는 Vercel build CI + 로컬 e2e(앱 회귀) 로 검증.

## 전이가능 인사이트
- redirect-only 임시 페이지(OAuth 콜백 등)는 반드시 `replace` — `push` 면 뒤로가기로 1회용 side-effect 가 재실행된다. 마운트 1회 가드(useRef)는 재마운트를 못 막는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)