### PR TITLE
fix(partyroom): WS 재연결 멤버십 resync — 감지-후-분기 (#402)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-ws-reconnect-resync.md
+++ b/docs/superpowers/plans/2026-06-19-ws-reconnect-resync.md
@@ -1,0 +1,245 @@
+# WS 재연결 멤버십 resync Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** WS 재연결 시 멤버십을 재확립하고(CRW-001 차단), 멤버십이 실제 끊긴 경우만 상태를 재수화하여 흔한 블립에서 플레이어 remount를 피한다.
+
+**Architecture:** 백엔드 `tryEnter`가 이미 계산하는 "재활성 여부"를 응답 `reactivated`로 노출. 프론트는 재연결(첫 연결 skip)마다 `tryEnter` 호출 후 `reactivated`로 분기 — true면 풀 재수화, false면 경량(DJ큐 invalidate만).
+
+**Tech Stack:** platform(Spring/JUnit), web(Next.js/TanStack Query/Vitest). 스펙: `docs/superpowers/specs/2026-06-19-ws-reconnect-resync-design.md`.
+
+---
+
+## 파일 구조
+
+**platform**
+
+- Modify `app/.../party/application/service/PartyroomAccessCommandService.java` — `tryEnter` 반환을 `TryEnterResult(crew, reactivated)`로; 내부 `record TryEnterResult` 추가.
+- Modify `app/.../party/adapter/in/web/PartyroomAccessCommandController.java` — `EnterPartyroomResponse.from(result.crew(), result.reactivated())`.
+- Modify `app/.../party/adapter/in/web/payload/response/access/EnterPartyroomResponse.java` — `reactivated` 필드 + 오버로드.
+- Modify `app/.../virtualdj/application/service/VirtualDjOrchestratorImpl.java` — 반환 무시라 무변경(컴파일만 확인).
+- Test `app/.../party/application/service/PartyroomAccessCommandServiceTest.java` (또는 기존 IT).
+
+**web**
+
+- Modify `src/shared/api/http/types/partyrooms.ts` — `EnterResponse`에 `reactivated: boolean`.
+- Modify `src/features/partyroom/enter/lib/use-enter-partyroom.ts` — 비-once resync 핸들러 + `firstConnect` useRef.
+- Test `src/features/partyroom/enter/lib/use-enter-partyroom.test.ts` (기존 확장).
+
+---
+
+## Chunk 1: platform — `reactivated` 신호
+
+### Task 1: `tryEnter`가 reactivated 반환
+
+**Files:** Modify `PartyroomAccessCommandService.java`, `PartyroomAccessCommandController.java`, `EnterPartyroomResponse.java`; Test `PartyroomAccessCommandServiceTest.java`
+
+- [ ] **Step 1: 실패 테스트** — 재활성 vs 유지 구분 (기존 테스트 하니스 패턴 따름; mock aggregatePort)
+
+```java
+@Test
+@DisplayName("tryEnter — 이미 active(같은 룸 재입장)면 reactivated=false")
+void tryEnterAlreadyActiveReactivatedFalse() {
+    // given: 활성 crew 존재, autoExit helper가 같은 룸 active 반환하도록 셋업
+    // (기존 PartyroomAccessCommandServiceTest 의 active-crew 셋업 패턴 재사용)
+    // when
+    var result = accessCommandService.tryEnter(partyroomId, countryCode);
+    // then
+    assertThat(result.reactivated()).isFalse();
+}
+
+@Test
+@DisplayName("tryEnter — inactive crew 재활성이면 reactivated=true")
+void tryEnterReactivatedTrue() {
+    // given: inactive crew, activateCrew toggle 1 반환(transitioned=true)
+    // when / then
+    assertThat(accessCommandService.tryEnter(partyroomId, countryCode).reactivated()).isTrue();
+}
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `JAVA_HOME="C:/Users/Eisen/.jdks/ms-21.0.7" ./gradlew :app:test --tests "*PartyroomAccessCommandServiceTest"` · Expected: 컴파일 실패(메서드 시그니처) 또는 FAIL.
+
+- [ ] **Step 3: 구현**
+
+  - `tryEnter` 반환 타입 `CrewData` → `TryEnterResult`:
+    - 같은-룸 재입장 분기(L112): `return new TryEnterResult(saved, false);`
+    - 말미(L129): `return new TryEnterResult(result.crew(), result.transitioned());`
+  - 클래스 내부에 record 추가:
+    ```java
+    /** reactivated=true 는 신규 INSERT(최초 입장)에도 true. 재연결 소비자에게만 유의미(재연결은 INSERT 안 함). */
+    public record TryEnterResult(CrewData crew, boolean reactivated) {}
+    ```
+  - `EnterPartyroomResponse`:
+    ```java
+    private long crewId;
+    private GradeType gradeType;
+    private boolean reactivated;
+    public static EnterPartyroomResponse from(CrewData crew, boolean reactivated) {
+        return new EnterPartyroomResponse(crew.getId(), crew.getGradeType(), reactivated);
+    }
+    ```
+  - 컨트롤러 L44-45:
+    ```java
+    var result = partyroomAccessCommandService.tryEnter(new PartyroomId(partyroomId), countryCode);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiCommonResponse.success(EnterPartyroomResponse.from(result.crew(), result.reactivated())));
+    ```
+  - 봇 `VirtualDjOrchestratorImpl:149`: `accessCommandService.tryEnter(partyroomId, null);` 그대로(반환 무시) — 컴파일 OK.
+
+- [ ] **Step 4: 통과 확인** — Run: `… :app:test --tests "*PartyroomAccessCommandServiceTest"` · Expected: PASS.
+- [ ] **Step 5: 회귀** — Run: `… :app:test` · Expected: 풀 GREEN(특히 컨트롤러/봇 경로).
+- [ ] **Step 6: 커밋** — `git commit -m "feat(party): tryEnter 응답에 reactivated 노출 (web#402 신호)"`
+
+---
+
+## Chunk 2: web — 재연결 resync 핸들러
+
+### Task 2: `EnterResponse`에 reactivated
+
+**Files:** Modify `src/shared/api/http/types/partyrooms.ts`
+
+- [ ] **Step 1: 구현** (타입 추가, 별도 테스트 불필요 — 타입체크가 게이트)
+
+```ts
+export type EnterResponse = {
+  crewId: number;
+  gradeType: GradeType;
+  reactivated: boolean;
+};
+```
+
+- [ ] **Step 2: 커밋** — `git commit -m "types(partyroom): EnterResponse.reactivated (#402)"`
+
+### Task 3: 재연결 resync 핸들러
+
+**Files:** Modify `src/features/partyroom/enter/lib/use-enter-partyroom.ts`; Test `…/use-enter-partyroom.test.ts`
+
+- [ ] **Step 1: 실패 테스트** (기존 하니스 확장 — `mockOnConnect`/`mockMutate`/`mockInvalidateQueries`/`mockPush` + `partyroomsService` 목)
+
+```ts
+// 추가 목: partyroomsService.getSetupInfo/getNotice
+vi.mock('@/shared/api/http/services', () => ({
+  partyroomsService: { getSetupInfo: vi.fn(), getNotice: vi.fn() },
+}));
+// ... 기존 beforeEach 유지 (getSetupInfo는 never-resolve 기본; 호출 여부만 단언)
+
+test('resync 핸들러를 비-once 로 등록한다', () => {
+  const { result } = renderHook(() => useEnterPartyroom(1));
+  act(() => result.current());
+  // 0번째 = once enter, 1번째 = resync(non-once)
+  expect(mockOnConnect).toHaveBeenNthCalledWith(2, expect.any(Function), undefined);
+});
+
+test('resync — 첫 연결은 skip (mutate 미호출)', () => {
+  const { result } = renderHook(() => useEnterPartyroom(7));
+  act(() => result.current());
+  const resync = mockOnConnect.mock.calls[1][0];
+  resync(); // 첫 발화 = firstConnect skip
+  expect(mockMutate).not.toHaveBeenCalled();
+});
+
+test('resync — 재연결 시 enter(tryEnter) 호출', () => {
+  const { result } = renderHook(() => useEnterPartyroom(7));
+  act(() => result.current());
+  const resync = mockOnConnect.mock.calls[1][0];
+  resync(); // 첫 = skip
+  resync(); // 재연결
+  expect(mockMutate).toHaveBeenCalledWith(
+    expect.objectContaining({ partyroomId: 7 }),
+    expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+  );
+});
+
+test('resync — reactivated=false → setup 미호출, DJ큐 invalidate', () => {
+  const { result } = renderHook(() => useEnterPartyroom(7));
+  act(() => result.current());
+  const resync = mockOnConnect.mock.calls[1][0];
+  resync();
+  resync();
+  const onSuccess = mockMutate.mock.calls[0][1].onSuccess;
+  onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: false });
+  expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.DjingQueue, 7] });
+});
+
+test('resync — reactivated=true → setup 호출(재수화)', () => {
+  (partyroomsService.getSetupInfo as Mock).mockReturnValue(new Promise(() => {}));
+  (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
+  const { result } = renderHook(() => useEnterPartyroom(7));
+  act(() => result.current());
+  const resync = mockOnConnect.mock.calls[1][0];
+  resync();
+  resync();
+  mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: true });
+  expect(partyroomsService.getSetupInfo).toHaveBeenCalled();
+});
+
+test('resync — enter onError → 로비', () => {
+  const { result } = renderHook(() => useEnterPartyroom(7));
+  act(() => result.current());
+  const resync = mockOnConnect.mock.calls[1][0];
+  resync();
+  resync();
+  mockMutate.mock.calls[0][1].onError();
+  expect(mockPush).toHaveBeenCalledWith('/parties');
+});
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `npx vitest run src/features/partyroom/enter/lib/use-enter-partyroom.test.ts` · Expected: FAIL(resync 미구현).
+
+- [ ] **Step 3: 구현** — `use-enter-partyroom.ts`: hook 스코프에 `const firstConnect = useRef(true);` 추가, 반환 함수에 resync 등록
+
+```ts
+return () => {
+  client.onConnect(
+    /* 기존 once enter 그대로 */ () => {
+      /* ... enter+setup ... */
+    },
+    { once: true }
+  );
+
+  // 재연결 resync (비-once). firstConnect ref 로 첫 연결 skip(이중 tryEnter 방지).
+  client.onConnect(() => {
+    if (firstConnect.current) {
+      firstConnect.current = false;
+      return;
+    }
+    enter(
+      { partyroomId },
+      {
+        onSuccess: (enterResponse) => {
+          const invalidateDjQueue = () =>
+            queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
+          if (enterResponse.reactivated) {
+            // 멤버십 상실 → 풀 재수화. 룸 재구독은 추가하지 않음(handleConnect가 이미 reconcile).
+            silent(setup(enterResponse), {
+              onSuccess: invalidateDjQueue,
+              onError: () => router.push('/parties'),
+            });
+          } else {
+            // 멤버십 유지 → 경량(플레이어/구독 무영향)
+            invalidateDjQueue();
+          }
+        },
+        onError: () => router.push('/parties'),
+      }
+    );
+  });
+};
+```
+
+- [ ] **Step 4: 통과 확인** — Run: `npx vitest run src/features/partyroom/enter/lib/use-enter-partyroom.test.ts` · Expected: PASS.
+- [ ] **Step 5: 타입체크** — Run: `yarn test:type` · Expected: 0 에러.
+- [ ] **Step 6: 커밋** — `git commit -m "fix(partyroom): WS 재연결 멤버십 resync — 감지-후-분기 (#402)"`
+
+---
+
+## 회귀/검증
+
+- web: `yarn test`(전체) GREEN — 특히 enter 흐름·room layout 회귀.
+- platform: `:app:test` 풀 GREEN.
+- (머지 전, 게이트) 로컬 풀스택 + 수동 스모크: 백그라운드 탭 1분 방치→복귀(소프트 재연결) 시 (a) 액션 정상(CRW-001 없음) (b) 짧은 블립에선 플레이어 무중단.
+
+## 범위 밖
+
+백엔드 refresh(#306-①), WS inbound 만료검증(#306-②). 경량 경로 playback staleness가 가시적이면 selective merge 후속.

--- a/docs/superpowers/specs/2026-06-19-ws-reconnect-resync-design.md
+++ b/docs/superpowers/specs/2026-06-19-ws-reconnect-resync-design.md
@@ -1,0 +1,98 @@
+# WS 재연결 멤버십 resync (감지-후-분기)
+
+- 날짜: 2026-06-19
+- 범위: pfplay-web (주) + pfplay-platform (응답 신호 1필드)
+- 이슈: web #402 · 상위 platform #306(토큰/멤버십) · 가족 #304 / #303 / web #428(③)
+- 상태: 설계 승인됨 (구현 전)
+
+## 1. 배경 / 문제
+
+WS 소프트 재연결(백그라운드 탭 복귀, 네트워크 블립) 시 `handleConnect`(매 연결)는 구독을 reconcile하고 비-`once` onConnect 콜백을 재실행하지만, **룸 입장 로직 `enter`가 `{ once: true }`로 등록**돼(`use-enter-partyroom.ts:97`) 재연결 시 재실행되지 않는다. `enter`가 하던 두 가지가 누락된다:
+
+1. `tryEnter`(백엔드 crew 멤버십 재활성) → presence grace가 만료된 동안 백엔드가 exit시킨 경우 **멤버십 미복구** → 룸 액션이 `CRW-001`/`No value present`로 실패(#303·#304·③의 상류).
+2. `setup`(setupInfo·notice fetch → `initPartyroom` 스토어 재수화) → **디스플레이 검정**(상태 stale).
+
+= [[reference_ws_reconnect_no_state_resync]] / web #402. 이 갭이 stale-멤버십 클래스의 **공통 상류 트리거**.
+
+## 2. 목표 / 비목표
+
+**목표**
+
+- 재연결 시 멤버십을 재확립해 `CRW-001` 버스트·stale 멤버십을 제거.
+- 멤버십이 실제 끊긴(grace 만료) 경우 디스플레이/상태를 복구(검정 해소).
+- **흔한 짧은 블립(멤버십 유지)에서 YouTube 플레이어 remount를 유발하지 않는다** (#426 iOS 자동재생 끊김 계열 회귀 방지).
+
+**비목표**
+
+- 백엔드 refresh/슬라이딩 갱신(#306-①), WS inbound 만료검증(#306-②)은 별도.
+
+## 3. 핵심 통찰
+
+- `handleDisconnect`는 **live STOMP 핸들만 teardown**하고 `subscriptions[]`·zustand 스토어는 **보존**한다(`client.ts:69-77,193-198`). 따라서 짧은 블립(멤버십 유지)에선 스토어/플레이어가 살아있어 추가 재수화가 불필요하다.
+- **디스플레이 검정은 멤버십 상실(긴 단절)과 동행**한다 → "재수화가 필요한 경우"와 "멤버십이 끊긴 경우"가 일치 → 멤버십 상실 신호로 분기하면 두 증상을 함께 해결하면서 remount를 최소화할 수 있다.
+- 백엔드 `tryEnter`는 이미 분기를 계산한다: 같은-룸 재입장(이미 active, countryCode만 갱신) vs `ensureCrewActive`의 `transitioned`(inactive→active 재활성). **이 신호를 응답에 노출**하면 프론트가 분기 가능.
+
+## 4. 설계 — 감지-후-분기 (Approach C)
+
+### 4.1 platform — enter 응답에 `reactivated: boolean`
+
+- `tryEnter`의 반환을 `CrewData` → 작은 결과 타입 `TryEnterResult(CrewData crew, boolean reactivated)`로 변경.
+  - 같은-룸 재입장 분기(`PartyroomAccessCommandService:87-113`) → `reactivated=false`.
+  - `ensureCrewActive` 경로 → `reactivated = result.transitioned`(기존 inactive→active 또는 신규 INSERT는 true; 이미 active/raceLoser는 false).
+  - ⚠️ `transitioned=true`는 **신규 INSERT(최초 입장)에도** true다. 무해함: web resync는 **재연결에서만** 동작(첫 연결 skip)하고 그땐 crew row가 이미 존재해 INSERT 분기에 안 닿는다. 첫 연결 `once` enter는 `reactivated`를 무시한다. → `TryEnterResult`에 "reactivated=true는 신규 INSERT 포함; 재연결 소비자에게만 유의미(재연결은 INSERT 안 함)" 주석.
+- 호출처 2곳: 컨트롤러(`PartyroomAccessCommandController:44`)는 `EnterPartyroomResponse.from(crew, reactivated)`로 매핑; 봇(`VirtualDjOrchestratorImpl:149`)은 반환 무시(필드 미사용).
+- `EnterPartyroomResponse` + web `EnterResponse` 타입에 `reactivated` 추가. **이벤트/도메인 로직 무변경 — 신호 노출만.**
+
+### 4.2 web — 재연결 resync 핸들러
+
+- `use-enter-partyroom.ts`에 **비-`once` onConnect "resync" 핸들러** 추가. **첫 연결 skip 가드는 훅 인스턴스 스코프 `useRef`**(`firstConnect`)로 둬 연결 간 보존 — 콜백 로컬 변수 금지(매 연결 리셋되면 무의미). enter 함수는 `useDidMountEffect`로 마운트당 1회만 호출되므로 핸들러 중복 등록 없음. (가드 필수 이유: 등록 시점에 소켓 미연결이라 `once` enter와 resync가 같은 큐에 들어가 **첫 `handleConnect`에서 둘 다 발화 → 첫 연결 이중 tryEnter** 위험.)
+- 재연결 동작:
+  1. `enter({ partyroomId })`(tryEnter) 호출 — 멱등, 멤버십 재확립(CRW-001 차단).
+  2. 응답 `reactivated`로 분기:
+     - **`true`(멤버십 상실 → 재활성)**: `setup(enterResponse)` 풀 재수화(initPartyroom) + DJ큐 invalidate. 검정 해소. 드문 케이스라 플레이어 remount 허용. **룸 재구독은 추가하지 않는다** — `handleConnect`가 onConnect 큐 _이전에_ `subscriptions[]`를 이미 reconcile(재구독)하므로, 여기서 `client.subscribe`를 다시 부르면 동일 destination 중복 핸들이 생긴다(client 계약 위반).
+     - **`false`(멤버십 유지)**: **경량** — `initPartyroom`/플레이어/구독 미접촉. DJ큐만 invalidate(블립 중 놓친 큐 변경 보정). playback/crews zustand는 직후 live 이벤트가 보정(짧은 블립이라 누락 최소, self-heal).
+  3. `enter` onError(tryEnter 실패 = 룸 닫힘/penalty/멤버십 영구 상실) → 로비(`/parties`). **의식적 결정**: `reactivated=true` 재수화의 `setup` 실패도 첫-입장과 동일하게 로비로 보낸다 — reactivated는 "이미 룸 밖이었음"을 뜻하므로 재입장 실패=로비가 일관. (이미 들어와 있던 유저를 화면만 깜빡하다 로비로 보내는 케이스는 아님.)
+
+### 4.3 #426 회귀 방어
+
+경량 경로가 `initPartyroom`·플레이어를 안 건드리므로 흔한 짧은 블립에서 remount 0. 풀 재수화는 멤버십이 실제 끊긴(사실상 재입장) 드문 경우만 → 그땐 remount 수용 가능.
+
+## 5. 데이터 흐름
+
+```
+handleConnect (매 연결)
+  ├─ 구독 reconcile (룸 sub 재구독 — 이벤트 스트림 복구)  [기존]
+  ├─ once enter (첫 연결만)                              [기존]
+  └─ resync (비-once, firstConnect 이후만):
+        enter(tryEnter) →
+          reactivated=true  → setup() 풀 재수화 (검정 해소)
+          reactivated=false → 경량 (DJ큐 invalidate, 플레이어 무영향)
+        onError → /parties
+```
+
+## 6. 엣지 케이스
+
+- 첫 연결: resync는 `firstConnect` ref로 skip → once enter만(중복 tryEnter 없음).
+- 멤버십 유지 + 블립 중 트랙 전환 발생: 경량 경로는 즉시 재수화 안 함 → 다음 live playback 이벤트가 보정(수 초 내). 가시적 staleness가 문제되면 후속으로 "playback만 선택 머지"(remount 없이) 검토.
+- 멤버십 영구 상실(룸 종료/추방): tryEnter throw → 로비.
+- 동시성: tryEnter는 멱등(`ensureCrewActive` race 처리 기존 보장).
+
+## 7. 테스트
+
+**platform (IT/unit)**
+
+- 같은-룸 재입장(이미 active) → `reactivated=false`.
+- inactive crew 후 tryEnter → `reactivated=true`.
+- 봇 경로 회귀(반환 무시).
+
+**web (vitest)**
+
+- 재연결 + `reactivated=false` → `setup`/`initPartyroom` **미호출**(플레이어 무영향), DJ큐 invalidate 호출.
+- 재연결 + `reactivated=true` → `setup` 호출(재수화).
+- 첫 연결 → resync skip(enter 1회만, 중복 tryEnter 없음).
+- `enter` onError → `/parties`.
+
+## 8. 미해결 / 후속
+
+- 경량 경로의 playback staleness가 실제로 가시적이면 "selective playback merge"(remount 없는 부분 갱신) 후속.
+- #306-①(refresh) 도입 시 재인증→재연결 흐름과 resync 연계.

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -9,6 +9,9 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
     useQueryClient: vi.fn(),
   };
 });
+vi.mock('@/shared/api/http/services', () => ({
+  partyroomsService: { getSetupInfo: vi.fn(), getNotice: vi.fn() },
+}));
 
 import { useQueryClient } from '@tanstack/react-query';
 import { renderHook, act } from '@testing-library/react';
@@ -16,6 +19,8 @@ import {
   usePartyroomClient,
   useHandlePartyroomSubscriptionEvent,
 } from '@/entities/partyroom-client';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { partyroomsService } from '@/shared/api/http/services';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { useEnterPartyroom } from './use-enter-partyroom';
@@ -108,5 +113,63 @@ describe('useEnterPartyroom', () => {
       expect.objectContaining({ partyroomId: 7 }),
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
     );
+  });
+});
+
+describe('useEnterPartyroom resync (#402)', () => {
+  // calls[0] = once enter, calls[1] = resync(non-once)
+  const registerAndGetResync = (partyroomId: number) => {
+    const { result } = renderHook(() => useEnterPartyroom(partyroomId));
+    act(() => result.current());
+    return mockOnConnect.mock.calls[1][0] as () => void;
+  };
+
+  test('resync 핸들러를 비-once 로 등록한다 (2번째 onConnect, options 없음)', () => {
+    const { result } = renderHook(() => useEnterPartyroom(1));
+    act(() => result.current());
+    expect(mockOnConnect).toHaveBeenNthCalledWith(2, expect.any(Function));
+  });
+
+  test('첫 연결은 skip — mutate 미호출', () => {
+    const resync = registerAndGetResync(7);
+    resync(); // 첫 발화 = firstConnect skip
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test('재연결 시 enter(tryEnter) 호출', () => {
+    const resync = registerAndGetResync(7);
+    resync(); // skip
+    resync(); // 재연결
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ partyroomId: 7 }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    );
+  });
+
+  test('reactivated=false → setup 미호출, DJ큐 invalidate', () => {
+    const resync = registerAndGetResync(7);
+    resync();
+    resync();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: false });
+    expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.DjingQueue, 7] });
+  });
+
+  test('reactivated=true → setup(재수화) 호출', () => {
+    (partyroomsService.getSetupInfo as Mock).mockReturnValue(new Promise(() => {}));
+    (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
+    const resync = registerAndGetResync(7);
+    resync();
+    resync();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: true });
+    expect(partyroomsService.getSetupInfo).toHaveBeenCalled();
+  });
+
+  test('enter onError → 로비', () => {
+    const resync = registerAndGetResync(7);
+    resync();
+    resync();
+    mockMutate.mock.calls[0][1].onError();
+    expect(mockPush).toHaveBeenCalledWith('/parties');
   });
 });

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   useHandlePartyroomSubscriptionEvent,
@@ -28,6 +29,8 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   const router = useAppRouter();
 
   const entrySource: EntrySource = options.entrySource ?? 'direct';
