### PR TITLE
fix(maintenance): 점검 ACTIVE 화면 격리 — /me 반복 호출·Network Error 모달 차단 (#406)

### DIFF
--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,84 @@
+import { ReactElement } from 'react';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { SystemAnnouncementSubscriber } from '@/features/system-announcement';
+import { getEdgeConfigMaintenance, getSystemStatus } from '@/shared/api/system-status';
+import RootLayout from './layout';
+
+// next/font, CSS(css:false), 무거운 provider 들은 트리 식별/import 경량화를 위해 stub.
+// 트리는 렌더하지 않고 element 트리를 walk 하므로 provider 본문은 실행되지 않는다.
+vi.mock('next/headers', () => ({
+  cookies: () => ({ get: () => ({ value: 'en' }) }),
+}));
+vi.mock('@/shared/lib/localization/get-server-dictionary', () => ({
+  getServerDictionary: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@/shared/ui/foundation/fonts', () => ({
+  pretendardVariable: { className: 'font' },
+}));
+vi.mock('@/shared/api/system-status', () => ({
+  getEdgeConfigMaintenance: vi.fn(),
+  getSystemStatus: vi.fn(),
+}));
+vi.mock('@/features/system-announcement', () => ({
+  SystemAnnouncementSubscriber: () => null,
+}));
+vi.mock('@/features/system-announcement/ui/hydrate-announcements-from-status', () => ({
+  default: () => null,
+}));
+vi.mock('@/features/system-announcement/ui/system-announcement-display', () => ({
+  default: () => null,
+}));
+vi.mock('./_providers/react-query.provider', () => ({ default: ({ children }: any) => children }));
+vi.mock('./_providers/analytics.provider', () => ({ default: ({ children }: any) => children }));
+vi.mock('./_providers/stores.provider', () => ({ default: ({ children }: any) => children }));
+vi.mock('./_providers/wallet.provider', () => ({
+  WalletProvider: ({ children }: any) => children,
+}));
+
+const ACTIVE = {
+  phase: 'ACTIVE' as const,
+  startAt: '2026-06-15T03:00:00',
+  endAt: '2026-06-15T04:00:00',
+  messageKo: '점검 중',
+  messageEn: 'Maintenance',
+};
+
+/** 렌더하지 않고 element 트리에 특정 컴포넌트 타입이 존재하는지 검사. */
+function containsType(node: unknown, type: unknown): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (Array.isArray(node)) return node.some((n) => containsType(n, type));
+  const el = node as { type?: unknown; props?: { children?: unknown } };
+  if (el.type === type) return true;
+  return containsType(el.props?.children, type);
+}
+
+const Child = () => null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RootLayout — 점검 화면 격리 (#406)', () => {
+  test('점검 ACTIVE 면 SystemAnnouncementSubscriber 를 마운트하지 않고 children 만 렌더한다', async () => {
+    (getEdgeConfigMaintenance as Mock).mockResolvedValue(ACTIVE);
+
+    const tree = (await RootLayout({ children: <Child /> })) as ReactElement;
+
+    expect(containsType(tree, SystemAnnouncementSubscriber)).toBe(false);
+    expect(containsType(tree, Child)).toBe(true);
+    // 점검 중 백엔드는 down — getSystemStatus 를 호출하면 안 된다(불필요한 실패 호출 방지).
+    expect(getSystemStatus).not.toHaveBeenCalled();
+  });
+
+  test('점검이 아니면 평소처럼 SystemAnnouncementSubscriber 를 마운트하고 getSystemStatus 를 호출한다', async () => {
+    (getEdgeConfigMaintenance as Mock).mockResolvedValue(null);
+    (getSystemStatus as Mock).mockResolvedValue({ activeAnnouncements: [], maintenance: null });
+
+    const tree = (await RootLayout({ children: <Child /> })) as ReactElement;
+
+    expect(containsType(tree, SystemAnnouncementSubscriber)).toBe(true);
+    expect(containsType(tree, Child)).toBe(true);
+    expect(getSystemStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/features/system-announcement/model/system-announcement.types';
 import HydrateAnnouncementsFromStatus from '@/features/system-announcement/ui/hydrate-announcements-from-status';
 import SystemAnnouncementDisplay from '@/features/system-announcement/ui/system-announcement-display';
-import { getSystemStatus } from '@/shared/api/system-status';
+import { getEdgeConfigMaintenance, getSystemStatus } from '@/shared/api/system-status';
 import { DomId } from '@/shared/config/dom-id';
 import { Language } from '@/shared/lib/localization/constants';
 import { LANGUAGE_COOKIE_KEY } from '@/shared/lib/localization/constants';
@@ -37,8 +37,22 @@ export const metadata: Metadata = {
 };
 
 const RootLayout = async ({ children }: PropsWithChildren) => {
-  const dictionary = await getServerDictionary();
   const lang = cookies().get(LANGUAGE_COOKIE_KEY)?.value || Language.En;
+
+  // #406: 점검 ACTIVE 면 앱-부팅 기계(me-fetch · WS 구독 · 전역 에러 모달)를 마운트하지 않고
+  // 점검 화면(middleware rewrite 로 주입된 children)만 inert 하게 렌더한다. 신뢰 소스는
+  // Edge Config — middleware 와 동일하며, 점검 중 백엔드는 down 이라 getSystemStatus 로는 점검을
+  // 알 수 없다(throw → null). EDGE_CONFIG 부재(로컬/test)면 null → 평소 트리로 통과.
+  const maintenance = await getEdgeConfigMaintenance();
+  if (maintenance?.phase === 'ACTIVE') {
+    return (
+      <html lang={lang}>
+        <body className={pretendardVariable.className}>{children}</body>
+      </html>
+    );
+  }
+
+  const dictionary = await getServerDictionary();
 
   // Edge Config 가 unreachable 한 경우의 1차 fallback —
   // /v1/system/status 결과로 active announcements + maintenance 를 hydrate.


### PR DESCRIPTION
Closes #406

## 무엇을 고쳤나
점검 ACTIVE 인데 점검 화면에서 `/users/me/info`·`/me/profile/summary` 가 계속 실패 호출되고 Network Error 모달이 뜨던 문제.

**원인**: middleware rewrite 로 점검 화면은 떴지만, 루트 layout 이 점검 여부와 무관하게 `SystemAnnouncementSubscriber`(→ `useFetchMe`) + 전역 에러 모달 + 앱 provider 트리를 무조건 마운트 → 백엔드 down 상태에서 me-fetch 가 Network Error 로 실패, react-query retry 로 반복.

**수정**: 루트 layout 에서 `getEdgeConfigMaintenance()`(middleware 와 동일 신뢰 소스, 백엔드 down 중에도 동작)로 게이트. `phase==='ACTIVE'` 면 앱-부팅 기계 없이 children(점검 화면)만 렌더하는 최소 트리 early return.

## 검증
- 신규 `layout.test.tsx`: ACTIVE→subscriber 미마운트+getSystemStatus 미호출 / 정상→마운트+호출
- 전체 단위 1581 GREEN, tsc·eslint 클린
- ⚠️ 점검 e2e 는 Edge Config 필요라 로컬 재현 불가 → stg 에서 실 토글 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)