### PR TITLE
fix(music-preview): 모바일 미리듣기 64×36 → 전체너비 16:9 카드 — ToS 최소 크기(200×200) (#420)

### DIFF
--- a/src/entities/music-preview/config/youtube-player.config.ts
+++ b/src/entities/music-preview/config/youtube-player.config.ts
@@ -28,13 +28,13 @@ export const previewPlayerConfig: YouTubeConfig = {
 };
 
 /**
- * 미리보기 플레이어 기본 크기.
+ * 데스크탑 미리듣기 플레이어 크기.
  *
  * ⚠️ YouTube ToS(Required Minimum Functionality): 임베드 플레이어 viewport ≥200×200 (issue #420).
  * 16:9 에서 높이 200px 는 너비 356px 를 요구하므로 데스크탑 미리듣기는 최소 권장 480×270 사용.
  *
- * `mobile-bottom` 은 PR3 에서 전체너비 16:9 카드로 재설계 예정(112px 바엔 ≥200 불가). 그 전까지
- * 임시로 남겨두며, 컴플라이언스 가드(config.test)는 데스크탑 키만 검사한다.
+ * 모바일 미리듣기는 고정 px 가 아니라 전체너비(100%) × 202px 카드로 렌더하므로 본 config 를
+ * 쓰지 않는다(MiniPlayer 참조). 과거 `mobile-bottom`(64×36)은 ToS 위반이라 제거됨.
  */
 export const PREVIEW_PLAYER_SIZES = {
   sidebar: {
@@ -44,9 +44,5 @@ export const PREVIEW_PLAYER_SIZES = {
   modal: {
     width: 480,
     height: 270,
-  },
-  'mobile-bottom': {
-    width: 64,
-    height: 36,
   },
 } as const;

--- a/src/entities/music-preview/ui/youtube-preview-player.component.tsx
+++ b/src/entities/music-preview/ui/youtube-preview-player.component.tsx
@@ -15,9 +15,9 @@ import { previewPlayerAPI } from '../lib/react-player.api';
 const YoutubePlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
 
 type YouTubePreviewPlayerProps = {
-  /** 플레이어 크기 */
-  width: number;
-  height: number;
+  /** 플레이어 크기. number(px) 또는 CSS 문자열('100%' 등 — 모바일 전체너비 카드용, issue #420). */
+  width: number | string;
+  height: number | string;
   /** 추가 CSS 클래스 */
   className?: string;
   /** 닫기 버튼 표시 여부 */

--- a/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.test.tsx
+++ b/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.test.tsx
@@ -28,8 +28,12 @@ vi.mock('@/shared/lib/store/stores.context', () => ({
 }));
 
 vi.mock('@/entities/music-preview/index.ui', () => ({
-  YouTubePreviewPlayer: (props: { width: number; height: number }) => (
-    <div data-testid='yt-player' data-width={props.width} data-height={props.height} />
+  YouTubePreviewPlayer: (props: { width: number | string; height: number | string }) => (
+    <div
+      data-testid='yt-player'
+      data-width={String(props.width)}
+      data-height={String(props.height)}
+    />
   ),
 }));
 
@@ -73,7 +77,7 @@ describe('MiniPlayer (mobile-bottom)', () => {
     expect(startPreview).toHaveBeenCalledWith(track);
   });
 
-  test('currentTrack 있음 + playState=playing 시 YouTubePreviewPlayer 렌더 (64×36)', () => {
+  test('currentTrack 있음 + playState=playing 시 전체너비 16:9 카드로 렌더 (ToS ≥200×200, issue #420)', () => {
     useMusicPreviewMock.mockReturnValue({
       currentTrack: { name: 'Song A', artist: 'Artist X', source: 'preview-search' },
       playState: 'playing',
@@ -82,8 +86,9 @@ describe('MiniPlayer (mobile-bottom)', () => {
     });
     render(<MiniPlayer onAdd={vi.fn()} addPending={false} />);
     const yt = screen.getByTestId('yt-player');
-    expect(yt.getAttribute('data-width')).toBe('64');
-    expect(yt.getAttribute('data-height')).toBe('36');
+    // 64×36 썸네일은 ToS 위반 → 전체너비(100%) + 높이 ≥200 카드로 교체.
+    expect(yt.getAttribute('data-width')).toBe('100%');
+    expect(Number(yt.getAttribute('data-height'))).toBeGreaterThanOrEqual(200);
   });
 
   test('source 무관 렌더 (playlist-track source 도 정상) — spec §B.4', () => {

--- a/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.tsx
+++ b/src/widgets-mobile/music-preview-mini-player/ui/mini-player.component.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { FC } from 'react';
-import { PREVIEW_PLAYER_SIZES } from '@/entities/music-preview/config/youtube-player.config';
 import { YouTubePreviewPlayer } from '@/entities/music-preview/index.ui';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
@@ -9,6 +8,14 @@ import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFClose, PFPauseCircleFilled, PFPlayCircleFilled } from '@/shared/ui/icons';
 
+/**
+ * 미리듣기 영상 높이(px). YouTube ToS(Required Minimum Functionality, issue #420)는 임베드
+ * 플레이어 viewport ≥200×200 을 요구한다. 모바일은 전체너비(100%) × 이 높이로 렌더 →
+ * 어느 폰 폭(≥320)에서도 width·height 모두 ≥200 을 만족(과거 64×36 썸네일은 위반).
+ * 16:9 기준 너비 358px(iPhone13)에서 ~201 → 202 로 둬 양 축 ≥200 안전 확보.
+ */
+const PREVIEW_CARD_VIDEO_HEIGHT = 202;
+
 interface Props {
   /** 추가 시그널. 대상 트랙은 시트가 결정한다(mini-player 의 currentTrack 은 duration 없는 lossy PreviewTrack). */
   onAdd: () => void;
@@ -16,10 +23,10 @@ interface Props {
 }
 
 /**
- * sheet 내부 bottom mini-player (spec §5.5 outcome A).
- * - 112px 컨테이너 (= video 36 + 좌우 padding + 컨트롤 cluster 영역)
- * - 좌측: 곡명/아티스트 (flex-1 min-w-0 ellipsis)
- * - 우측: ⏯ + [+ 추가] + × 컨트롤 cluster + video 64×36 (visible frame, ToS 보존)
+ * sheet 내부 bottom 미리듣기 카드 (issue #420 ToS 최소 크기 준수).
+ * - 과거 112px 바 + 64×36 영상(ToS 위반)을 **전체너비 16:9 카드**로 교체.
+ * - 상단: 영상(w-full × 202px, viewport ≥200×200 컴플라이언트)
+ * - 하단: 곡명/아티스트(flex-1 ellipsis) + ⏯ · [+ 추가] · × 컨트롤 cluster
  * - track 변경 시 YouTubePreviewPlayer 의 wrapper 가 loadVideoById 로 IFrame remount 0 (chunk 3.1 패턴)
  * - source 무관 (spec §B.4) — 데스크탑 sidebar-player 의 source==='playlist-track' 분기 없음
  * - currentTrack 없으면 미렌더. playState idle/paused 도 ▶ 토글 분기 가능하게 렌더.
@@ -33,7 +40,6 @@ const MiniPlayer: FC<Props> = ({ onAdd, addPending }) => {
 
   if (!currentTrack) return null;
 
-  const SIZE = PREVIEW_PLAYER_SIZES['mobile-bottom'];
   const isPlaying = playState === 'playing';
 
   const togglePlay = () => {
@@ -48,20 +54,27 @@ const MiniPlayer: FC<Props> = ({ onAdd, addPending }) => {
   const displayArtist = track.artist ?? '';
 
   return (
-    <div className='h-[112px] flex items-center gap-3 px-3 border-t border-gray-800 bg-black'>
-      <div className='flex-1 min-w-0'>
-        <Typography type='body3' className='truncate' data-testid='mini-player-name'>
-          {displayName}
-        </Typography>
-        <Typography
-          type='detail2'
-          className='truncate text-gray-400'
-          data-testid='mini-player-artist'
-        >
-          {displayArtist}
-        </Typography>
+    <div className='border-t border-gray-800 bg-black'>
+      <div className='w-full'>
+        <YouTubePreviewPlayer
+          width='100%'
+          height={PREVIEW_CARD_VIDEO_HEIGHT}
+          showCloseButton={false}
+        />
       </div>
-      <div className='flex flex-col items-end gap-2'>
+      <div className='flex items-center gap-3 px-3 py-2'>
+        <div className='flex-1 min-w-0'>
+          <Typography type='body3' className='truncate' data-testid='mini-player-name'>
+            {displayName}
+          </Typography>
+          <Typography
+            type='detail2'
+            className='truncate text-gray-400'
+            data-testid='mini-player-artist'
+          >
+            {displayArtist}
+          </Typography>
+        </div>
         <div className='flex items-center gap-2'>
           <TextButton
             data-testid='mini-player-toggle-play'
@@ -90,7 +103,6 @@ const MiniPlayer: FC<Props> = ({ onAdd, addPending }) => {
             aria-label='미리듣기 종료'
           />
         </div>
-        <YouTubePreviewPlayer width={SIZE.width} height={SIZE.height} showCloseButton={false} />
       </div>
     </div>
   );

--- a/src/widgets/music-preview-player/ui/player-container.component.tsx
+++ b/src/widgets/music-preview-player/ui/player-container.component.tsx
@@ -5,8 +5,8 @@ import { YouTubePreviewPlayer } from '@/entities/music-preview/index.ui';
 import { useStores } from '@/shared/lib/store/stores.context';
 
 type PlayerContainerProps = {
-  /** 플레이어 위치 타입 */
-  position: 'sidebar' | 'modal' | 'mobile-bottom';
+  /** 플레이어 위치 타입 (모바일은 별도 전체너비 카드 — MiniPlayer) */
+  position: 'sidebar' | 'modal';
   /** 추가 CSS 클래스 */
   className?: string;
   /** 닫기 핸들러 */


### PR DESCRIPTION
## 무엇 / 왜

issue #420 (YouTube 임베드 플레이어 최소 크기 200×200 위반)의 **모바일 미리듣기 부분** (마지막 조각).

모바일 미니플레이어의 **64×36** 영상은 [YouTube Required Minimum Functionality](https://developers.google.com/youtube/terms/required-minimum-functionality)(viewport ≥200×200) 위반 — 위반 중 가장 심각. 112px 바에는 ≥200 영상이 물리적으로 불가 → **전체너비 16:9 카드**로 재설계(brainstorm 합의).

## 변경

- **MiniPlayer**: 112px 바 + 64×36 영상 → **전체너비(100%) × 202px 영상 카드** + 하단 곡명/아티스트 + ⏯·추가·닫기 컨트롤. 어느 폰 폭(≥320px)에서도 viewport 양 축 ≥200 충족(예: iPhone13 358×202).
- **YouTubePreviewPlayer**: width/height 타입 `number | string` 확장('100%' 허용 — 전체너비 카드용).
- **`PREVIEW_PLAYER_SIZES`**: `mobile-bottom`(64×36) 제거(미사용·위반). `PlayerContainer` position 타입 `'sidebar' | 'modal'` 로 좁힘.
- 기존 testid·컨트롤·연속 전환 동작 모두 보존(미니플레이어 회귀 테스트 그대로 통과).

## 스택 / 검증

- ⚠️ **PR #422(데스크탑 미리듣기) 위에 스택** — 동일 `PREVIEW_PLAYER_SIZES` 객체를 수정해 develop 직접 분기 시 머지 충돌. PR #422 머지 후 base 자동 재타깃.
- `tsc`·`eslint`(0) ✅ / 유닛 풀회귀 **1592 passed** ✅
- ⏳ 로컬 풀스택 수동 확인은 머지 전 권장(시트 카드 시각).

이로써 #420 전체 스윕 완료: 전광판(#421) + 데스크탑 미리듣기(#422) + 모바일 카드(본 PR).
