### PR TITLE
fix(crews): 크루 목록 계급 그룹 기본 펼침 (#411)

### DIFF
--- a/src/shared/ui/components/collapse-list/collapse-list.component.test.tsx
+++ b/src/shared/ui/components/collapse-list/collapse-list.component.test.tsx
@@ -21,6 +21,15 @@ describe('CollapseList', () => {
     expect(screen.queryByText('숨겨진 내용')).toBeNull();
   });
 
+  test('defaultOpen=true 이면 초기 상태에서 내용이 표시된다 (#411)', () => {
+    render(
+      <CollapseList title='목록' defaultOpen>
+        펼쳐진 내용
+      </CollapseList>
+    );
+    expect(screen.getByText('펼쳐진 내용')).toBeTruthy();
+  });
+
   test('버튼 클릭 시 내용이 표시된다', () => {
     render(<CollapseList title='목록'>펼쳐진 내용</CollapseList>);
 

--- a/src/shared/ui/components/collapse-list/collapse-list.component.tsx
+++ b/src/shared/ui/components/collapse-list/collapse-list.component.tsx
@@ -11,6 +11,8 @@ type CollapseListProps = {
   title: string;
   infoText?: string;
   displaySuffix?: boolean;
+  /** 초기 펼침 상태 (기본 false). Headless UI Disclosure 의 defaultOpen 으로 전달. */
+  defaultOpen?: boolean;
   buttonTestId?: string;
   classNames?: {
     button?: string;
@@ -25,11 +27,16 @@ const CollapseList = ({
   variant = 'default',
   children,
   displaySuffix = true,
+  defaultOpen = false,
   buttonTestId,
   classNames,
 }: PropsWithChildren<CollapseListProps>) => {
   return (
-    <Disclosure as='div' className='mx-auto w-full max-w-md bg-transparent'>
+    <Disclosure
+      as='div'
+      defaultOpen={defaultOpen}
+      className='mx-auto w-full max-w-md bg-transparent'
+    >
       {({ open }) => (
         <>
           <DisclosureButton

--- a/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
+++ b/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
@@ -25,6 +25,7 @@ export default function AllCrewsPanel() {
           key={'AllCrewsPanel' + category}
           title={category}
           displaySuffix={false}
+          defaultOpen
           buttonTestId={`all-crews-category-${category}`}
         >
           {crews.map((crew) => {


### PR DESCRIPTION
Closes #411

## 변경
- 파티룸 크루 목록 탭에서 계급별 그룹이 **기본 펼침(전체 표시)** 되도록.
- `CollapseList` 에 `defaultOpen` prop 추가(Headless UI `Disclosure.defaultOpen` 전달, 기본 false → 기존 사용처 무영향).
- `all-crews-panel` 계급 그룹에 `defaultOpen` 적용.
- 모바일 크루 패널은 평면 리스트(계급 그룹·접힘 없음)라 변경 불필요.

## 검증
- CollapseList `defaultOpen=true` → 초기 내용 표시 테스트 추가(RED→GREEN), 9 tests pass, tsc·eslint 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)