### PR TITLE
feat(crew-profile): 상대 crew 프로필 모달 (아바타·닉네임·소개·DJ점수) (#409)

### DIFF
--- a/src/features/view-crew-profile/api/use-view-crew-profile.query.ts
+++ b/src/features/view-crew-profile/api/use-view-crew-profile.query.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { crewsService } from '@/shared/api/http/services';
+
+/**
+ * 다른 crew 의 프로필(닉네임·소개·아바타·활동 점수) 조회 (#409).
+ * 백엔드 GET /v1/partyrooms/crews/{crewId}/profile/summary 를 그대로 사용.
+ */
+export function useViewCrewProfile(crewId: number) {
+  return useQuery({
+    queryKey: [QueryKeys.Crews, crewId, 'profile'],
+    queryFn: () => crewsService.getCrewProfileSummary({ crewId }),
+    staleTime: 60_000,
+  });
+}

--- a/src/features/view-crew-profile/index.ts
+++ b/src/features/view-crew-profile/index.ts
@@ -1,0 +1,1 @@
+export { useOpenCrewProfile } from './lib/use-open-crew-profile.hook';

--- a/src/features/view-crew-profile/lib/use-open-crew-profile.hook.tsx
+++ b/src/features/view-crew-profile/lib/use-open-crew-profile.hook.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useDialog } from '@/shared/ui/components/dialog';
+import CrewProfileCard from '../ui/crew-profile-card.component';
+
+/**
+ * crew 프로필 모달 열기(#409). 크루 목록·채팅 등 어디서든 재사용하는 단일 트리거.
+ * 운영 액션(등급조정/차단)과 별개로, 아바타/닉네임 클릭으로 모두에게 노출한다.
+ */
+export function useOpenCrewProfile() {
+  const { openDialog } = useDialog();
+
+  return (crewId: number) =>
+    openDialog(() => ({
+      showCloseIcon: true,
+      Body: <CrewProfileCard crewId={crewId} />,
+    }));
+}

--- a/src/features/view-crew-profile/ui/crew-profile-card.component.test.tsx
+++ b/src/features/view-crew-profile/ui/crew-profile-card.component.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { Mock } from 'vitest';
+import { ActivityType } from '@/shared/api/http/types/@enums';
+import CrewProfileCard from './crew-profile-card.component';
+import { useViewCrewProfile } from '../api/use-view-crew-profile.query';
+
+vi.mock('../api/use-view-crew-profile.query');
+vi.mock('@/entities/avatar/ui/avatar.component', () => ({
+  default: () => <div data-testid='avatar' />,
+}));
+
+const baseProfile = {
+  crewId: 1,
+  nickname: '디제이마스터',
+  introduction: '음악 좋아요',
+  avatarBodyUri: 'body.png',
+  avatarFaceUri: 'face.png',
+  combinePositionX: 0,
+  combinePositionY: 0,
+  activitySummaries: [{ activityType: ActivityType.DJ_PNT, score: 150 }],
+};
+
+describe('CrewProfileCard (#409)', () => {
+  test('닉네임·소개·DJ 점수를 표시한다', () => {
+    (useViewCrewProfile as Mock).mockReturnValue({ data: baseProfile, isLoading: false });
+
+    render(<CrewProfileCard crewId={1} />);
+
+    expect(screen.getByText('디제이마스터')).toBeInTheDocument();
+    expect(screen.getByText('음악 좋아요')).toBeInTheDocument();
+    expect(screen.getByText('150p')).toBeInTheDocument();
+  });
+
+  test('DJ 점수가 없으면 0p 로 표시한다', () => {
+    (useViewCrewProfile as Mock).mockReturnValue({
+      data: { ...baseProfile, activitySummaries: [] },
+      isLoading: false,
+    });
+
+    render(<CrewProfileCard crewId={1} />);
+
+    expect(screen.getByText('0p')).toBeInTheDocument();
+  });
+
+  test('로딩 중에는 안내 문구를 표시한다', () => {
+    (useViewCrewProfile as Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<CrewProfileCard crewId={1} />);
+
+    expect(screen.getByText('불러오는 중...')).toBeInTheDocument();
+  });
+});

