### PR TITLE
feat(chat): 파티룸 입장 공지 시스템 메시지 (#412)

### DIFF
--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-entered-callback.hook.test.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-entered-callback.hook.test.ts
@@ -95,4 +95,44 @@ describe('useCrewEnteredCallback', () => {
       motionType: MotionType.DANCE_TYPE_1,
     });
   });
+
+  test('새 입장 시 입장 공지 시스템 채팅 메시지를 추가한다 (#412)', () => {
+    const { result } = renderHook(() => useCrewEnteredCallback());
+
+    result.current(createCrewEnteredEvent(1, '새유저'));
+
+    const systemMsg = store
+      .getState()
+      .chat.getMessages()
+      .find((m) => m.from === 'system');
+    expect(systemMsg).toBeDefined();
+    expect((systemMsg as { content: string }).content).toContain('새유저');
+    expect((systemMsg as { content: string }).content).toContain('입장');
+  });
+
+  test('이미 존재하는 crew의 재입장(spurious ENTER)은 공지를 추가하지 않는다 (#412)', () => {
+    store.getState().updateCrews(() => [createCrew({ crewId: 1, nickname: '기존유저' })]);
+    const { result } = renderHook(() => useCrewEnteredCallback());
+
+    result.current(createCrewEnteredEvent(1));
+
+    const systemMsgs = store
+      .getState()
+      .chat.getMessages()
+      .filter((m) => m.from === 'system');
+    expect(systemMsgs).toHaveLength(0);
+  });
+
+  test('본인 입장은 공지를 추가하지 않는다 (#412)', () => {
+    store.getState().updateMe({ crewId: 1 });
+    const { result } = renderHook(() => useCrewEnteredCallback());
+
+    result.current(createCrewEnteredEvent(1));
+
+    const systemMsgs = store
+      .getState()
+      .chat.getMessages()
+      .filter((m) => m.from === 'system');
+    expect(systemMsgs).toHaveLength(0);
+  });
 });

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-entered-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-crew-entered-callback.hook.ts
@@ -5,10 +5,18 @@ import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function useCrewEnteredCallback() {
   const { useCurrentPartyroom } = useStores();
-  const updateCrews = useCurrentPartyroom((state) => state.updateCrews);
+  const [updateCrews, appendChatMessage] = useCurrentPartyroom((state) => [
+    state.updateCrews,
+    state.appendChatMessage,
+  ]);
 
   return (event: CrewEnteredEvent) => {
     const crew = flattenCrewFromEvent(event.crew);
+    // #412: 입장 공지는 '새 입장'만 — 재입장/spurious ENTER(이미 crews 에 있는 경우)와
+    // 본인 입장은 제외한다. 판정은 updateCrews 전 현재 스토어 상태로 한다.
+    const { crews, me } = useCurrentPartyroom.getState();
+    const isNewEntry = !crews.some((prevCrew) => prevCrew.crewId === crew.crewId);
+
     updateCrews((prev) => {
       const existingCrew = prev.find((prevCrew) => prevCrew.crewId === crew.crewId);
 
@@ -22,6 +30,14 @@ export default function useCrewEnteredCallback() {
           : prevCrew
       );
     });
+
+    if (isNewEntry && me?.crewId !== crew.crewId) {
+      appendChatMessage({
+        from: 'system',
+        content: `${crew.nickname}님이 입장했습니다`,
+        receivedAt: Date.now(),
+      });
+    }
   };
 }
 


### PR DESCRIPTION
Closes #412

## 변경
- `CREW_ENTERED` 시 채팅창에 **'xxx님이 입장했습니다'** 시스템 메시지. **퇴장은 공지 안 함**.
- 기존 `SystemChat` 인프라 재사용(grade/penalty 콜백과 동일 패턴, 양쪽 패널이 이미 `from:'system'` 렌더).
- **새 입장만 공지**: 재입장/spurious ENTER 제외 + **본인 입장 제외**.

## 검증
- 새 입장→공지(RED→GREEN) / 재입장→공지없음 / 본인→공지없음. 5 tests pass, tsc·eslint 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)