### PR TITLE
feat(playlist): 트랙 목록에 NOW/NEXT 재생 커서 배지 (#453)

### DIFF
--- a/e2e/mobile/playlist-management.spec.ts
+++ b/e2e/mobile/playlist-management.spec.ts
@@ -114,6 +114,10 @@ test.describe('mobile playlist management (chunk 6)', () => {
     const removeBtn = page.getByTestId(/^detail-track-remove-/).first();
     await expect(removeBtn).toBeVisible({ timeout: 15_000 });
 
+    // #453: 갓 생성한 플리(커서 null) → 추가한 곡에 NEXT 배지. 비-DJ라 NOW 없음.
+    await expect(page.getByTestId('track-badge-next')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('track-badge-now')).toHaveCount(0);
+
     // 곡 삭제 → 다시 빈 상태 (트랙 0)
     log('remove track');
     await removeBtn.click();

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-playback-start-callback.hook.test.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-playback-start-callback.hook.test.ts
@@ -1,12 +1,18 @@
+const { invalidateQueries } = vi.hoisted(() => ({ invalidateQueries: vi.fn() }));
+
 vi.mock('@/shared/lib/store/stores.context');
 vi.mock('@/shared/lib/analytics', () => ({
   track: vi.fn(),
   identify: vi.fn(),
 }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries }),
+}));
 
 import { renderHook } from '@testing-library/react';
 import type * as Crew from '@/entities/current-partyroom/model/crew.model';
 import { createCurrentPartyroomStore } from '@/entities/current-partyroom/model/current-partyroom.store';
+import { QueryKeys } from '@/shared/api/http/query-keys';
 import { GradeType, MotionType } from '@/shared/api/http/types/@enums';
 import { PartyroomEventType } from '@/shared/api/websocket/types/partyroom';
 import { identify, track } from '@/shared/lib/analytics';
