### PR TITLE
feat(mobile): 네이티브 터치 질감 리셋 (#414)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 
 import '@rainbow-me/rainbowkit/styles.css';
 import '@/shared/ui/foundation/globals.css';
+import '@/shared/ui/foundation/touch-reset.css';
 
 import { PropsWithChildren } from 'react';
 

--- a/src/shared/ui/foundation/touch-reset.css
+++ b/src/shared/ui/foundation/touch-reset.css
@@ -1,0 +1,41 @@
+/**
+ * 모바일 네이티브 터치 질감 리셋 (#414)
+ *
+ * ⚠️ 데스크톱 영향 0 — 모든 리셋은 "순수 터치 디바이스"에만 적용한다.
+ *   `(hover: none) and (pointer: coarse)` = 호버 불가 + 주포인터 거침(터치) →
+ *   데스크톱(hover: hover / pointer: fine)·터치 가능 노트북(hover 있음)은 자동 제외.
+ *   `any-pointer` 는 터치 노트북까지 매칭하므로 사용 금지.
+ */
+@media (hover: none) and (pointer: coarse) {
+  /* 탭 시 파란/회색 플래시 제거 */
+  * {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* 더블탭 줌·탭 지연(300ms) 제거 */
+  html {
+    touch-action: manipulation;
+  }
+
+  /* 길게 누름 콜아웃 메뉴·텍스트 선택 차단 — UI 크롬(인터랙티브)만.
+     ⚠️ 콘텐츠/텍스트는 선택 가능하게 유지(user-select 전역 금지). */
+  button,
+  a,
+  [role='button'],
+  label {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* 터치 탭 focus 링 제거 — 키보드(:focus-visible)는 링 유지(a11y 보존).
+     게다가 본 미디어 안이라 데스크톱과는 무관. */
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /* 스크롤 바운스·스크롤 체이닝 억제(앱 같은 질감). contain = 당겨서새로고침은 유지. */
+  body {
+    overscroll-behavior: contain;
+  }
+}

--- a/src/shared/ui/foundation/touch-reset.css.test.ts
+++ b/src/shared/ui/foundation/touch-reset.css.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * #414 데스크톱-무영향 불변식의 구조 회귀 가드.
+ * CSS 미디어쿼리는 jsdom 이 평가하지 못하므로(런타임 단언 불가), 대신 파일 구조로
+ * "모든 터치 리셋이 (hover: none) and (pointer: coarse) 안에만 있고, 전역 user-select 가 없음" 을 단언한다.
+ */
+const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'touch-reset.css'), 'utf-8');
+
+// 주석 제거 후 공백 정규화
+const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '').trim();
+
+describe('touch-reset.css — 데스크톱 무영향 불변식 (#414)', () => {
+  test('모든 규칙이 (hover: none) and (pointer: coarse) 미디어 블록 안에만 있다', () => {
+    // 주석 제외 본문이 정확히 하나의 coarse 미디어 블록으로 감싸여야 한다(밖에 떠도는 규칙 0).
+    expect(stripped).toMatch(/^@media \(hover: none\) and \(pointer: coarse\) \{[\s\S]*\}$/);
+    // any-pointer 사용 금지(터치 노트북까지 매칭 → 데스크톱 오염)
+    expect(stripped).not.toContain('any-pointer');
+  });
+
+  test('user-select 가 전역(*, html, body, :root)에 적용되지 않는다 — 콘텐츠 선택 보존', () => {
+    expect(stripped).not.toMatch(/\*\s*\{[^}]*user-select/);
+    expect(stripped).not.toMatch(/\b(html|body|:root)\s*\{[^}]*user-select/);
+    // user-select 는 인터랙티브 크롬(button 등)에만
+    expect(stripped).toMatch(/button[\s\S]*?\{[^}]*user-select:\s*none/);
+  });
+
+  test('focus 링 제거는 :focus:not(:focus-visible) 만 — 키보드 a11y 보존', () => {
+    expect(stripped).toContain(':focus:not(:focus-visible)');
+    // 무조건적 outline:none(:focus 전체 제거) 금지
+    expect(stripped).not.toMatch(/(?<!:not\(:focus-visible\))\s*:focus\s*\{[^}]*outline:\s*none/);
+  });
+});


### PR DESCRIPTION
## 무엇을 / 왜
모바일 웹의 "이질감"(네이티브 대비)을 만드는 브라우저 기본 터치 동작을 리셋 → 앱 같은 터치 질감. PWA(#404 껍데기)와 짝.

## 🚫 데스크톱 영향 0 (하드 제약)
모든 리셋을 **`@media (hover: none) and (pointer: coarse)`** 안에만 적용 → 데스크톱(hover/fine)·터치 가능 노트북(hover 있음) 자동 제외. `any-pointer` 미사용.
- `user-select`·콜아웃 = **UI 크롬(button/a/role=button/label)만** → 콘텐츠/텍스트 선택 보존.
- focus = `:focus:not(:focus-visible)` → 터치 탭 링만 제거, **키보드 링 유지(a11y)**.

## 적용 (touch-reset.css, layout import)
tap-highlight transparent · touch-action manipulation · callout/user-select(크롬) · :focus 링(터치) · overscroll-behavior contain.

## 검증
- **데스크톱-무영향 불변식 = 구조 회귀 테스트**(3 GREEN): 모든 룰이 coarse 미디어 안 / 전역·body·html user-select 없음 / `:focus:not(:focus-visible)`만. (CSS 미디어쿼리는 jsdom 미평가라 런타임 단언 대신 구조 단언.)
- lint 0 · tsc 0.
- ⚠️ DoD 잔여(수동): 모바일 실기기(탭플래시·콜아웃·바운스·더블탭줌 제거) + 데스크톱(텍스트선택·키보드focus·트랙패드·hover 정상).

Closes #414