### PR TITLE
feat(avatar): 채팅 시 발신자 아바타에 말풍선(...) 표시 (#410)

### DIFF
--- a/src/entities/avatar/ui/avatar.component.tsx
+++ b/src/entities/avatar/ui/avatar.component.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 
 const ReactionLottie = dynamic(
   () => import('@/entities/avatar/ui/reaction-lottie').then((mod) => mod.ReactionLottie),
@@ -8,6 +8,7 @@ const ReactionLottie = dynamic(
 import { AvatarCompositionType, MotionType, ReactionType } from '@/shared/api/http/types/@enums';
 import { AvatarFacePos } from '@/shared/api/http/types/users';
 import { cn } from '@/shared/lib/functions/cn';
+import ChatBubble from './chat-bubble.component';
 import calculateDimensions from '../lib/calculate-dimensions';
 import { Model } from '../model/avatar.model';
 
@@ -16,10 +17,18 @@ const MoveableFace = dynamic(
   { ssr: false }
 );
 
+/** 말풍선(#410) 노출 시간 (ms). */
+const CHAT_BUBBLE_DURATION = 2500;
+
 type Props = Model & {
   height: number;
   reaction?: ReactionType;
   motionType?: MotionType;
+  /**
+   * 이 crew 가 마지막으로 채팅한 시각(ms). 값이 바뀌면 머리 위 말풍선(#410)을
+   * CHAT_BUBBLE_DURATION 동안 노출한다. (#410)
+   */
+  lastChatAt?: number;
   /**
    * 함수가 있으면 얼굴 위치 조정 가능, 없으면 얼굴 위치 조정 불가능
    */
@@ -45,6 +54,7 @@ const Avatar = memo(
     facePosY,
     reaction,
     motionType,
+    lastChatAt,
     offsetX,
     offsetY,
     scale,
@@ -55,6 +65,16 @@ const Avatar = memo(
     const faceImgRef = useRef<HTMLImageElement>(null);
 
     const ref = useRef<HTMLDivElement>(null);
+
+    // #410: lastChatAt 가 갱신되면 말풍선을 잠시 노출. 연속 채팅이면 effect 가 재실행돼
+    // 이전 타이머를 정리하고 노출 시간이 자연히 연장된다.
+    const [showChatBubble, setShowChatBubble] = useState(false);
+    useEffect(() => {
+      if (!lastChatAt) return;
+      setShowChatBubble(true);
+      const timer = setTimeout(() => setShowChatBubble(false), CHAT_BUBBLE_DURATION);
+      return () => clearTimeout(timer);
+    }, [lastChatAt]);
 
     useEffect(() => {
       avatarRef?.(ref.current, motionType ?? MotionType.NONE);
@@ -86,6 +106,12 @@ const Avatar = memo(
             className='absolute left-1/2 -top-6 transform -translate-x-1/2 -z-1'
           >
             <ReactionLottie reaction={reaction} />
+          </div>
+        )}
+
+        {showChatBubble && (
+          <div className='absolute left-1/2 -top-8 z-10 -translate-x-1/2 transform'>
+            <ChatBubble />
           </div>
         )}
 

--- a/src/entities/avatar/ui/chat-bubble.component.test.tsx
+++ b/src/entities/avatar/ui/chat-bubble.component.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import ChatBubble from './chat-bubble.component';
+
+describe('ChatBubble (#410)', () => {
+  test('말풍선 컨테이너와 "..." 3점이 렌더된다', () => {
+    const { container } = render(<ChatBubble />);
+
+    expect(screen.getByTestId('avatar-chat-bubble')).toBeInTheDocument();
+    // 타이핑 인디케이터 점 3개
+    const dots = container.querySelectorAll('span');
+    expect(dots).toHaveLength(3);
+  });
+});

--- a/src/entities/avatar/ui/chat-bubble.component.tsx
+++ b/src/entities/avatar/ui/chat-bubble.component.tsx
@@ -1,0 +1,30 @@
+/**
+ * 아바타 머리 위 말풍선(#410). 사용자가 채팅을 칠 때 발신자 아바타에 잠시 노출된다.
+ * 좋아요 리액션(ReactionLottie)과 동일한 overlay 슬롯에 얹는다.
+ *
+ * 순수 CSS — 흰 말풍선 + 아래 꼬리 + 타이핑 인디케이터 스타일의 "..." 3점 staggered bounce.
+ * (별도 에셋/Lottie 불필요)
+ */
+export default function ChatBubble() {
+  return (
+    <div
+      data-testid='avatar-chat-bubble'
+      aria-label='Avatar Chat Bubble'
+      role='presentation'
+      className={
+        'relative flex items-center gap-1 rounded-2xl bg-white px-2.5 py-1.5 shadow-md ' +
+        // 아래쪽을 향하는 꼬리 (말풍선이 아바타 머리 위에 떠 있고 꼬리가 아래 head 를 가리킴)
+        'after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:content-[""] ' +
+        'after:border-4 after:border-transparent after:border-t-white'
+      }
+    >
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className='block h-1.5 w-1.5 rounded-full bg-gray-500 animate-bounce'
+          style={{ animationDelay: `${i * 150}ms`, animationDuration: '1s' }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/entities/current-partyroom/model/crew.model.ts
+++ b/src/entities/current-partyroom/model/crew.model.ts
@@ -10,6 +10,11 @@ export type Model = PartyroomCrew & {
    * setup 시점엔 동기화 하지 않음, 웹소켓 이벤트 수신때마다 변경됨
    */
   reactionType?: ReactionType;
+  /**
+   * 이 crew 가 마지막으로 채팅한 시각(ms). 채팅 시 갱신되며, 아바타 위 말풍선(#410)을
+   * 일정 시간 노출하는 트리거로 쓰인다. (Avatar 가 값 변경 시 transient 표시)
+   */
+  lastChatAt?: number;
 };
 
 /**

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-chat-callback.hook.test.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-chat-callback.hook.test.ts
@@ -64,6 +64,22 @@ describe('useChatCallback', () => {
     }
   });
 
+  test('채팅 시 발신 crew 에 lastChatAt 을 세팅한다 (#410 말풍선)', () => {
+    const crew = createCrew({ crewId: 5, nickname: '채팅유저' });
+    store.getState().updateCrews(() => [crew]);
+    const before = Date.now();
+
+    const { result } = renderHook(() => useChatCallback());
+    result.current({
+      eventType: PartyroomEventType.CHAT_MESSAGE_SENT,
+      crew: { crewId: 5 },
+      message: { messageId: 'msg-1', content: '안녕하세요' },
+    });
+
+    const updated = store.getState().crews.find((c) => c.crewId === 5);
+    expect(updated?.lastChatAt).toBeGreaterThanOrEqual(before);
+  });
+
   test('크루를 찾지 못하면 warn 로그 + 메시지 append하지 않음', () => {
     store.getState().updateCrews(() => [createCrew({ crewId: 1 })]);
 

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-chat-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-chat-callback.hook.ts
@@ -6,7 +6,10 @@ import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function useChatCallback() {
   const { useCurrentPartyroom } = useStores();
-  const appendChatMessage = useCurrentPartyroom((state) => state.appendChatMessage);
+  const [appendChatMessage, updateCrews] = useCurrentPartyroom((state) => [
+    state.appendChatMessage,
+    state.updateCrews,
+  ]);
 
   return (event: ChatMessageSentEvent) => {
     const { crews } = useCurrentPartyroom.getState();
@@ -23,6 +26,14 @@ export default function useChatCallback() {
       message: event.message,
       receivedAt: Date.now(),
     });
+
+    // #410: 발신 crew 아바타 위에 말풍선을 띄우기 위한 트리거. lastChatAt 갱신 시
+    // Avatar 가 transient 로 말풍선을 노출한다(연속 채팅이면 값이 갱신돼 시간 연장).
+    updateCrews((prev) =>
+      prev.map((prevCrew) =>
+        prevCrew.crewId === crew.crewId ? { ...prevCrew, lastChatAt: Date.now() } : prevCrew
+      )
+    );
   };
 }
 

--- a/src/widgets/partyroom-avatars/ui/avatars.component.tsx
+++ b/src/widgets/partyroom-avatars/ui/avatars.component.tsx
@@ -127,6 +127,7 @@ export default function Avatars({
             facePosX={dj.combinePositionX}
             facePosY={dj.combinePositionY}
             reaction={dj.reactionType}
+            lastChatAt={dj.lastChatAt}
             motionType={dj.motionType}
             offsetX={dj.offsetX || BASE_X}
             offsetY={dj.offsetY || BASE_Y}
@@ -159,6 +160,7 @@ export default function Avatars({
             facePosX={crew.combinePositionX}
             facePosY={crew.combinePositionY}
             reaction={crew.reactionType}
+            lastChatAt={crew.lastChatAt}
             offsetX={crew.offsetX || BASE_X}
             offsetY={crew.offsetY || BASE_Y}
             scale={crew.scale || BASE_SCALE}
@@ -194,6 +196,7 @@ export default function Avatars({
               facePosX={crew.combinePositionX}
               facePosY={crew.combinePositionY}
               reaction={crew.reactionType}
+              lastChatAt={crew.lastChatAt}
               offsetX={crew.offsetX || BASE_X}
               offsetY={crew.offsetY || BASE_Y}
               scale={crew.scale || BASE_SCALE}


### PR DESCRIPTION
Closes #410

## 변경
- 채팅 칠 때 **발신자 아바타 머리 위에 말풍선**이 잠시 노출(좋아요 리액션과 동일 overlay 슬롯). 말풍선 안 = **타이핑 인디케이터 '...' 3점**(순수 CSS, 에셋·Lottie 불필요).
- `Avatar` 에 `lastChatAt` prop → 값 변경 시 2.5s transient 노출(연속 채팅 시 연장).
- `use-chat-callback` 이 채팅 시 발신 crew 에 `lastChatAt` 세팅, avatars 3 스팟에 전달.

## 검증
- 채팅→발신 crew lastChatAt 세팅(RED→GREEN), ChatBubble 렌더 테스트. avatar/avatars/callbacks 79 tests GREEN, tsc·eslint 클린.

## 참고
- 표시 내용 = 💬 대신 **말풍선+'...' 타이핑 인디케이터**(사용자 요청). 노출 2.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)