+  // 재연결 resync 의 첫 연결 skip 가드 (연결 간 보존). 첫 연결은 아래 once enter 가 담당. (#402)
+  const firstConnect = useRef(true);
 
   const setup = async (enterResponse: EnterResponse) => {
     const [setUpInfo, notice] = await Promise.all([
@@ -96,6 +99,34 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
       },
       { once: true }
     );
+
+    // 재연결 resync (비-once). 첫 연결은 firstConnect ref 로 skip(이중 tryEnter 방지). (#402)
+    client.onConnect(() => {
+      if (firstConnect.current) {
+        firstConnect.current = false;
+        return;
+      }
+      enter(
+        { partyroomId },
+        {
+          onSuccess: (enterResponse) => {
+            const invalidateDjQueue = () =>
+              queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
+            if (enterResponse.reactivated) {
+              // 멤버십 상실 → 풀 재수화(검정 해소). 룸 재구독은 추가하지 않음(handleConnect 가 이미 reconcile).
+              silent(setup(enterResponse), {
+                onSuccess: invalidateDjQueue,
+                onError: () => router.push('/parties'),
+              });
+            } else {
+              // 멤버십 유지 → 경량(플레이어/구독 무영향)
+              invalidateDjQueue();
+            }
+          },
+          onError: () => router.push('/parties'),
+        }
+      );
+    });
   };
 }
 

