### PR TITLE
fix(e2e): 크루 계급 그룹 펼침 헬퍼 상태 인지형 전환 — e2e-c 모더레이션 kick/ban 복구 (#440)

### DIFF
--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -313,7 +313,14 @@ async function expandAllCrewCategories(page: Page) {
   const count = await categoryButtons.count();
 
   for (let i = 0; i < count; i++) {
-    await categoryButtons.nth(i).click();
+    const button = categoryButtons.nth(i);
+    // #411 이후 계급 그룹이 defaultOpen(기본 펼침)이다 — 버튼은 Disclosure 토글이라
+    // 무조건 클릭하면 오히려 접혀서 크루 행이 사라진다(#440). aria-expanded 로
+    // 상태를 확인해 접힌 그룹만 펼친다(기본 접힘/펼침 양쪽 UI와 호환).
+    if ((await button.getAttribute('aria-expanded')) !== 'true') {
+      await button.click();
+      await expect(button).toHaveAttribute('aria-expanded', 'true', { timeout: 5_000 });
+    }
   }
 }
 


### PR DESCRIPTION
Closes #440

## 근본 원인 (테스트 결함 — 제품 무결)
e2e 헬퍼 `expandAllCrewCategories`가 크루 계급 그룹 버튼(Headless UI Disclosure **토글**)을 무조건 클릭한다. 6월까지는 그룹이 기본 접힘이라 클릭=펼침이었지만, **#411(계급 그룹 기본 펼침, `defaultOpen`) 머지 이후 클릭=접힘**이 되어 user2 크루 행이 언마운트 → `crew-list-item-hover` 15s 타임아웃.

### 증거 (Playwright 트레이스 분석)
- 액션 타임라인: All 탭 전환(스냅샷에 user2 행+hover 컨테이너 **존재** 확인) → 카테고리 버튼 2개 클릭 → 직후 탐색 실패
- DOM 스냅샷: 카테고리 버튼 `aria-expanded="true"`/`data-open` (클릭 전 이미 펼침)
- 이슈의 "로비 축출" 추정은 오독 — 실패 스냅샷이 teardown(룸 닫힘) 이후에 캡처된 것. 실패 시점 user1은 룸 안에서 정상(WS 핑·이벤트 수신 지속)
- 실패 모드가 실행마다 달랐던 것(행 미발견 vs hover 메뉴 미표시)도 접힘 애니메이션 타이밍 차이로 일관 설명

## 수정
헬퍼를 **상태 인지형**으로: `aria-expanded !== 'true'`인 그룹만 클릭 + 클릭 후 펼침 단언. 기본 접힘/펼침 양쪽 UI와 호환(과거 브랜치에서도 동작).

## 검증
- 수정 전: e2e-c kick/ban 테스트 재현 3회 연속 실패 (분기점 a3394bb에서도 재현 — #440 격리 기록)
- 수정 후: **e2e-c 전체(3 테스트) 2회 연속 그린** (로컬 풀스택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)