### PR TITLE
fix(auth): 방 안 회원 토큰 만료 시 게스트 강등 → 재로그인 라우팅 (#428)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-expired-member-reauth-routing.md
+++ b/docs/superpowers/plans/2026-06-19-expired-member-reauth-routing.md
@@ -1,0 +1,347 @@
+# 만료-회원 재인증 라우팅 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 방 안에서 로그인 회원의 토큰이 만료되면 게스트로 강등하지 않고 재로그인으로 라우팅한다(방문자·게스트만료는 게스트 경로 유지).
+
+**Architecture:** localStorage "회원 세션 이력" 플래그로 만료-회원 vs 방문자를 구별하고, `signInGuest`의 유일 호출처(`useAutoSignInByGuest`)에서 분류기로 게이트. 만료-회원은 단일 `reauthenticate()` 지점(향후 refresh 삽입점)으로 보낸다.
+
+**Tech Stack:** Next.js(App Router), React, TanStack Query, Vitest + @testing-library/react. 스펙: `docs/superpowers/specs/2026-06-19-expired-member-reauth-routing-design.md`.
+
+---
+
+## 파일 구조
+
+- Create `src/entities/me/lib/member-session.ts` — 회원 세션 이력 플래그(localStorage, SSR 가드). 책임: mark/has/clear.
+- Create `src/entities/me/lib/member-session.test.ts`
+- Create `src/features/sign-in/by-guest/lib/classify-auth-error.ts` — 순수 분류기(401 → IGNORE/VISITOR/EXPIRED_MEMBER).
+- Create `src/features/sign-in/by-guest/lib/classify-auth-error.test.ts`
+- Create `src/features/sign-in/by-guest/lib/reauthenticate.ts` — `buildReauthUrl`(순수) + `reauthenticate`(내비게이션).
+- Create `src/features/sign-in/by-guest/lib/reauthenticate.test.ts`
+- Modify `src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.ts` — 분류기로 게이트, EXPIRED_MEMBER→reauthenticate.
+- Modify `src/app/parties/layout.tsx` — me 성공 시 `markMemberSession`.
+- Modify `src/features/sign-out/api/use-sign-out.mutation.ts` — onSettled에 `clearMemberSession`.
+
+---
+
+## Chunk 1: 핵심 단위 (격리)
+
+### Task 1: 회원 세션 이력 플래그 (`member-session`)
+
+**Files:** Create `src/entities/me/lib/member-session.ts`, `src/entities/me/lib/member-session.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성** — `member-session.test.ts`
+
+```ts
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import { markMemberSession, hadMemberSession, clearMemberSession } from './member-session';
+
+beforeEach(() => localStorage.clear());
+
+describe('member-session', () => {
+  test('비게스트(FM) me → 플래그 세팅', () => {
+    markMemberSession(AuthorityTier.FM);
+    expect(hadMemberSession()).toBe(true);
+  });
+  test('비게스트(AM) me → 플래그 세팅', () => {
+    markMemberSession(AuthorityTier.AM);
+    expect(hadMemberSession()).toBe(true);
+  });
+  test('게스트(GT) me → 세팅 안 함', () => {
+    markMemberSession(AuthorityTier.GT);
+    expect(hadMemberSession()).toBe(false);
+  });
+  test('clear → 제거', () => {
+    markMemberSession(AuthorityTier.FM);
+    clearMemberSession();
+    expect(hadMemberSession()).toBe(false);
+  });
+  test('기본값 false', () => {
+    expect(hadMemberSession()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `yarn vitest run src/entities/me/lib/member-session.test.ts` · Expected: FAIL (module not found).
+
+- [ ] **Step 3: 구현** — `member-session.ts`
+
+```ts
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+
+const KEY = 'pf_had_member_session';
+
+// SSR 가드: window 없으면 no-op/false.
+export function markMemberSession(authorityTier: AuthorityTier): void {
+  if (typeof window === 'undefined') return;
+  if (authorityTier === AuthorityTier.FM || authorityTier === AuthorityTier.AM) {
+    window.localStorage.setItem(KEY, '1');
+  }
+}
+
+export function hadMemberSession(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(KEY) === '1';
+}
+
+export function clearMemberSession(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(KEY);
+}
+```
+
+- [ ] **Step 4: 통과 확인** — Run: `yarn vitest run src/entities/me/lib/member-session.test.ts` · Expected: PASS.
+- [ ] **Step 5: 커밋** — `git add src/entities/me/lib/member-session.* && git commit -m "feat(auth): 회원 세션 이력 플래그 (#428)"`
+
+### Task 2: 순수 분류기 (`classifyAuthError`)
+
+**Files:** Create `src/features/sign-in/by-guest/lib/classify-auth-error.ts`, `.test.ts`
+
+- [ ] **Step 1: 실패 테스트**
+
+```ts
+import { AxiosError } from 'axios';
+import { classifyAuthError } from './classify-auth-error';
+
+const err401 = new AxiosError('e', undefined, undefined, undefined, { status: 401 } as never);
+const err500 = new AxiosError('e', undefined, undefined, undefined, { status: 500 } as never);
+
+describe('classifyAuthError', () => {
+  test('401 + 플래그 있음 → EXPIRED_MEMBER', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: 5, hadMemberSession: true })).toBe(
+      'EXPIRED_MEMBER'
+    );
+  });
+  test('401 + 플래그 없음 → VISITOR', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: 5, hadMemberSession: false })).toBe(
+      'VISITOR'
+    );
+  });
+  test('비401 → IGNORE', () => {
+    expect(classifyAuthError({ error: err500, partyroomId: 5, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+  test('partyroomId 없음 → IGNORE', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: null, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+  test('error 없음 → IGNORE', () => {
+    expect(classifyAuthError({ error: null, partyroomId: 5, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `yarn vitest run src/features/sign-in/by-guest/lib/classify-auth-error.test.ts` · Expected: FAIL.
+
+- [ ] **Step 3: 구현**
+
+```ts
+import isAuthError from '@/shared/api/http/error/is-auth-error';
+
+export type AuthErrorClass = 'IGNORE' | 'VISITOR' | 'EXPIRED_MEMBER';
+
+interface Input {
+  error: unknown;
+  partyroomId: number | null;
+  hadMemberSession: boolean;
+}
+
+export function classifyAuthError({ error, partyroomId, hadMemberSession }: Input): AuthErrorClass {
+  if (!error || !isAuthError(error) || !partyroomId) return 'IGNORE';
+  return hadMemberSession ? 'EXPIRED_MEMBER' : 'VISITOR';
+}
+```
+
+- [ ] **Step 4: 통과 확인** · Expected: PASS.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(auth): 파티룸 401 분류기 (#428)"`
+
+### Task 3: 재인증 지점 (`reauthenticate`)
+
+**Files:** Create `src/features/sign-in/by-guest/lib/reauthenticate.ts`, `.test.ts`
+
+- [ ] **Step 1: 실패 테스트** (순수 `buildReauthUrl`만 단위 테스트 — 내비게이션 부작용은 통합에서)
+
+```ts
+import { buildReauthUrl } from './reauthenticate';
+
+describe('buildReauthUrl', () => {
+  test('룸 pathname을 returnTo로 인코딩한 /sign-in URL', () => {
+    expect(buildReauthUrl('/parties/5')).toBe('/sign-in?returnTo=%2Fparties%2F5');
+  });
+  test('pathname만 받으므로 휘발성 쿼리(?source=link)는 애초에 포함 안 됨', () => {
+    // 호출처가 location.pathname(쿼리 제외)을 넘기는 계약을 문서화
+    expect(buildReauthUrl('/parties/5')).not.toContain('source');
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인** · Expected: FAIL.
+
+- [ ] **Step 3: 구현**
+
+```ts
+// returnTo 는 location.pathname(쿼리 제외)만 받는다 → ?source=link 등 휘발성 쿼리 자연 배제.
+export function buildReauthUrl(roomPathname: string): string {
+  return `/sign-in?returnTo=${encodeURIComponent(roomPathname)}`;
+}
+
+// 오늘(#1): 재로그인 페이지로 이동. 향후 refresh 도입 시 이 함수 맨 앞에
+// "조용히 refresh 시도 → 성공 시 무중단 / 실패 시 아래 이동" 단계를 삽입한다(단일 지점).
+export function reauthenticate(roomPathname: string): void {
+  if (typeof window === 'undefined') return;
+  window.location.href = buildReauthUrl(roomPathname);
+}
+```
+
+- [ ] **Step 4: 통과 확인** · Expected: PASS.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(auth): reauthenticate 지점(returnTo 보존) (#428)"`
+
+---
+
+## Chunk 2: 통합 (배선)
+
+### Task 4: `useAutoSignInByGuest` 게이트 + mark/clear 배선
+
+**Files:**
+
+- Modify `src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.ts`
+- Modify `src/app/parties/layout.tsx`
+- Modify `src/features/sign-out/api/use-sign-out.mutation.ts`
+- Test: `src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.test.ts` (없으면 생성)
+
+- [ ] **Step 1: 실패 테스트** — 만료-회원은 `signInGuest` 미호출 + reauth, 방문자는 signInGuest
+
+```ts
+const mockSignInGuest = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/shared/api/http/services', () => ({
+  usersService: { signInGuest: () => mockSignInGuest() },
+}));
+const mockReauth = vi.fn();
+vi.mock('./reauthenticate', () => ({ reauthenticate: (p: string) => mockReauth(p) }));
+vi.mock('@/entities/me/lib/member-session', () => ({ hadMemberSession: () => mockHadMember }));
+
+import { renderHook } from '@testing-library/react';
+import { AxiosError } from 'axios';
+// ... QueryClientProvider wrapper (기존 테스트 헬퍼 패턴 따름)
+let mockHadMember = false;
+const err401 = new AxiosError('e', undefined, undefined, undefined, { status: 401 } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHadMember = false;
+});
+
+test('만료-회원(플래그 O) 401 → reauthenticate, signInGuest 미호출', async () => {
+  mockHadMember = true;
+  renderHook(() => useAutoSignIn(err401, 5), { wrapper });
+  await waitFor(() => expect(mockReauth).toHaveBeenCalled());
+  expect(mockSignInGuest).not.toHaveBeenCalled();
+});
+
+test('방문자(플래그 X) 401 → signInGuest, reauth 미호출', async () => {
+  mockHadMember = false;
+  renderHook(() => useAutoSignIn(err401, 5), { wrapper });
+  await waitFor(() => expect(mockSignInGuest).toHaveBeenCalled());
+  expect(mockReauth).not.toHaveBeenCalled();
+});
+
+test('멱등성 — 재렌더해도 reauth 1회', async () => {
+  mockHadMember = true;
+  const { rerender } = renderHook(() => useAutoSignIn(err401, 5), { wrapper });
+  rerender();
+  rerender();
+  await waitFor(() => expect(mockReauth).toHaveBeenCalledTimes(1));
+});
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `yarn vitest run src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.test.ts` · Expected: FAIL.
+
+- [ ] **Step 3: 구현** — `use-auto-sign-in.hook.ts` 수정 (기존 `attempted` ref 유지, 분류기 게이트)
+
+```ts
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { usersService } from '@/shared/api/http/services';
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import { hadMemberSession } from '@/entities/me/lib/member-session';
+import { trackSignedIn } from '@/shared/lib/analytics/auth-tracking';
+import { classifyAuthError } from './classify-auth-error';
+import { reauthenticate } from './reauthenticate';
+
+export default function useAutoSignIn(error: unknown, partyroomId: number | null) {
+  const queryClient = useQueryClient();
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    const decision = classifyAuthError({
+      error,
+      partyroomId,
+      hadMemberSession: hadMemberSession(),
+    });
+    if (decision === 'IGNORE') return;
+
+    attempted.current = true;
+
+    if (decision === 'EXPIRED_MEMBER') {
+      reauthenticate(window.location.pathname); // returnTo = 룸 pathname(쿼리 제외)
+      return;
+    }
+
+    // VISITOR (기존 게스트 자동 로그인 — 링크-도메인 A 포함)
+    setIsSigningIn(true);
+    usersService
+      .signInGuest()
+      .then(() => {
+        trackSignedIn(AuthorityTier.GT);
+        return queryClient.refetchQueries({ queryKey: [QueryKeys.Me] });
+      })
+      .catch(() => {
+        location.href = '/';
+      })
+      .finally(() => setIsSigningIn(false));
+  }, [error, partyroomId, queryClient]);
+
+  return { isSigningIn };
+}
+```
+
+- [ ] **Step 4: `parties/layout.tsx`에 mark 배선** — 기존 `me` effect(`:31-38`) 옆에 추가
+
+```tsx
+import { markMemberSession } from '@/entities/me/lib/member-session';
+// ...
+useEffect(() => {
+  if (me) markMemberSession(me.authorityTier);
+}, [me]);
+```
+
+- [ ] **Step 5: `use-sign-out.mutation.ts`에 clear 배선** — `onSettled` 안, `setUserId(null)` 옆
+
+```ts
+import { clearMemberSession } from '@/entities/me/lib/member-session';
+// onSettled 내부:
+clearMemberSession();
+```
+
+- [ ] **Step 6: 통과 확인** — Run: `yarn vitest run src/features/sign-in/by-guest src/entities/me/lib` · Expected: PASS (신규 + 기존 회귀).
+- [ ] **Step 7: 타입체크/린트** — Run: `yarn tsc --noEmit && yarn lint` (또는 레포 스크립트) · Expected: 0 에러.
+- [ ] **Step 8: 커밋** — `git commit -m "feat(auth): 만료-회원 재로그인 라우팅 배선 (#428)"`
+
+---
+
+## 회귀/검증
+
+- 전체 유닛: `yarn vitest run` (또는 영향 범위) GREEN.
+- 불변식 회귀: 링크-도메인/방문자 401 → 여전히 게스트 로그인(VISITOR). 만료-회원 401 → reauth.
+- (머지 전, 사용자 게이트) 로컬 풀스택 + e2e: 회원 만료 시뮬레이션은 비용 큼 → 유닛/통합으로 충분 판단, 필요 시 수동 스모크.
+
+## 범위 밖 (별도 트랙)
+
+백엔드 refresh/슬라이딩 갱신(#306-①), WS inbound 만료검증(#306-②), web #402 재연결 tryEnter. `reauthenticate`가 향후 refresh 삽입 단일 지점.

--- a/docs/superpowers/specs/2026-06-19-expired-member-reauth-routing-design.md
+++ b/docs/superpowers/specs/2026-06-19-expired-member-reauth-routing-design.md
@@ -1,0 +1,109 @@
+# 만료-회원 재인증 라우팅 (Expired-Member Re-auth Routing)
+
+- 날짜: 2026-06-19
+- 범위: pfplay-web (프론트엔드)
+- 이슈: web #428 (본 작업) · 상위 platform #306 (토큰 만료 split-brain) · 가족 #304 / #303 / web #402
+- 상태: 설계 승인됨 (구현 전)
+
+## 1. 배경 / 문제
+
+유저 인증은 `SharedSessionToken` **24h 단일 세션 토큰**이며 **refresh·슬라이딩 갱신·refresh 엔드포인트가 없다**(백엔드 확인: `JwtCookieValidator`는 쿠키 부재/만료/무효를 전부 `Optional.empty()`로 뭉갠다). 프론트 HTTP 인터셉터에도 401 재발급/재시도가 없다.
+
+방 안에서 토큰이 만료되면 `useFetchMe`(GET `/users/me/info`)가 401을 받고, 현재 `useAutoSignInByGuest`가 **모든 401을 게스트 자동 로그인으로 처리**한다. 결과로 **로그인 회원이 조용히 게스트(GT)로 강등**되어 userId가 바뀐다(신원 불연속). 기존 crew/DJ row는 옛 userId에 묶여 있어, 이는 #304(비활성/불일치 크루 명령)·amplitude userId 불연속 계열의 상류 원인이 된다.
+
+핵심: 현재 프론트는 **"만료된 회원"과 "진짜 비로그인 방문자"를 구별하지 못한다**(백엔드가 구별 신호를 주지 않음).
+
+## 2. 목표 / 비목표
+
+**목표**
+
+- 방 안 회원 토큰 만료(상황 C) 시 게스트 강등 대신 **재로그인 유도**(회원 신원 보존).
+- **방문자(상황 A: 링크-도메인/딥링크 직접 진입)·게스트 만료(B)의 게스트 자동 로그인은 그대로 유지.**
+- 향후 refresh 토큰 도입 시 **무중단 자동 갱신으로 매끄럽게 확장될 단일 재인증 지점**을 깐다.
+
+**비목표 (별도 트랙)**
+
+- ① 백엔드 refresh/슬라이딩 갱신 (platform #306-①; admin `AdminTokenRenewalFilter` 패턴 이식).
+- ② WS inbound 만료 검증 ChannelInterceptor (platform #306-②; 핸드셰이크-1회 인증 split-brain).
+- web #402 재연결 시 `tryEnter` 재실행.
+- ③(본 스펙)은 이들의 **전제 인프라(분류 + 재인증 지점)**만 제공한다.
+
+## 3. 상황 분류 (불변식)
+
+| 상황                                            | 신원 이력   | 기대 동작                 |
+| ----------------------------------------------- | ----------- | ------------------------- |
+| A. 링크-도메인/딥링크 직접 진입 (무신원 방문자) | 없음        | 게스트 자동 로그인 (유지) |
+| B. 게스트(GT) 토큰 만료                         | 게스트뿐    | 게스트 재발급 (유지)      |
+| C. 로그인 회원(FM/AM) 토큰 만료                 | 회원 있었음 | **재로그인 유도 (신규)**  |
+
+## 4. 설계
+
+격리된 단위 3개로 구성한다.
+
+### 4.1 신원 기억 — `had-member-session`
+
+- 책임: "이 기기에서 비게스트(FM/AM)로 인증된 적이 있는가"를 기록.
+- 동작:
+  - `useFetchMe` 성공 + `me.authorityTier ∈ {FM, AM}` → localStorage `pf_had_member_session='1'` 세팅.
+  - `me.authorityTier === GT`(게스트) → 세팅하지 않음.
+  - 명시적 로그아웃(`useSignOut`) → 플래그 제거.
+- 인터페이스: `markMemberSession(authorityTier)`, `hadMemberSession(): boolean`, `clearMemberSession()`.
+- **호출 위치**: `markMemberSession`은 `useFetchMe` 성공을 소비하는 곳(예: `parties/layout.tsx`의 기존 `me` effect `:31-38` 옆 `useEffect`)에서 호출. **`use-fetch-me.query.ts`의 `queryFn`/모듈 레벨 `queryOptions`(`:24`)에는 넣지 않는다** — 캐시 레이어를 localStorage에 결합시키지 않기 위함. `clearMemberSession`은 `use-sign-out.mutation.ts`의 `onSettled`(`:8-15`, 이미 Amplitude `setUserId(null)` 정리하는 자리) 옆.
+- 선택 이유: boolean 플래그(PII 없음), localStorage라 **새로고침/하드 리로드에도 생존**(만료를 reload 후 알아채도 견고). react-query 캐시 메모리는 리로드에 소실되므로 부적합.
+
+### 4.2 분류·라우팅 chokepoint — `classifyAuthError`
+
+- 책임: 파티룸 컨텍스트의 401을 분류해 게스트/재인증으로 라우팅.
+- **통합 지점(정정)**: 실제 chokepoint은 `signInGuest()`의 **유일한 호출처인 `useAutoSignInByGuest`**(`use-auto-sign-in.hook.ts:25`, `parties/layout.tsx:20`에 1회 배선). 본 분류기는 그 훅을 **감싸거나 그 안에서 게이트**한다. (주의: `parties/layout.tsx:26`의 비파티룸 홈 리다이렉트와 `handle-bubbled-error.tsx:30-40`의 `/parties/<id>`·`/link/*` 리다이렉트 **억제 가드는 "중복 분기"가 아니라 보존 대상** — 이 가드들이 in-room에서 분류기가 돌도록 길을 열어준다. "일원화/중복 제거"가 아님.)
+- 입력: `{ error, isPartyroomRoute, partyroomId, hadMemberSession }`.
+- 규칙:
+  - `isAuthError(error)` 아님 → 무시(통과).
+  - 파티룸 컨텍스트 + 401:
+    - `hadMemberSession === true` → `EXPIRED_MEMBER` → `reauthenticate(returnTo)`.
+    - `hadMemberSession === false` → `VISITOR` → `signInGuest()` (기존 동작; 링크-도메인 A 포함).
+- **멱등성**: 기존 `attempted` 1회성 ref 가드(`use-auto-sign-in.hook.ts:16,21`)와 동등한 가드를 유지 — `EXPIRED_MEMBER`가 매 렌더마다 `reauthenticate`를 반복 발화하지 않게 한다.
+- 출력: 분류 결과(enum) — 라우팅은 호출처(layout/provider)가 수행하거나 훅이 캡슐화.
+
+### 4.3 재인증 지점 — `reauthenticate(returnTo)`
+
+- 책임: 만료-회원을 재인증으로 보냄. **향후 refresh 삽입의 유일한 지점.**
+- 오늘(#1): "세션이 만료되었습니다 · 다시 로그인" 안내(모달 또는 로그인 리다이렉트). **현재 룸 URL을 `returnTo`로 보존** → 재로그인 후 동일 방 복귀. **`returnTo`는 휘발성 쿼리(`?source=link` 등)를 제거하고 `/parties/<id>` 경로만 보존** — 재진입 시 일회성 사이드이펙트 재발화 방지.
+- in-room 내비게이션 소유: `reauthenticate`는 `/parties/<id>` 안에서 모달/리다이렉트를 수행한다. 이게 가능한 이유는 `handle-bubbled-error.tsx:32-36`이 그 경로의 전역 `/` 리다이렉트를 **억제**하기 때문 → **그 carve-out을 제거하지 말 것**.
+- 나중(refresh, 별도): 본 함수 맨 앞에 "조용히 refresh 시도 → 성공 시 무중단 지속(+WS 재연결·재입장) / 실패 시 위 안내로 폴백" 단계 삽입. 4.1·4.2는 변경 없이 재사용.
+
+## 5. 데이터 흐름
+
+```
+useFetchMe()
+  ├─ 성공 → markMemberSession(me.authorityTier)   // FM/AM만 플래그
+  └─ 401  → classifyAuthError({error, isPartyroomRoute, partyroomId, hadMemberSession()})
+              ├─ VISITOR         → signInGuest()        (기존)
+              └─ EXPIRED_MEMBER  → reauthenticate(returnTo=현재 룸 URL)
+useSignOut() → clearMemberSession()
+```
+
+분류기는 `signInGuest`의 유일 호출처인 `useAutoSignInByGuest`를 게이트한다(§4.2). `parties/layout.tsx:26`의 비파티룸 홈 리다이렉트와 `handle-bubbled-error.tsx`의 `/parties/<id>`·`/link/*` 억제 carve-out은 **보존**한다(병합·제거 아님) — 전자는 비파티룸 보호, 후자는 in-room 분류기/`reauthenticate` 실행을 가능케 하는 가드.
+
+## 6. 엣지 케이스
+
+- A 링크-도메인 직접 진입: 플래그 없음 → VISITOR → 게스트 로그인. **불변식 보존.**
+- B 게스트 만료: GT는 플래그 미세팅 → VISITOR → 재게스트.
+- 회원 로그아웃 후 재방문: 로그아웃이 플래그 제거 → VISITOR.
+- 회원 로그인 직후 만료(동일 세션): 플래그 존재 → EXPIRED_MEMBER. 정상.
+- 플래그 오탐 위험: localStorage는 origin·기기 단위. 재로그인 안내는 비파괴적(사용자가 선택 가능)이라 오탐 비용 낮음.
+- WS split-brain(#306-②)·재연결 재입장(#402)은 범위 밖. 단 재로그인으로 새 토큰 발급 시 WS 재연결이 정상화되어 간접 완화.
+
+## 7. 테스트 (TDD)
+
+- 신원 기억: 비게스트 me 성공→플래그 세팅 / 게스트 me→미세팅 / 로그아웃→제거 / reload 후 생존.
+- 분류기: (플래그 + 401)→EXPIRED_MEMBER, (무플래그 + 401)→VISITOR, (비401)→무시.
+- 통합: 만료-회원 401 → `signInGuest` 미호출 + reauth 발동 / 방문자 401 → `signInGuest` 발동 / 링크-도메인 경로 회귀.
+- 멱등성: 만료-회원 상태에서 여러 번 렌더돼도 `reauthenticate`는 **1회만** 발화(1회성 가드).
+- `returnTo`: `/parties/5?source=link`에서 만료-회원 401 → `returnTo`가 `?source=link` 제거된 `/parties/5`인지.
+
+## 8. 미해결 / 후속
+
+- `reauthenticate` UX 최종형(전역 모달 vs 로그인 페이지 리다이렉트 + returnTo) — 구현 시 기존 로그인 진입과 정합 맞춰 확정.
+- refresh 도입(#306-①) 시 `reauthenticate`에 자동 갱신 단계 삽입 + WS 재연결/`tryEnter`(#402) 연계.
+- 백엔드 401 사유 코드(만료 vs 부재) 노출(ii) 추가 시 분류 정밀화(현재는 프론트 신원 기억만으로 충분).
+- 참고: `me.authorityTier`를 읽는 다른 경로(`use-fetch-me-async.ts`, `use-is-guest.hook.tsx`)가 있으나, 회원을 게스트로 강등시키는 `signInGuest` 호출처는 `useAutoSignInByGuest` **1곳뿐**이라 분류기 게이트만으로 충분(정보성).

--- a/src/app/parties/layout.tsx
+++ b/src/app/parties/layout.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 import { PropsWithChildren, useEffect } from 'react';
 import { useFetchMe } from '@/entities/me';
+import { markMemberSession } from '@/entities/me/lib/member-session';
 import { GUEST_AUTO_LOGIN_ROUTE_PATTERN } from '@/entities/me/model/constants';
 import { usePartyroomEnterErrorAlerts } from '@/features/partyroom/enter';
 import { useAutoSignInByGuest } from '@/features/sign-in/by-guest';
@@ -29,6 +30,11 @@ const ProtectedLayout = ({ children }: PropsWithChildren) => {
   }, [error, isPartyroomRoute]);
 
   useEffect(() => {
+    // 비게스트(FM/AM) 세션 이력 기록 → 이후 토큰 만료(401) 시 만료-회원 vs 방문자 구별 (#428).
+    if (me) {
+      markMemberSession(me.authorityTier);
+    }
+
     /**
      * 로그인은 했지만 프로필을 아직 생성하지 않은 경우
      */

--- a/src/entities/me/lib/member-session.test.ts
+++ b/src/entities/me/lib/member-session.test.ts
@@ -1,0 +1,27 @@
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+import { markMemberSession, hadMemberSession, clearMemberSession } from './member-session';
+
+beforeEach(() => localStorage.clear());
+
+describe('member-session', () => {
+  test('비게스트(FM) me → 플래그 세팅', () => {
+    markMemberSession(AuthorityTier.FM);
+    expect(hadMemberSession()).toBe(true);
+  });
+  test('비게스트(AM) me → 플래그 세팅', () => {
+    markMemberSession(AuthorityTier.AM);
+    expect(hadMemberSession()).toBe(true);
+  });
+  test('게스트(GT) me → 세팅 안 함', () => {
+    markMemberSession(AuthorityTier.GT);
+    expect(hadMemberSession()).toBe(false);
+  });
+  test('clear → 제거', () => {
+    markMemberSession(AuthorityTier.FM);
+    clearMemberSession();
+    expect(hadMemberSession()).toBe(false);
+  });
+  test('기본값 false', () => {
+    expect(hadMemberSession()).toBe(false);
+  });
+});

--- a/src/entities/me/lib/member-session.ts
+++ b/src/entities/me/lib/member-session.ts
@@ -1,0 +1,25 @@
+import { AuthorityTier } from '@/shared/api/http/types/@enums';
+
+const KEY = 'pf_had_member_session';
+
+/**
+ * "이 기기에서 비게스트(FM/AM)로 인증된 적이 있는가"를 기록한다.
+ * 방 안 토큰 만료(401) 시 만료-회원 vs 진짜 방문자(링크-도메인 직접 진입 포함)를
+ * 구별하는 단서. localStorage라 새로고침/하드 리로드에도 생존한다. (#428, platform#306)
+ */
+export function markMemberSession(authorityTier: AuthorityTier): void {
+  if (typeof window === 'undefined') return;
+  if (authorityTier === AuthorityTier.FM || authorityTier === AuthorityTier.AM) {
+    window.localStorage.setItem(KEY, '1');
+  }
+}
+
+export function hadMemberSession(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(KEY) === '1';
+}
+
+export function clearMemberSession(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(KEY);
+}

--- a/src/features/sign-in/by-guest/lib/classify-auth-error.test.ts
+++ b/src/features/sign-in/by-guest/lib/classify-auth-error.test.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from 'axios';
+import { classifyAuthError } from './classify-auth-error';
+
+const err401 = new AxiosError('e', undefined, undefined, undefined, { status: 401 } as never);
+const err500 = new AxiosError('e', undefined, undefined, undefined, { status: 500 } as never);
+
+describe('classifyAuthError', () => {
+  test('401 + 플래그 있음 → EXPIRED_MEMBER', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: 5, hadMemberSession: true })).toBe(
+      'EXPIRED_MEMBER'
+    );
+  });
+  test('401 + 플래그 없음 → VISITOR', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: 5, hadMemberSession: false })).toBe(
+      'VISITOR'
+    );
+  });
+  test('비401 → IGNORE', () => {
+    expect(classifyAuthError({ error: err500, partyroomId: 5, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+  test('partyroomId 없음 → IGNORE', () => {
+    expect(classifyAuthError({ error: err401, partyroomId: null, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+  test('error 없음 → IGNORE', () => {
+    expect(classifyAuthError({ error: null, partyroomId: 5, hadMemberSession: true })).toBe(
+      'IGNORE'
+    );
+  });
+});

--- a/src/features/sign-in/by-guest/lib/classify-auth-error.ts
+++ b/src/features/sign-in/by-guest/lib/classify-auth-error.ts
@@ -1,0 +1,20 @@
+import isAuthError from '@/shared/api/http/error/is-auth-error';
+
+export type AuthErrorClass = 'IGNORE' | 'VISITOR' | 'EXPIRED_MEMBER';
+
+interface Input {
+  error: unknown;
+  partyroomId: number | null;
+  hadMemberSession: boolean;
+}
+
+/**
+ * 파티룸 컨텍스트의 401을 분류한다. (#428)
+ * - IGNORE: 비401 또는 파티룸 컨텍스트 아님.
+ * - EXPIRED_MEMBER: 비게스트 세션 이력 있음 → 재로그인 유도(reauthenticate).
+ * - VISITOR: 이력 없음 → 기존 게스트 자동 로그인(링크-도메인 직접 진입 포함).
+ */
+export function classifyAuthError({ error, partyroomId, hadMemberSession }: Input): AuthErrorClass {
+  if (!error || !isAuthError(error) || !partyroomId) return 'IGNORE';
+  return hadMemberSession ? 'EXPIRED_MEMBER' : 'VISITOR';
+}

--- a/src/features/sign-in/by-guest/lib/reauthenticate.test.ts
+++ b/src/features/sign-in/by-guest/lib/reauthenticate.test.ts
@@ -1,0 +1,10 @@
+import { buildReauthUrl } from './reauthenticate';
+
+describe('buildReauthUrl', () => {
+  test('룸 pathname을 returnTo로 인코딩한 /sign-in URL', () => {
+    expect(buildReauthUrl('/parties/5')).toBe('/sign-in?returnTo=%2Fparties%2F5');
+  });
+  test('pathname만 받으므로 휘발성 쿼리(?source=link)는 포함되지 않는다', () => {
+    expect(buildReauthUrl('/parties/5')).not.toContain('source');
+  });
+});

--- a/src/features/sign-in/by-guest/lib/reauthenticate.ts
+++ b/src/features/sign-in/by-guest/lib/reauthenticate.ts
@@ -1,0 +1,14 @@
+// returnTo 는 location.pathname(쿼리 제외)만 받는다 → ?source=link 등 휘발성 쿼리 자연 배제.
+export function buildReauthUrl(roomPathname: string): string {
+  return `/sign-in?returnTo=${encodeURIComponent(roomPathname)}`;
+}
+
+/**
+ * 만료-회원을 재인증으로 보낸다. 향후 refresh 토큰 도입 시 이 함수 맨 앞에
+ * "조용히 refresh 시도 → 성공 시 무중단 지속 / 실패 시 아래 이동"을 삽입하는
+ * 단일 지점이다. (#428, platform#306)
+ */
+export function reauthenticate(roomPathname: string): void {
+  if (typeof window === 'undefined') return;
+  window.location.href = buildReauthUrl(roomPathname);
+}

--- a/src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.test.ts
+++ b/src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.test.ts
@@ -1,0 +1,61 @@
+const mockRefetch = vi.fn().mockResolvedValue(undefined);
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ refetchQueries: mockRefetch }),
+}));
+
+const mockSignInGuest = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/shared/api/http/services', () => ({
+  usersService: { signInGuest: () => mockSignInGuest() },
+}));
+
+const mockReauth = vi.fn();
+vi.mock('./reauthenticate', () => ({ reauthenticate: (p: string) => mockReauth(p) }));
+
+let mockHadMember = false;
+vi.mock('@/entities/me/lib/member-session', () => ({
+  hadMemberSession: () => mockHadMember,
+}));
+
+vi.mock('@/shared/lib/analytics/auth-tracking', () => ({ trackSignedIn: vi.fn() }));
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import useAutoSignIn from './use-auto-sign-in.hook';
+
+const err401 = new AxiosError('e', undefined, undefined, undefined, { status: 401 } as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHadMember = false;
+});
+
+describe('useAutoSignIn (만료-회원 라우팅)', () => {
+  test('만료-회원(플래그 O) 401 → reauthenticate, signInGuest 미호출', async () => {
+    mockHadMember = true;
+    renderHook(() => useAutoSignIn(err401, 5));
+    await waitFor(() => expect(mockReauth).toHaveBeenCalled());
+    expect(mockSignInGuest).not.toHaveBeenCalled();
+  });
+
+  test('방문자(플래그 X) 401 → signInGuest, reauthenticate 미호출', async () => {
+    mockHadMember = false;
+    renderHook(() => useAutoSignIn(err401, 5));
+    await waitFor(() => expect(mockSignInGuest).toHaveBeenCalled());
+    expect(mockReauth).not.toHaveBeenCalled();
+  });
+
+  test('멱등성 — 재렌더해도 reauthenticate 1회', async () => {
+    mockHadMember = true;
+    const { rerender } = renderHook(() => useAutoSignIn(err401, 5));
+    rerender();
+    rerender();
+    await waitFor(() => expect(mockReauth).toHaveBeenCalledTimes(1));
+  });
+
+  test('비파티룸(partyroomId null) → 아무 것도 안 함', () => {
+    mockHadMember = true;
+    renderHook(() => useAutoSignIn(err401, null));
+    expect(mockReauth).not.toHaveBeenCalled();
+    expect(mockSignInGuest).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.ts
+++ b/src/features/sign-in/by-guest/lib/use-auto-sign-in.hook.ts
@@ -1,14 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import isAuthError from '@/shared/api/http/error/is-auth-error';
+import { hadMemberSession } from '@/entities/me/lib/member-session';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import { usersService } from '@/shared/api/http/services';
 import { AuthorityTier } from '@/shared/api/http/types/@enums';
 import { trackSignedIn } from '@/shared/lib/analytics/auth-tracking';
+import { classifyAuthError } from './classify-auth-error';
+import { reauthenticate } from './reauthenticate';
 
 /**
- * 비로그인 상태에서 파티룸 직접 접속 시 guest 자동 로그인 수행
- * POST /v1/users/guests/sign 호출로 게스트 세션 생성
+ * 파티룸 컨텍스트의 401을 분류해 라우팅한다. (#428, platform#306)
+ * - VISITOR(비로그인 방문자·링크-도메인 직접 진입): 게스트 자동 로그인.
+ * - EXPIRED_MEMBER(만료된 회원): 게스트 강등 대신 재로그인 유도(reauthenticate).
  */
 export default function useAutoSignIn(error: unknown, partyroomId: number | null) {
   const queryClient = useQueryClient();
@@ -16,11 +19,25 @@ export default function useAutoSignIn(error: unknown, partyroomId: number | null
   const attempted = useRef(false);
 
   useEffect(() => {
-    if (!error || !isAuthError(error) || !partyroomId || attempted.current) return;
+    if (attempted.current) return;
+
+    const decision = classifyAuthError({
+      error,
+      partyroomId,
+      hadMemberSession: hadMemberSession(),
+    });
+    if (decision === 'IGNORE') return;
 
     attempted.current = true;
-    setIsSigningIn(true);
 
+    if (decision === 'EXPIRED_MEMBER') {
+      // returnTo = 룸 pathname(쿼리 제외). 향후 refresh 는 reauthenticate 내부에서 흡수.
+      reauthenticate(window.location.pathname);
+      return;
+    }
+
+    // VISITOR — 기존 게스트 자동 로그인 (링크-도메인 직접 진입 포함)
+    setIsSigningIn(true);
     usersService
       .signInGuest()
       .then(() => {

--- a/src/features/sign-out/api/use-sign-out.mutation.ts
+++ b/src/features/sign-out/api/use-sign-out.mutation.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { clearMemberSession } from '@/entities/me/lib/member-session';
 import { usersService } from '@/shared/api/http/services';
 import { setUserId } from '@/shared/lib/analytics';
 
@@ -9,6 +10,8 @@ export default function useSignOut() {
       // Detach the Amplitude user_id; deviceId persists so the next anonymous
       // visit remains continuous, and a fresh login will re-attach a new user.
       setUserId(null);
+      // 회원 세션 이력 플래그 제거 → 로그아웃 후 방문은 방문자(게스트)로 분류 (#428).
+      clearMemberSession();
       // 파티룸 클라이언트 정리는 레이아웃 언마운트(teardown)가 수행하며,
       // 서버 세션 만료는 비자발적 이탈로서 presence grace window가 처리한다.
       location.href = '/';


### PR DESCRIPTION
## 무엇을 / 왜
방 안에서 로그인 회원의 24h 세션 토큰이 만료되면, 현재 `useAutoSignInByGuest`가 모든 401을 게스트 자동 로그인으로 처리해 **회원이 조용히 게스트로 강등**(userId 불연속)됐다. 만료-회원 vs 진짜 방문자를 구별해 **회원은 재로그인 유도**(신원 보존), 방문자(링크-도메인 직접 진입 포함)·게스트만료는 게스트 경로를 유지한다.

= platform #306(토큰 만료 split-brain) 프론트 piece. 향후 refresh 도입의 **단일 재인증 지점** 마련.

## 설계/계획
- 스펙: `docs/superpowers/specs/2026-06-19-expired-member-reauth-routing-design.md`
- 계획: `docs/superpowers/plans/2026-06-19-expired-member-reauth-routing.md`

## 구성 (격리 단위 3 + 배선)
- `member-session.ts`: 비게스트(FM/AM) me 성공 시 localStorage 플래그(새로고침 생존), 로그아웃 시 제거.
- `classify-auth-error.ts`: 파티룸 401 → IGNORE/VISITOR/EXPIRED_MEMBER.
- `reauthenticate.ts`: `buildReauthUrl`(returnTo=룸 pathname, 휘발성 쿼리 자연 배제) + 내비게이션. **향후 refresh 삽입 단일 지점.**
- 배선: `useAutoSignInByGuest`(signInGuest 유일 호출처)를 분류기로 게이트 + `attempted` ref 멱등 / mark=`parties/layout` / clear=`use-sign-out` onSettled.

## 불변식 보존
- 링크-도메인/딥링크 직접 진입(무신원 방문자) → 게스트 자동 로그인 유지.
- 게스트 토큰 만료 → 게스트 재발급 유지.

## 검증
- 단위/통합 16 GREEN(member-session·classify·reauth·hook), **전체 회귀 295파일/1602 tests GREEN**, `tsc --noEmit` 0, eslint 0.

## 범위 밖 (별도 트랙)
백엔드 refresh/슬라이딩 갱신(#306-①), WS inbound 만료검증(#306-②), web #402 재연결 tryEnter.

관련: platform #306 · #304 · web #402