@@ -136,6 +142,8 @@ describe('usePlaybackStartCallback', () => {
       );
       expect(djTurnCalls).toHaveLength(0);
       expect(identify).not.toHaveBeenCalled();
+      // 내 턴이 아니면 커서 미전진 → 트랙쿼리 invalidate 안 함
+      expect(invalidateQueries).not.toHaveBeenCalled();
     });
 
     test('event.crewId === my.crewId 일 때 DJ Turn Started + total_dj_sessions add+1', () => {
@@ -149,6 +157,8 @@ describe('usePlaybackStartCallback', () => {
         track_id: 'yt-abc123',
       });
       expect(identify).toHaveBeenCalledWith({ add: { total_dj_sessions: 1 } });
+      // 내 턴 시작 → 커서 전진 반영 위해 내 트랙쿼리 invalidate (NOW/NEXT 갱신)
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.PlaylistTracks] });
     });
   });
 });

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-playback-start-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-playback-start-callback.hook.ts
@@ -1,9 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryKeys } from '@/shared/api/http/query-keys';
 import { PlaybackStartedEvent } from '@/shared/api/websocket/types/partyroom';
 import { identify, track } from '@/shared/lib/analytics';
 import { useStores } from '@/shared/lib/store/stores.context';
 
 export default function usePlaybackStartCallback() {
   const { useCurrentPartyroom } = useStores();
+  const queryClient = useQueryClient();
   const [
     updatePlaybackActivated,
     updatePlayback,
@@ -47,6 +50,10 @@ export default function usePlaybackStartCallback() {
     });
 
     if (me?.crewId !== undefined && event.crewId === me.crewId) {
+      // 내 턴이 시작되면 재생 커서가 전진하므로, 내 트랙 목록을 무효화해
+      // NOW/NEXT 배지가 새 커서로 갱신되게 한다. (열려있지 않은 쿼리는 stale 표시만)
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.PlaylistTracks] });
+
       track('DJ Turn Started', {
         partyroom_id: partyroomId,
         track_id: event.playback.linkId,

--- a/src/features/playlist/list-tracks/api/use-fetch-playlist-tracks.query.ts
+++ b/src/features/playlist/list-tracks/api/use-fetch-playlist-tracks.query.ts
@@ -2,12 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import { playlistsService } from '@/shared/api/http/services';
-import { APIError, PaginationResponse } from '@/shared/api/http/types/@shared';
-import { type PlaylistTrack } from '@/shared/api/http/types/playlists';
+import { APIError } from '@/shared/api/http/types/@shared';
+import { type TracksOfPlaylistResponse } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES } from '@/shared/config/time';
 
 export const useFetchPlaylistTracks = (listId: number) => {
-  return useQuery<PaginationResponse<PlaylistTrack>, AxiosError<APIError>>({
+  return useQuery<TracksOfPlaylistResponse, AxiosError<APIError>>({
     queryKey: [QueryKeys.PlaylistTracks, listId],
     queryFn: () =>
       /**

--- a/src/features/playlist/list-tracks/lib/resolve-next-track.test.ts
+++ b/src/features/playlist/list-tracks/lib/resolve-next-track.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveNextTrackId } from './resolve-next-track';
+
+describe('resolveNextTrackId', () => {
+  it('커서가 중간이면 바로 다음 트랙', () => {
+    expect(resolveNextTrackId([10, 20, 30, 40], 20)).toBe(30);
+  });
+
+  it('커서가 마지막이면 wrap 하여 첫 트랙', () => {
+    expect(resolveNextTrackId([10, 20, 30], 30)).toBe(10);
+  });
+
+  it('커서가 null/undefined면 첫 트랙', () => {
+    expect(resolveNextTrackId([10, 20, 30], null)).toBe(10);
+    expect(resolveNextTrackId([10, 20, 30], undefined)).toBe(10);
+  });
+
+  it('커서가 목록에 없으면(삭제) 첫 트랙', () => {
+    expect(resolveNextTrackId([10, 20, 30], 999)).toBe(10);
+  });
+
+  it('단일 트랙이면 커서가 그 트랙이어도 자기 자신', () => {
+    expect(resolveNextTrackId([10], 10)).toBe(10);
+    expect(resolveNextTrackId([10], null)).toBe(10);
+  });
+
+  it('빈 목록이면 null', () => {
+    expect(resolveNextTrackId([], 10)).toBeNull();
+    expect(resolveNextTrackId([], null)).toBeNull();
+  });
+
+  it('재정렬 시나리오 — 커서 트랙을 맨 끝으로 옮기면 NEXT가 wrap 되어 맨 앞', () => {
+    // [10,20,30,40] 커서=20 → NEXT=30. 커서(20)를 끝으로: [10,30,40,20] → NEXT=wrap=10
+    expect(resolveNextTrackId([10, 30, 40, 20], 20)).toBe(10);
+  });
+});

--- a/src/features/playlist/list-tracks/lib/resolve-next-track.ts
+++ b/src/features/playlist/list-tracks/lib/resolve-next-track.ts
@@ -1,0 +1,19 @@
+/**
+ * 정렬된 트랙 id 목록에서 재생 커서 "다음"에 시작될 트랙 id를 파생한다(순환).
+ * - 커서가 null/undefined이거나 목록에서 찾지 못하면(삭제) 첫 트랙.
+ * - 빈 목록이면 null.
+ *
+ * NOTE: 백엔드 PlaybackCursorPolicy.startIndexAfterCursor와 동일 시맨틱.
+ * 클라이언트가 (낙관적 재정렬을 반영한) 현재 순서로부터 직접 계산하므로
+ * 재정렬 후 refetch 없이도 NEXT가 정확하게 유지된다.
+ */
+export function resolveNextTrackId(
+  orderedTrackIds: number[],
+  cursor: number | null | undefined
+): number | null {
+  if (orderedTrackIds.length === 0) return null;
+  if (cursor == null) return orderedTrackIds[0];
+  const idx = orderedTrackIds.indexOf(cursor);
+  if (idx < 0) return orderedTrackIds[0];
+  return orderedTrackIds[(idx + 1) % orderedTrackIds.length];
+}

--- a/src/features/playlist/list-tracks/ui/track.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.test.tsx
@@ -27,6 +27,8 @@ import { useStores } from '@/shared/lib/store/stores.context';
 import Track from './track.component';
 
 const NOT_PLAYABLE = 'Not playable here (exceeds this room limit)';
+const NOW_LABEL = 'Now';
+const NEXT_LABEL = 'Next';
 
 const track = {
   linkId: 'l1',
@@ -40,6 +42,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (useI18n as Mock).mockReturnValue({
     dj: { para: { not_playable_in_room: NOT_PLAYABLE } },
+    playlist: { para: { now_playing: NOW_LABEL, next_up: NEXT_LABEL } },
   });
   (useStores as Mock).mockReturnValue({
     useUIState: (selector: (...args: any[]) => any) =>
@@ -72,5 +75,25 @@ describe('Track over-limit 배지', () => {
     expect(screen.getByText('My Song')).toBeInTheDocument();
     expect(screen.getByText('6:00')).toBeInTheDocument();
     expect(container.querySelector('[data-dnd="attr"]')).not.toBeNull();
+  });
+});
+
+describe('Track NOW/NEXT 배지', () => {
+  test('isNow=true 면 NOW 배지 렌더', () => {
+    render(<Track track={track} menuItems={[]} isNow />);
+    expect(screen.getByTestId('track-badge-now')).toHaveTextContent(NOW_LABEL);
+    expect(screen.queryByTestId('track-badge-next')).not.toBeInTheDocument();
+  });
+
+  test('isNext=true 면 NEXT 배지 렌더', () => {
+    render(<Track track={track} menuItems={[]} isNext />);
+    expect(screen.getByTestId('track-badge-next')).toHaveTextContent(NEXT_LABEL);
+    expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
+  });
+
+  test('배지 미지정 시 NOW/NEXT 모두 없음', () => {
+    render(<Track track={track} menuItems={[]} />);
+    expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('track-badge-next')).not.toBeInTheDocument();
   });
 });

--- a/src/features/playlist/list-tracks/ui/track.component.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.tsx
@@ -17,9 +17,19 @@ type TrackProps = {
   track: PlaylistTrack;
   menuItems: MenuItem[];
   isOverRoomLimit?: boolean;
+  /** 지금 재생 중(CurrentDJ 본인 한정, 방 안). NOW 배지. */
+  isNow?: boolean;
+  /** 내가 다음에 디제잉하면 시작될 곡. NEXT 배지. */
+  isNext?: boolean;
 };
 
-const Track = ({ track, menuItems, isOverRoomLimit = false }: TrackProps) => {
+const Track = ({
+  track,
+  menuItems,
+  isOverRoomLimit = false,
+  isNow = false,
+  isNext = false,
+}: TrackProps) => {
   const t = useI18n();
   const cinemaView = useStores().useUIState((s) => s.cinemaView);
   const layerZIndex = usePlaylistLayerZIndex();
@@ -65,6 +75,17 @@ const Track = ({ track, menuItems, isOverRoomLimit = false }: TrackProps) => {
         </div>
 
         <div className='flex-1 min-w-0 select-none flexCol overflow-hidden pointer-events-none'>
+          {(isNow || isNext) && (
+            <span
+              data-testid={isNow ? 'track-badge-now' : 'track-badge-next'}
+              className={cn(
+                'mb-0.5 inline-flex w-fit items-center rounded-[3px] px-1.5 py-[1px] text-[10px] font-bold leading-[14px]',
+                isNow ? 'bg-red-300 text-white' : 'bg-gray-600 text-gray-100'
+              )}
+            >
+              {isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
+            </span>
+          )}
           <Typography type='caption1' overflow='ellipsis' className='text-gray-50'>
             {track.name}
           </Typography>

--- a/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
@@ -18,12 +18,33 @@ vi.mock('../api/use-fetch-playlist-tracks.query', () => ({
   useFetchPlaylistTracks: vi.fn(),
 }));
 
-let lastTrackProps: Array<{ duration: string; isOverRoomLimit?: boolean }> = [];
+let storeState: { me?: { crewId: number }; currentDj?: { crewId: number } } = {};
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useCurrentPartyroom: (selector: (s: typeof storeState) => unknown) => selector(storeState),
+  }),
+}));
+
+let lastTrackProps: Array<{
+  trackId: number;
+  duration: string;
+  isOverRoomLimit?: boolean;
+  isNow?: boolean;
+  isNext?: boolean;
+}> = [];
 vi.mock('./track.component', () => ({
-  default: (props: { track: { duration: string }; isOverRoomLimit?: boolean }) => {
+  default: (props: {
+    track: { duration: string; trackId: number };
+    isOverRoomLimit?: boolean;
+    isNow?: boolean;
+    isNext?: boolean;
+  }) => {
     lastTrackProps.push({
+      trackId: props.track.trackId,
       duration: props.track.duration,
       isOverRoomLimit: props.isOverRoomLimit,
+      isNow: props.isNow,
+      isNext: props.isNext,
     });
     return <div data-testid='track' />;
   },
@@ -49,8 +70,14 @@ function makeTrack(linkId: string, duration: string): PlaylistTrack {
   } as unknown as PlaylistTrack;
 }
 
-function setTracks(tracks: PlaylistTrack[]) {
-  (useFetchPlaylistTracks as Mock).mockReturnValue({ data: { content: tracks } });
+function setTracks(tracks: PlaylistTrack[], lastPlayedTrackId: number | null = null) {
+  (useFetchPlaylistTracks as Mock).mockReturnValue({
+    data: { content: tracks, lastPlayedTrackId },
+  });
+}
+
+function setStore(next: typeof storeState) {
+  storeState = next;
 }
 
 function setSummary(summary: unknown) {
@@ -64,6 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   lastTrackProps = [];
   paramsValue = { id: '7' };
+  storeState = {};
   (useI18n as Mock).mockReturnValue({
     playlist: { btn: { delete_playlist: 'd', move_playlist: 'm' } },
   });
@@ -136,5 +164,64 @@ describe('TracksInPlaylist over-limit 계산', () => {
     const [partyroomId, enabled] = (useFetchPartyroomDetailSummary as Mock).mock.calls[0];
     expect(partyroomId).toBe(7);
     expect(enabled).toBe(true);
+  });
+});
+
+describe('TracksInPlaylist NOW/NEXT 배지', () => {
+  const t10 = () => makeTrack('t10', '1:00'); // trackId 10
+  const t20 = () => makeTrack('t20', '1:00'); // trackId 20
+  const t30 = () => makeTrack('t30', '1:00'); // trackId 30
+
+  const byId = (id: number) => {
+    const found = lastTrackProps.find((p) => p.trackId === id);
+    if (!found) throw new Error(`track ${id} not rendered`);
+    return found;
+  };
+
+  test('커서 null: NEXT는 첫 트랙, NOW 없음(비-DJ)', () => {
+    setTracks([t10(), t20(), t30()], null);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(byId(10).isNext).toBe(true);
+    expect(byId(20).isNext).toBe(false);
+    expect(lastTrackProps.every((p) => !p.isNow)).toBe(true);
+  });
+
+  test('내가 CurrentDJ + 커서=20: NOW=20, NEXT=30', () => {
+    setStore({ me: { crewId: 5 }, currentDj: { crewId: 5 } });
+    setTracks([t10(), t20(), t30()], 20);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(byId(20).isNow).toBe(true);
+    expect(byId(20).isNext).toBe(false);
+    expect(byId(30).isNext).toBe(true);
+    expect(byId(10).isNow).toBe(false);
+  });
+
+  test('내가 CurrentDJ 아님 + 커서=20: NOW 없음, NEXT=30만', () => {
+    setStore({ me: { crewId: 5 }, currentDj: { crewId: 9 } });
+    setTracks([t10(), t20(), t30()], 20);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(lastTrackProps.every((p) => !p.isNow)).toBe(true);
+    expect(byId(30).isNext).toBe(true);
+  });
+
+  test('커서=마지막(30): NEXT는 wrap 하여 첫 트랙(10)', () => {
+    setStore({ me: { crewId: 5 }, currentDj: { crewId: 5 } });
+    setTracks([t10(), t20(), t30()], 30);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(byId(30).isNow).toBe(true);
+    expect(byId(10).isNext).toBe(true);
+  });
+
+  test('단일 트랙 + CurrentDJ 겹침(NOW==NEXT): NOW만, isNext=false', () => {
+    setStore({ me: { crewId: 5 }, currentDj: { crewId: 5 } });
+    setTracks([t10()], 10);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(byId(10).isNow).toBe(true);
+    expect(byId(10).isNext).toBe(false);
   });
 });

--- a/src/features/playlist/list-tracks/ui/tracks.component.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.tsx
@@ -21,10 +21,12 @@ import { Playlist, PlaylistTrack } from '@/shared/api/http/types/playlists';
 import { errorLog } from '@/shared/lib/functions/log/logger';
 import withDebugger from '@/shared/lib/functions/log/with-debugger';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { PFAddPlaylist, PFDelete } from '@/shared/ui/icons';
 import Track from './track.component';
 import { useFetchPlaylistTracks } from '../api/use-fetch-playlist-tracks.query';
 import { parseDurationToSeconds } from '../lib/parse-duration';
+import { resolveNextTrackId } from '../lib/resolve-next-track';
 
 const logger = withDebugger(0);
 const errorLogger = logger(errorLog);
@@ -41,8 +43,19 @@ const TracksInPlaylist = ({ playlist }: TracksInPlaylistProps) => {
   const limitMin = summary?.playbackTimeLimit ?? 0;
   const { data } = useFetchPlaylistTracks(playlist.id);
   const playlistAction = usePlaylistAction();
+  const [me, currentDj] = useStores().useCurrentPartyroom((state) => [state.me, state.currentDj]);
 
   const [items, setItems] = useState<PlaylistTrack[]>([]);
+
+  // 재생 커서(NOW 앵커). NEXT는 커서 + 현재(낙관적 재정렬 반영) 순서로부터 파생 → refetch 불필요.
+  const cursor = data?.lastPlayedTrackId ?? null;
+  const isMeCurrentDj = me?.crewId != null && me.crewId === currentDj?.crewId;
+  const nextTrackId = resolveNextTrackId(
+    items.map((track) => track.trackId),
+    cursor
+  );
+  // NOW는 내가 CurrentDJ일 때(방 안)만. 방 밖에선 currentDj가 없어 자연히 비활성.
+  const nowTrackId = isMeCurrentDj ? cursor : null;
 
   useEffect(() => {
     if (data?.content) {
@@ -98,11 +111,16 @@ const TracksInPlaylist = ({ playlist }: TracksInPlaylistProps) => {
           {items.map((track) => {
             const sec = parseDurationToSeconds(track.duration);
             const isOverRoomLimit = limitMin > 0 && sec !== null && sec > limitMin * 60;
+            const isNow = nowTrackId !== null && track.trackId === nowTrackId;
+            // NOW==NEXT(1곡) 겹침 시 NOW만 표시 → isNext는 isNow가 아닐 때만.
+            const isNext = !isNow && nextTrackId !== null && track.trackId === nextTrackId;
             return (
               <Track
                 key={track.linkId}
                 track={track}
                 isOverRoomLimit={isOverRoomLimit}
+                isNow={isNow}
+                isNext={isNext}
                 menuItems={[
                   {
                     onClickItem: () => playlistAction.removeTrack(playlist.id, track.trackId),

--- a/src/shared/api/http/services/playlists.ts
+++ b/src/shared/api/http/services/playlists.ts
@@ -1,12 +1,11 @@
 import { getErrorCode } from '@/shared/api/http/error/get-error-code';
-import { ErrorCode, PaginationResponse } from '@/shared/api/http/types/@shared';
+import { ErrorCode } from '@/shared/api/http/types/@shared';
 import { Singleton } from '@/shared/lib/decorators/singleton';
 import { SkipGlobalErrorHandling } from '@/shared/lib/decorators/skip-global-error-handling';
 import HTTPClient from '../client/client';
 import type {
   GetPlaylistsResponse,
   GetTracksOfPlaylistParameters,
-  PlaylistTrack,
   SearchMusicsRequest,
   SearchMusicsResponse,
   CreatePlaylistRequestBody,
@@ -19,6 +18,7 @@ import type {
   PlaylistsClient,
   ChangeTrackOrderRequest,
   MoveTrackToPlaylistRequest,
+  TracksOfPlaylistResponse,
 } from '../types/playlists';
 
 @Singleton
@@ -54,7 +54,7 @@ export default class PlaylistsService extends HTTPClient implements PlaylistsCli
   }
 
   public getTracksOfPlaylist(playlistId: Playlist['id'], params?: GetTracksOfPlaylistParameters) {
-    return this.get<PaginationResponse<PlaylistTrack>>(`${this.ROUTE_V1}/${playlistId}/tracks`, {
+    return this.get<TracksOfPlaylistResponse>(`${this.ROUTE_V1}/${playlistId}/tracks`, {
       params,
     });
   }

--- a/src/shared/api/http/types/playlists.ts
+++ b/src/shared/api/http/types/playlists.ts
@@ -30,6 +30,15 @@ export interface PlaylistTrack {
   thumbnailImage: string;
 }
 
+/**
+ * 트랙 목록 조회 응답. 페이지네이션 봉투 + 재생 커서.
+ * - lastPlayedTrackId: 재생 커서. CurrentDJ에겐 NOW(지금 재생 중) 트랙. 커서 미설정 시 null.
+ *   NEXT(다음 재생 곡)는 이 커서 + 현재 트랙 순서로부터 클라이언트가 파생한다.
+ */
+export interface TracksOfPlaylistResponse extends PaginationResponse<PlaylistTrack> {
+  lastPlayedTrackId: number | null;
+}
+
 export interface SearchMusicsRequest {
   q: string;
   platform: 'youtube'; // 현재 플랫폼 하나만 있음
@@ -105,7 +114,7 @@ export interface PlaylistsClient {
   getTracksOfPlaylist: (
     playlistId: Playlist['id'],
     params?: GetTracksOfPlaylistParameters
-  ) => Promise<PaginationResponse<PlaylistTrack>>;
+  ) => Promise<TracksOfPlaylistResponse>;
   addTrackToPlaylist: (
     playlistId: Playlist['id'],
     params: AddTrackToPlaylistRequestBody

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -305,7 +305,9 @@
       "search_url": "Search for music and URL",
       "up_to_10_if_connect_wallet": "If you connect your wallet, you can create up to 10!",
       "no_other_playlist": "There are no other playlists to move this song to",
-      "select_for_move": "Please select the playlist to move the selected song to"
+      "select_for_move": "Please select the playlist to move the selected song to",
+      "now_playing": "Now",
+      "next_up": "Next"
     },
     "ec": {
       "exceeded_list_connect_wallet": "You have already exceeded the number of lists that can be created. ",

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -305,7 +305,9 @@
       "search_url": "URL 혹은 음악을 검색할 수 있어요",
       "up_to_10_if_connect_wallet": "지갑을 연동하시면 10개까지 생성할 수 있어요!",
       "no_other_playlist": "이동할 수 있는 다른 플레이리스트가 없어요",
-      "select_for_move": "선택한 곡을 이동할 재생목록을 선택해 주세요"
+      "select_for_move": "선택한 곡을 이동할 재생목록을 선택해 주세요",
+      "now_playing": "재생 중",
+      "next_up": "다음 곡"
     },
     "ec": {
       "exceeded_list_connect_wallet": "이미 생성 가능한 리스트 수를 초과했어요.\n",

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
@@ -13,6 +13,14 @@ vi.mock('@/shared/lib/localization/i18n.context', () => ({
         sheet_add_tracks_title: '곡 추가',
       },
     },
+    playlist: { para: { now_playing: '재생 중', next_up: '다음 곡' } },
+  }),
+}));
+
+let storeState: { me?: { crewId: number }; currentDj?: { crewId: number } } = {};
+vi.mock('@/shared/lib/store/stores.context', () => ({
+  useStores: () => ({
+    useCurrentPartyroom: (selector: (s: typeof storeState) => unknown) => selector(storeState),
   }),
 }));
 
@@ -45,6 +53,7 @@ describe('PlaylistDetailSheet', () => {
   beforeEach(() => {
     removeTrackMock.mockReset();
     pushMock.mockReset();
+    storeState = {};
   });
 
   test('곡 목록 렌더', () => {
@@ -80,5 +89,24 @@ describe('PlaylistDetailSheet', () => {
     useFetchPlaylistTracksMock.mockReturnValue({ data: { content: [TRACK] } });
     render(<PlaylistDetailSheet playlist={PL as never} />);
     expect(screen.getByTestId('detail-track-remove-11').querySelector('svg')).toBeTruthy();
+  });
+
+  test('커서=11 + 내가 CurrentDJ → NOW 배지', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 5 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+    expect(screen.getByTestId('track-badge-now')).toHaveTextContent('재생 중');
+  });
+
+  test('커서=11 + 내가 CurrentDJ 아님 → NOW 없음, NEXT(wrap=11)만', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 9 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+    expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
+    expect(screen.getByTestId('track-badge-next')).toHaveTextContent('다음 곡');
   });
 });

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
@@ -1,9 +1,12 @@
 'use client';
 import { FC } from 'react';
 import { useFetchPlaylistTracks } from '@/features/playlist/list-tracks/api/use-fetch-playlist-tracks.query';
+import { resolveNextTrackId } from '@/features/playlist/list-tracks/lib/resolve-next-track';
 import { useRemovePlaylistTrack } from '@/features/playlist/remove-track/api/use-remove-playlist-track.mutation';
 import { Playlist } from '@/shared/api/http/types/playlists';
+import { cn } from '@/shared/lib/functions/cn';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFClose } from '@/shared/ui/icons';
@@ -19,7 +22,17 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
   const { push } = useFullscreenSheet();
   const { data } = useFetchPlaylistTracks(playlist.id);
   const { mutate: removeTrack } = useRemovePlaylistTrack();
+  const [me, currentDj] = useStores().useCurrentPartyroom((state) => [state.me, state.currentDj]);
   const tracks = data?.content ?? [];
+
+  // 재생 커서 기반 NOW/NEXT (데스크톱 TracksInPlaylist와 동일 규칙).
+  const cursor = data?.lastPlayedTrackId ?? null;
+  const isMeCurrentDj = me?.crewId != null && me.crewId === currentDj?.crewId;
+  const nextTrackId = resolveNextTrackId(
+    tracks.map((track) => track.trackId),
+    cursor
+  );
+  const nowTrackId = isMeCurrentDj ? cursor : null;
 
   const openAddTracks = () =>
     push({
@@ -39,27 +52,44 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
           </div>
         ) : (
           <ul className='flex flex-col divide-y divide-gray-800'>
-            {tracks.map((track) => (
-              <li key={track.trackId} className='flex items-center gap-3 px-5 py-3'>
-                <img
-                  src={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
-                  alt={track.name}
-                  className='w-[64px] h-[36px] shrink-0 rounded object-cover bg-gray-700'
-                />
-                <Typography type='caption1' className='flex-1 min-w-0 truncate text-gray-50'>
-                  {track.name}
-                </Typography>
-                <button
-                  type='button'
-                  data-testid={`detail-track-remove-${track.trackId}`}
-                  onClick={() => removeTrack({ playlistId: playlist.id, trackId: track.trackId })}
-                  className='shrink-0 px-2 py-1 text-gray-400'
-                  aria-label={t.partyroom.queue.remove_track_label}
-                >
-                  <PFClose width={20} height={20} aria-hidden='true' />
-                </button>
-              </li>
-            ))}
+            {tracks.map((track) => {
+              const isNow = nowTrackId !== null && track.trackId === nowTrackId;
+              const isNext = !isNow && nextTrackId !== null && track.trackId === nextTrackId;
+              return (
+                <li key={track.trackId} className='flex items-center gap-3 px-5 py-3'>
+                  <img
+                    src={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
+                    alt={track.name}
+                    className='w-[64px] h-[36px] shrink-0 rounded object-cover bg-gray-700'
+                  />
+                  <div className='flex-1 min-w-0 flex flex-col'>
+                    {(isNow || isNext) && (
+                      <span
+                        data-testid={isNow ? 'track-badge-now' : 'track-badge-next'}
+                        className={cn(
+                          'mb-0.5 inline-flex w-fit items-center rounded-[3px] px-1.5 py-[1px] text-[10px] font-bold leading-[14px]',
+                          isNow ? 'bg-red-300 text-white' : 'bg-gray-600 text-gray-100'
+                        )}
+                      >
+                        {isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
+                      </span>
+                    )}
+                    <Typography type='caption1' className='min-w-0 truncate text-gray-50'>
+                      {track.name}
+                    </Typography>
+                  </div>
+                  <button
+                    type='button'
+                    data-testid={`detail-track-remove-${track.trackId}`}
+                    onClick={() => removeTrack({ playlistId: playlist.id, trackId: track.trackId })}
+                    className='shrink-0 px-2 py-1 text-gray-400'
+                    aria-label={t.partyroom.queue.remove_track_label}
+                  >
+                    <PFClose width={20} height={20} aria-hidden='true' />
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>


### PR DESCRIPTION
## 개요
Closes #453 · 백엔드: pfplay/pfplay-platform#335

플레이리스트 트랙 목록에 **NOW / NEXT** 재생 커서 배지.
- **NEXT**(다음 시작 곡): 파티룸 **안/밖 모두**.
- **NOW**(지금 재생 중): 파티룸 **안 + 내가 CurrentDJ일 때만**.

## 동작
- 백엔드 `lastPlayedTrackId`(커서)를 앵커로 사용.
- **NEXT는 커서 + 현재(낙관적 재정렬 반영) 순서로부터 클라이언트가 파생**(`resolveNextTrackId`). 재정렬 후 refetch 없이 정확(재정렬 mutation은 플리커 방지로 invalidate 안 함).
- **NOW** = 커서 트랙, `me.crewId === currentDj.crewId`일 때만. 방 밖은 currentDj 없어 자연 비활성.
- **겹침(NOW==NEXT, 1곡)** → NOW만. **wrap**(NOW 맨아래·NEXT 맨위)은 각자 위치(순환목록 정확 표현).
- 곡 전환(내 턴) WS 콜백에서 내 트랙쿼리 invalidate → 커서 전진 시 재계산.

## 데스크톱 + 모바일 (별개 컴포넌트)
- 데스크톱/시네마: `features/playlist/list-tracks/ui/track.component.tsx` (`TracksInPlaylist`).
- **모바일: `widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx`** — 별개 컴포넌트라 로컬 e2e 조사 중 누락이 발견되어 동일 규칙으로 보완(파리티 커밋).

## 테스트
- 유닛: `resolveNextTrackId`(중간/wrap/null/삭제/단일곡/빈목록/재정렬), `tracks.component`·`track.component`·모바일 시트 배지 로직, playback-start 콜백 invalidation.
- **로컬 라이브 e2e**(mobile/playlist-management, 로컬 풀스택): 곡 추가 후 `track-badge-next` 가시성 + `track-badge-now` 부재 단언 GREEN. 백엔드가 실제로 `lastPlayedTrackId` 서빙 확인.
- 전체 웹 스위트 1672 GREEN, tsc·eslint·prettier 통과. 백엔드 로컬 docker 부팅 정상.

## i18n
`playlist.para.now_playing`("재생 중"/"Now") · `next_up`("다음 곡"/"Next") ko·en.