--- a/src/shared/api/http/types/partyrooms.ts
+++ b/src/shared/api/http/types/partyrooms.ts
@@ -195,6 +195,8 @@ export type GetPartyroomDetailSummaryPayload = {
 export type EnterResponse = {
   crewId: number;
   gradeType: GradeType;
+  /** WS 재연결 resync 신호: 멤버십이 inactive→active 로 재활성됐는지 (web#402). */
+  reactivated: boolean;
 };
 
 export type ExitPayload = {


### PR DESCRIPTION
## 무엇을 / 왜
WS 소프트 재연결 시 룸 `enter`가 `{once:true}`라 미실행 → 멤버십 미복구(**CRW-001 버스트**)·상태 stale(**디스플레이 검정**). 이게 #303(좋아요)·#304(enqueue orphan)·#428(③ 회원강등)의 **공통 상류 트리거**. 비-once resync 핸들러로 닫는다.

## 설계/계획
- 스펙: `docs/superpowers/specs/2026-06-19-ws-reconnect-resync-design.md`
- 계획: `docs/superpowers/plans/2026-06-19-ws-reconnect-resync.md`

## 동작 (감지-후-분기, Approach C)
- `firstConnect` ref로 첫 연결 skip(이중 tryEnter 방지) → 재연결에서만 동작.
- 재연결마다 `tryEnter`(멱등) → 멤버십 재확립(CRW-001 차단).
- 응답 `reactivated`로 분기:
  - **true(멤버십 상실)** → 풀 재수화(`setup`/검정 해소). 룸 재구독은 추가 안 함(handleConnect가 이미 reconcile).
  - **false(유지)** → 경량(DJ큐 invalidate만, 플레이어/구독 무영향 → **#426 remount 회피**).

## 의존성 / degrade
platform **#307**(`EnterResponse.reactivated`)에 의존. **미배포 시 `reactivated=undefined` → 경량 경로로 안전 degrade**(멤버십은 여전히 복구되어 CRW-001 해소, 검정-디스플레이 풀재수화만 보류).

## 검증
- 단위 10 GREEN(등록·첫연결skip·재연결·reactivated 분기·onError), **전체 회귀 291파일/1592 GREEN**, `tsc` 0, eslint 0.

관련: 상위 platform #306 · platform #307(신호) · #304 · #303 · #428