--- a/src/features/view-crew-profile/ui/crew-profile-card.component.tsx
+++ b/src/features/view-crew-profile/ui/crew-profile-card.component.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Avatar from '@/entities/avatar/ui/avatar.component';
+import { ActivityType, AvatarCompositionType } from '@/shared/api/http/types/@enums';
+import { Typography } from '@/shared/ui/components/typography';
+import { useViewCrewProfile } from '../api/use-view-crew-profile.query';
+
+type Props = {
+  crewId: number;
+};
+
+/**
+ * 다른 crew 프로필 카드(#409) — 다이얼로그 Body 로 렌더. 아바타·닉네임·소개 +
+ * DJ 점수(좋은 아바타를 입은 사람의 점수가 궁금하다는 요구). 아바타는 entities/avatar 의
+ * Avatar 를 재사용(프로필 응답엔 offset/scale 이 없어 기본값으로 렌더).
+ */
+export default function CrewProfileCard({ crewId }: Props) {
+  const { data, isLoading } = useViewCrewProfile(crewId);
+
+  if (isLoading || !data) {
+    return (
+      <div className='flex min-h-[200px] min-w-[240px] items-center justify-center'>
+        <Typography type='detail1' className='text-gray-400'>
+          불러오는 중...
+        </Typography>
+      </div>
+    );
+  }
+
+  const djScore =
+    data.activitySummaries.find((summary) => summary.activityType === ActivityType.DJ_PNT)?.score ??
+    0;
+
+  return (
+    <div className='flex min-w-[240px] flex-col items-center gap-3 px-2 py-1'>
+      <Avatar
+        height={120}
+        bodyUri={data.avatarBodyUri}
+        faceUri={data.avatarFaceUri}
+        compositionType={
+          data.avatarFaceUri
+            ? AvatarCompositionType.BODY_WITH_FACE
+            : AvatarCompositionType.SINGLE_BODY
+        }
+        facePosX={data.combinePositionX}
+        facePosY={data.combinePositionY}
+        offsetX={0}
+        offsetY={0}
+        scale={1}
+      />
+
+      <Typography type='body1' className='font-bold text-gray-50'>
+        {data.nickname}
+      </Typography>
+
+      {data.introduction && (
+        <Typography type='detail1' className='whitespace-pre-line text-center text-gray-400'>
+          {data.introduction}
+        </Typography>
+      )}
+
+      <div className='mt-1 flex items-center gap-2 rounded bg-gray-800 px-3 py-1.5'>
+        <Typography type='detail1' className='text-gray-400'>
+          DJ 점수
+        </Typography>
+        <Typography type='body1' className='font-bold text-red-300'>
+          {djScore}p
+        </Typography>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets-mobile/partyroom-chat-panel/ui/parts/chat-item.component.test.tsx
+++ b/src/widgets-mobile/partyroom-chat-panel/ui/parts/chat-item.component.test.tsx
@@ -3,6 +3,9 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { GradeType } from '@/shared/api/http/types/@enums';
 
+vi.mock('@/features/view-crew-profile', () => ({
+  useOpenCrewProfile: () => vi.fn(),
+}));
 vi.mock('@/shared/ui/components/profile/profile.component', () => ({
   __esModule: true,
   default: ({ src, size }: any) => <div data-testid='profile' data-src={src} data-size={size} />,

--- a/src/widgets-mobile/partyroom-chat-panel/ui/parts/chat-item.component.tsx
+++ b/src/widgets-mobile/partyroom-chat-panel/ui/parts/chat-item.component.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import { ChatMessage, Crew } from '@/entities/current-partyroom';
 import { GRADE_TYPE_LABEL } from '@/entities/partyroom-client';
+import { useOpenCrewProfile } from '@/features/view-crew-profile';
 import { GradeType } from '@/shared/api/http/types/@enums';
 import { cn } from '@/shared/lib/functions/cn';
 import Profile from '@/shared/ui/components/profile/profile.component';
@@ -14,6 +15,7 @@ type ChatItemProps = {
 
 const ChatItem = forwardRef<HTMLDivElement, ChatItemProps>(({ message }, ref) => {
   const crew = message.crew;
+  const openCrewProfile = useOpenCrewProfile();
   const myGradeComparator = Crew.GradeComparator.of(crew.gradeType);
   const showGradeLabel = myGradeComparator.isHigherThanOrEqualTo(GradeType.CLUBBER);
   const emphasisGradeLabel = myGradeComparator.isHigherThanOrEqualTo(GradeType.MODERATOR);
@@ -25,10 +27,15 @@ const ChatItem = forwardRef<HTMLDivElement, ChatItemProps>(({ message }, ref) =>
       data-testid='chat-message-item'
     >
       <div className='flexCol items-center gap-2 px-[5px] pt-[2px]'>
-        <div className='relative'>
+        <button
+          type='button'
+          onClick={() => openCrewProfile(crew.crewId)}
+          aria-label={`${crew.nickname} 프로필 보기`}
+          className='relative'
+        >
           <Profile src={crew.avatarIconUri} size={32} />
           <AuthorityHeadset grade={crew.gradeType} />
-        </div>
+        </button>
 
         {showGradeLabel && (
           <Typography

--- a/src/widgets-mobile/partyroom-crews-panel/partyroom-crews-panel.component.tsx
+++ b/src/widgets-mobile/partyroom-crews-panel/partyroom-crews-panel.component.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { FC } from 'react';
 import { useCurrentPartyroomCrews } from '@/features/partyroom/list-crews';
+import { useOpenCrewProfile } from '@/features/view-crew-profile';
 import { cn } from '@/shared/lib/functions/cn';
 import { useStores } from '@/shared/lib/store/stores.context';
 
@@ -16,6 +17,7 @@ import { useStores } from '@/shared/lib/store/stores.context';
  */
 const MobilePartyroomCrewsPanel: FC = () => {
   const crews = useCurrentPartyroomCrews();
+  const openCrewProfile = useOpenCrewProfile();
   const { useCurrentPartyroom } = useStores();
   const currentDj = useCurrentPartyroom((state) => state.currentDj);
 
@@ -34,12 +36,21 @@ const MobilePartyroomCrewsPanel: FC = () => {
           const isDj = currentDj?.crewId === crew.crewId;
           return (
             <li key={crew.crewId} className='flex items-center gap-3 px-4 py-3 min-h-[44px]'>
-              <div className='relative w-8 h-8 rounded-full overflow-hidden bg-gray-800 shrink-0'>
-                {crew.avatarIconUri && (
-                  <Image src={crew.avatarIconUri} alt='' fill className='object-cover' />
-                )}
-              </div>
-              <span className='text-sm text-white truncate flex-1'>{crew.nickname}</span>
+              <button
+                type='button'
+                onClick={() => openCrewProfile(crew.crewId)}
+                aria-label={`${crew.nickname} 프로필 보기`}
+                className='flex min-w-0 flex-1 items-center gap-3'
+              >
+                <div className='relative w-8 h-8 rounded-full overflow-hidden bg-gray-800 shrink-0'>
+                  {crew.avatarIconUri && (
+                    <Image src={crew.avatarIconUri} alt='' fill className='object-cover' />
+                  )}
+                </div>
+                <span className='text-sm text-white truncate flex-1 text-left'>
+                  {crew.nickname}
+                </span>
+              </button>
               {isDj && <span className='text-[10px] text-red-400 font-bold shrink-0'>DJ</span>}
             </li>
           );

--- a/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
+++ b/src/widgets/partyroom-chat-panel/ui/partyroom-chat-panel.component.tsx
@@ -13,6 +13,7 @@ import {
 import { useChatMessagesScrollManager } from '@/features/partyroom/list-chat-messages';
 import { useIsBlockedCrew } from '@/features/partyroom/list-my-blocked-crews';
 import { SendChatMessage } from '@/features/partyroom/send-chat-message';
+import { useOpenCrewProfile } from '@/features/view-crew-profile';
 import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { ONE_MINUTE } from '@/shared/config/time';
 import { useVerticalStretch } from '@/shared/lib/hooks/use-vertical-stretch.hook';
@@ -35,6 +36,7 @@ export default function PartyroomChatPanel() {
   const removeChatMessage = useRemoveChatMessage();
   const imposePenalty = useImposePenalty();
   const blockCrew = useBlockCrew();
+  const openCrewProfile = useOpenCrewProfile();
   const isBlockedCrew = useIsBlockedCrew();
   const containerRef = useVerticalStretch<HTMLDivElement>();
   const chatMessages = useCurrentPartyroomChat();
@@ -88,6 +90,11 @@ export default function PartyroomChatPanel() {
               menuPositionClassName='top-[8px] right-[12px]'
               menuItemPanelSize='sm'
               menuConfig={[
+                {
+                  label: '프로필 보기',
+                  onClickItem: () => openCrewProfile(message.crew.crewId),
+                  visible: true,
+                },
                 {
                   label: t.common.btn.authority,
                   onClickItem: () => adjustGrade(message.crew),

--- a/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
+++ b/src/widgets/partyroom-crews-panel/ui/parts/all-crews-panel.component.tsx
@@ -2,6 +2,7 @@ import { useAdjustGrade, useCanAdjustGrade } from '@/features/partyroom/adjust-g
 import { useBlockCrew } from '@/features/partyroom/block-crew';
 import { useCanImposePenalty, useImposePenalty } from '@/features/partyroom/impose-penalty';
 import { Crews, useCurrentPartyroomCrews } from '@/features/partyroom/list-crews';
+import { useOpenCrewProfile } from '@/features/view-crew-profile';
 import { PenaltyType } from '@/shared/api/http/types/@enums';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -16,6 +17,7 @@ export default function AllCrewsPanel() {
   const canImposePenalty = useCanImposePenalty();
   const imposePenalty = useImposePenalty();
   const blockCrew = useBlockCrew();
+  const openCrewProfile = useOpenCrewProfile();
   const [me, currentDj] = useStores().useCurrentPartyroom((state) => [state.me, state.currentDj]);
 
   return (
@@ -52,6 +54,11 @@ export default function AllCrewsPanel() {
                 key={crew.crewId}
                 userListItemConfig={crew}
                 menuItemList={[
+                  {
+                    label: '프로필 보기',
+                    onClickItem: () => openCrewProfile(crew.crewId),
+                    visible: true,
+                  },
                   {
                     label: t.common.btn.authority,
                     onClickItem: () => adjustGrade(crew),


### PR DESCRIPTION
Closes #409

## 변경
- 크루 클릭 → **프로필 모달**(아바타·닉네임·소개·**DJ 점수 'Np'**). "좋은 아바타 입은 사람 점수 궁금" 요구 반영.
- 데이터(백엔드 엔드포인트·웹 `getCrewProfileSummary`·`activitySummaries` score)는 **이미 존재** → **프론트 전용**.
- 피처 슬라이스 `view-crew-profile`: query 훅 + `CrewProfileCard`(Avatar 재사용) + `useOpenCrewProfile`(useDialog).
- **트리거 4 surface**: 데스크탑 크루목록·채팅 = 메뉴 '프로필 보기' / 모바일 크루패널·채팅 = 아바타·닉네임 직접 클릭. 운영 액션(등급/차단)과 공존.

## 검증
- 카드 테스트(닉네임·소개·DJ점수·0p·로딩) + 모바일 chat-item 회귀 mock. 37 tests GREEN, tsc·eslint(0 error) 클린.

## 참고
- 점수 = `DJ_PNT` 'Np'(기존 my-profile 패턴). '프로필 보기' 라벨 하드코딩(#412 선례, i18n 후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)