### PR TITLE
fix(wallet): NFT face sourceType URI 형태 판정 (#432)

### DIFF
--- a/src/entities/wallet/lib/use-is-nft.hook.test.ts
+++ b/src/entities/wallet/lib/use-is-nft.hook.test.ts
@@ -1,39 +1,30 @@
-const mockGetQueryData = vi.fn();
-vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({ getQueryData: mockGetQueryData }),
-}));
-
 import { renderHook } from '@testing-library/react';
 import useIsNft from './use-is-nft.hook';
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
-describe('useIsNft', () => {
-  test('NFT 목록에 URI가 존재하면 true를 반환한다', () => {
-    mockGetQueryData.mockReturnValue([
-      { resourceUri: 'https://example.com/nft1.png', available: true },
-      { resourceUri: 'https://example.com/nft2.png', available: true },
-    ]);
-
+describe('useIsNft (URI 형태 기반 판정)', () => {
+  test('firebasestorage(내부 face) URI 는 NFT 가 아니다 → false', () => {
     const { result } = renderHook(() => useIsNft());
-    expect(result.current('https://example.com/nft1.png')).toBe(true);
+    expect(
+      result.current(
+        'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/o/ava_face%2Fface_001.png?alt=media'
+      )
+    ).toBe(false);
   });
 
-  test('NFT 목록에 URI가 없으면 false를 반환한다', () => {
-    mockGetQueryData.mockReturnValue([
-      { resourceUri: 'https://example.com/nft1.png', available: true },
-    ]);
-
+  test('외부(cloudinary NFT 썸네일) URI 는 NFT 다 → true', () => {
     const { result } = renderHook(() => useIsNft());
-    expect(result.current('https://example.com/nonexistent.png')).toBe(false);
+    expect(
+      result.current(
+        'https://res.cloudinary.com/alchemyapi/image/upload/thumbnailv2/eth-mainnet/550d48e536a5ac401158912a0b9a1c2f'
+      )
+    ).toBe(true);
   });
 
-  test('NFT 데이터가 없으면 falsy를 반환한다', () => {
-    mockGetQueryData.mockReturnValue(undefined);
-
+  test('회귀 가드: NFT 캐시/지갑 연결과 무관하게 외부 URI 는 항상 NFT 로 판정된다', () => {
+    // 기존 버그(#432): 제출 시점에 휘발성 NFT 캐시 멤버십으로 재추론 → 캐시가 비면
+    // 정상 NFT 얼굴이 INTERNAL_IMAGE 로 오분류돼 백엔드가 거부했다.
+    // 형태 기반 판정은 캐시 상태에 의존하지 않는다.
     const { result } = renderHook(() => useIsNft());
-    expect(result.current('https://example.com/nft1.png')).toBeFalsy();
+    expect(result.current('https://example.com/some-nft.png')).toBe(true);
   });
 });

--- a/src/entities/wallet/lib/use-is-nft.hook.ts
+++ b/src/entities/wallet/lib/use-is-nft.hook.ts
@@ -1,12 +1,21 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { Nft } from '@/entities/wallet';
-import { QueryKeys } from '@/shared/api/http/query-keys';
+/**
+ * 내부(서비스 제공) face 리소스의 URI 접두어. 백엔드 AvatarRequestValidator 의
+ * INTERNAL_IMAGE 검증과 동일한 계약 — 내부 face/body 는 항상 이 firebasestorage
+ * 버킷에서 서빙된다.
+ */
+const INTERNAL_RESOURCE_URI_PREFIX =
+  'https://firebasestorage.googleapis.com/v0/b/pfplay-firebase.appspot.com/';
 
+/**
+ * face URI 가 NFT(외부) 출처인지 형태로 판정한다.
+ *
+ * 과거엔 제출 시점에 휘발성 NFT 캐시(`[QueryKeys.Nfts]`) 멤버십으로 재추론했는데,
+ * 그 캐시는 지갑 미연결 시 삭제되고(`useNfts`), 이미지 헬스체크 탈락분이 빠지며,
+ * gcTime 으로 GC 된다. 캐시가 비면 정상 NFT 얼굴이 INTERNAL_IMAGE 로 오분류돼
+ * 백엔드가 거부했다(#432). 내부 리소스는 항상 firebasestorage 접두어를 가지므로
+ * "접두어가 아니면 NFT" 로 판정하면 캐시 상태와 무관하게 안정적이고, 백엔드
+ * 검증 계약(INTERNAL_IMAGE=firebase, NFT_URI=http(s))과 정확히 일치한다.
+ */
 export default function useIsNft() {
-  const queryClient = useQueryClient();
-  const nfts = queryClient.getQueryData([QueryKeys.Nfts]) as Nft.Model[];
-
-  return (uri: string) => {
-    return nfts && nfts.find((nft) => nft.resourceUri === uri) !== undefined;
-  };
+  return (uri: string) => !uri.startsWith(INTERNAL_RESOURCE_URI_PREFIX);
 }


### PR DESCRIPTION
Closes #432

## 문제
아바타 face 를 NFT 로 설정 시 "유효하지 않은 face URI" 거부(예: cloudinary alchemy 썸네일). `isNft` 가 제출 시점에 휘발성 NFT 캐시(`[QueryKeys.Nfts]`) 멤버십으로 sourceType 을 재추론하는데, 그 캐시는 지갑 미연결 시 삭제·이미지 헬스체크 탈락·gcTime GC 로 비워질 수 있다. 비면 정상 NFT 얼굴이 `INTERNAL_IMAGE` 로 오분류 → 백엔드가 firebasestorage 접두어를 요구하다 거부.

## 수정
`isNft` 를 URI 형태 판정으로 — `firebasestorage` 접두어면 INTERNAL_IMAGE, 아니면 NFT. 백엔드 `AvatarRequestValidator` 계약(INTERNAL_IMAGE=firebase, NFT_URI=http(s))과 정확히 일치하고 캐시 상태에 무관. 훅에서 queryClient 의존 제거.

## 테스트
- 단위: `use-is-nft.hook.test.ts` 형태 기반으로 교체(RED→GREEN) + **회귀 가드**(캐시 비어도 외부 URI 는 NFT). wallet+avatar 26 GREEN, eslint·tsc 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)