### PR TITLE
fix(mobile): iOS 곡 전환마다 자동재생 끊김 — 전광판 iframe remount 제거 (#426)

### DIFF
--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.test.ts
@@ -87,7 +87,12 @@ describe('useAutoplayGestureGate', () => {
     expect(result.current.gate.autoplayBlocked).toBe(false);
   });
 
-  test('videoId 변경 시 played reset + 새 1500ms 타이머 시작 (트랙 변경 시 차단 재armed)', () => {
+  // #426: 이전엔 videoId 변경 시 played=false 로 리셋했고, video-frame 의 key 가 played 를
+  // 포함해 곡 전환마다 IFrame 이 remount → iOS WebKit 에서 user-activation 소실 → 매 곡 재-gate.
+  // 곡 전환은 백엔드가 PlaybackStartedEvent 만 보내(DEACTIVATE 없음) playable 이 연속 true 이므로,
+  // played 를 유지해야 key 가 불변 → remount 없음 → 첫 탭 이후 곡 전환이 끊김 없이 이어진다.
+  // (데스크톱 video.component 와 동일한 안정-인스턴스 정책.)
+  test('videoId 변경 시 played 유지 — 재생 중이면 재-gate 안 함 (트랙 전환 remount 방지 #426)', () => {
     let id = 'first' as string | null;
     const { result, rerender } = renderHook(() => {
       const playerRef = useRef<TReactPlayer | null>(null);
@@ -102,8 +107,29 @@ describe('useAutoplayGestureGate', () => {
     id = 'second';
     rerender();
 
+    // 재생 중이던 player 는 곡 전환에 played 유지 → key 불변 → remount 없음
+    expect(result.current.played).toBe(true);
+
+    // 이미 재생 중이므로 차단 재감지(재-gate) 하지 않는다
+    act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
+    expect(result.current.autoplayBlocked).toBe(false);
+  });
+
+  test('첫 곡이 아직 재생 전(played=false)일 때 videoId 변경되면 차단 감지는 계속 동작', () => {
+    // 첫 곡을 한 번도 재생 못 한 상태에서 트랙이 바뀌면 여전히 gate 로 탭 유도해야 한다.
+    let id = 'first' as string | null;
+    const { result, rerender } = renderHook(() => {
+      const playerRef = useRef<TReactPlayer | null>(null);
+      return useAutoplayGestureGate({ playerRef, playable: true, videoId: id });
+    });
+
+    act(() => result.current.onReady({} as TReactPlayer));
     expect(result.current.played).toBe(false);
 
+    id = 'second';
+    rerender();
+
+    expect(result.current.played).toBe(false);
     act(() => vi.advanceTimersByTime(AUTOPLAY_DETECT_MS));
     expect(result.current.autoplayBlocked).toBe(true);
   });

--- a/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
+++ b/src/widgets-mobile/partyroom-display-board/lib/use-autoplay-gesture-gate.hook.ts
@@ -37,8 +37,15 @@ export default function useAutoplayGestureGate({
     }
   }, [playable]);
 
+  // #426: videoId(곡) 변경 시 played 를 리셋하지 않는다.
+  // video-frame 의 player key 가 played 를 포함하므로, 곡마다 played 를 false 로 되돌리면
+  // IFrame 이 remount 되고 iOS WebKit 에서 user-activation 이 소실돼 곡 전환마다 재-gate 된다.
+  // 곡 전환은 백엔드 PlaybackStartedEvent 만(DEACTIVATE 없음) → playable 연속 true 이므로,
+  // played 를 유지하면 key 가 불변 → remount 없음 → 첫 탭 이후 곡 전환이 끊김 없이 이어진다.
+  // (데스크톱 video.component 의 안정-인스턴스 정책과 동일. 재생 정지→재시작은 아래 [playable]
+  //  cleanup 이 played 를 리셋하므로 정상적으로 다시 gate 된다.)
+  // autoplayBlocked 만 새 트랙 기준으로 재감지하도록 초기화한다(아직 미재생인 첫 곡 케이스 대비).
   useEffect(() => {
-    setPlayed(false);
     setAutoplayBlocked(false);
   }, [videoId]);
 

--- a/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
+++ b/src/widgets-mobile/partyroom-display-board/partyroom-display-board.component.test.tsx
@@ -200,7 +200,10 @@ describe('MobilePartyroomDisplayBoard · compact (크루/큐 탭)', () => {
 });
 
 describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
-  test('#7 트랙 변경 시 autoplay 차단 재armed: 새 videoId + 1500ms 후 차단 → overlay 렌더', () => {
+  // #426: 재생 중 곡이 바뀌어도 재-gate 하면 안 된다. 곡 전환은 backend PlaybackStartedEvent 만
+  // (DEACTIVATE 없음) → playable 연속 true, played 유지 → player key 불변 → remount 없음 →
+  // iOS WebKit user-activation 유지 → 끊김 없이 이어짐. (이전엔 played 리셋→remount→매 곡 재-gate 버그.)
+  test('#9 재생 중 트랙 변경 시 재-gate 안 함 (player remount 방지 #426)', () => {
     const { rerender } = render(<MobilePartyroomDisplayBoard partyroomId={1} />);
 
     const firstYt = youtubePlayerCalls[0];
@@ -209,21 +212,19 @@ describe('MobilePartyroomDisplayBoard · autoplay 차단 회귀', () => {
       (firstYt.onPlay as () => void)();
     });
 
+    // 트랙 변경 (재생 중 상태에서 새 곡으로 전환)
     setStoreState({
       playback: { name: 'Track 2', duration: '4:00', linkId: 'def', endTime: FUTURE_END_TIME },
     });
     rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
 
-    const newYt = youtubePlayerCalls[youtubePlayerCalls.length - 1];
-    act(() => {
-      (newYt.onReady as (p: unknown) => void)(makeMockPlayer());
-    });
     act(() => {
       vi.advanceTimersByTime(1500);
     });
     rerender(<MobilePartyroomDisplayBoard partyroomId={1} />);
 
-    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeTruthy();
+    // played 유지 → 차단 재감지 안 됨 → gesture gate 미표시 (자동재생 끊김 없음)
+    expect(screen.queryByTestId('autoplay-gesture-gate')).toBeNull();
   });
 
   test('#8 Mode C → 재할당 → onReady 후 1500ms 내 onPlay 없으면 차단 + overlay 렌더', () => {


### PR DESCRIPTION
Fixes #426

## 증상
iOS Safari(모바일 웹)에서 **DJ가 곡을 바꿀 때마다 자동재생이 끊기고 "클릭하여 재생"(gesture gate)이 매번 재등장**. 데스크톱/iPad 데스크톱 모드는 정상.

## 원인 (실기기 확정)
모바일 전광판이 **곡 전환마다 YouTube iframe을 remount** → 사용자가 첫 탭으로 얻은 **iOS WebKit user-activation 소실** → autoplay 재차단.
- `use-autoplay-gesture-gate.hook.ts`가 **videoId 변경마다 `setPlayed(false)`** + `video-frame`의 player `key`가 `played` 포함 → 곡 전환 시 key 변경 → remount.
- 데스크톱 `video.component.tsx`는 played를 곡 전환마다 리셋 안 함(안정 인스턴스) → 이어짐. **모바일이 gate 훅 분리하며 들어온 회귀.**
- **iPad 자연실험**(같은 WebKit): 데스크톱 모드=곡 전환 이어짐 / 모바일 모드=매 곡 재-gate → remount가 원인 확정.

## 수정
`use-autoplay-gesture-gate.hook.ts`의 `[videoId]` 효과에서 **`setPlayed(false)` 제거**(`autoplayBlocked`만 재감지용으로 유지).
- 곡 전환은 backend `PlaybackStartedEvent`만(DEACTIVATE 없음) → `playable` 연속 true → played 유지 → **key 불변 → remount 없음** → 첫 탭 이후 곡 전환 끊김 없이 이어짐. 곡 자체 전환은 기존 `loadVideoById`(같은 인스턴스 in-place)가 처리.
- **잔여(불가피)**: iOS는 최초 1탭(첫 곡 unlock)은 WebKit 정책상 필요. 효과="곡마다 탭 → 세션당 1탭".

## 비회귀 (코드 전수 추적 + 리뷰 확인)
- **BT 자동재개(#334)**: 모바일 gate `onPause`=no-op(모바일 무관), 데스크톱은 별도 파일 → **영향 없음.**
- 같은곡 reload(#384)·입장 seek(#382)·정지→재시작 re-gate·첫 곡 tap-to-play 게이트: 전부 무영향(미변경 경로).
- 데스크톱 무영향(모바일 파일만). 코드리뷰 6/6 compliance, Approved.

## 테스트
- 버그를 정답으로 박제했던 테스트 2건 재작성(hook: played 유지/재-gate 안 함, component #9: 재-gate 안 함) + 첫 곡 미재생 시 재감지 유지 케이스 추가.
- 모바일 전광판 스위트 63/63 GREEN, `tsc` 0, 풀 회귀(pre-push) 통과.
- ⏳ **실 iPad/iPhone Safari before-after는 머지 전 권장**(iOS autoplay 버전 편차).

## 머지 메모
base=`development`. ⚠️ #420/#421(전광판 ToS)과 인접 — 단 본 PR은 **gate 훅 + 테스트만** 변경(video-frame 소스 미변경)이라 충돌 적음. 머지 순서 충돌 시 hook 변경만 재적용. 포렌식: `bugs/2026-06-17-mobile-youtube-player-remount-ios-autoplay-regate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
