### PR TITLE
feat(playlist): 음악 검색 유튜브 URL 붙여넣기 정규화 (#451)

### DIFF
--- a/e2e/mobile/add-tracks.spec.ts
+++ b/e2e/mobile/add-tracks.spec.ts
@@ -96,6 +96,16 @@ test.describe('mobile add-tracks flow', () => {
     log('search');
     const searchInput = page.getByTestId('music-search-input');
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
+
+    // #451: 노이즈(list/index) 붙은 URL도 canonical watch?v= 로 정규화되어
+    // 해당 영상이 검색된다. videoId 접미 testid 로 "정확히 그 영상" 을 단언.
+    log('normalize noisy youtube URL');
+    await searchInput.fill('https://youtu.be/dQw4w9WgXcQ?list=LL&index=3');
+    await expect(page.getByTestId('search-item-preview-dQw4w9WgXcQ')).toBeVisible({
+      timeout: 20_000,
+    });
+    await searchInput.fill('');
+
     await searchInput.fill('test song');
 
     log('preview');

--- a/src/entities/music-preview/lib/preview-helpers.test.ts
+++ b/src/entities/music-preview/lib/preview-helpers.test.ts
@@ -53,6 +53,11 @@ describe('preview-helpers', () => {
       ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
       ['https://youtu.be/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
       ['https://www.youtube.com/watch?v=abc123&t=10', 'abc123'],
+      ['https://youtu.be/7uqoJ1_spiQ?list=LL', '7uqoJ1_spiQ'],
+      ['https://www.youtube.com/watch?v=7uqoJ1_spiQ&list=LL&index=17', '7uqoJ1_spiQ'],
+      ['https://www.youtube.com/shorts/7uqoJ1_spiQ', '7uqoJ1_spiQ'],
+      ['https://m.youtube.com/watch?v=7uqoJ1_spiQ', '7uqoJ1_spiQ'],
+      ['https://music.youtube.com/watch?v=7uqoJ1_spiQ', '7uqoJ1_spiQ'],
     ])('"%s" → "%s"', (url, expected) => {
       expect(extractVideoIdFromUrl(url)).toBe(expected);
     });

--- a/src/entities/music-preview/lib/preview-helpers.ts
+++ b/src/entities/music-preview/lib/preview-helpers.ts
@@ -25,10 +25,14 @@ export const convertSearchMusicToPreview = (music: Music): PreviewTrack => ({
 });
 
 /**
- * YouTube 비디오 ID를 URL에서 추출
+ * YouTube 비디오 ID를 URL에서 추출.
+ * watch?v= / youtu.be/ / shorts/ / embed/ / live/ 및 m.·music. 서브도메인을 지원한다.
+ * ID 문자([A-Za-z0-9_-])만 캡처하므로 뒤따르는 &list=, ?index=, &t= 등 노이즈는 자동 절단된다.
  */
 export const extractVideoIdFromUrl = (url: string): string | null => {
-  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/);
+  const match = url.match(
+    /(?:youtube\.com\/(?:watch\?v=|shorts\/|embed\/|live\/)|youtu\.be\/)([A-Za-z0-9_-]+)/
+  );
   return match?.[1] || null;
 };
 

--- a/src/features/playlist/add-tracks/api/use-search-musics.query.ts
+++ b/src/features/playlist/add-tracks/api/use-search-musics.query.ts
@@ -5,17 +5,22 @@ import { playlistsService } from '@/shared/api/http/services';
 import { APIError } from '@/shared/api/http/types/@shared';
 import { Music, SearchMusicsResponse } from '@/shared/api/http/types/playlists';
 import { FIVE_MINUTES } from '@/shared/config/time';
+import { normalizeYoutubeSearchInput } from '../lib/normalize-youtube-search';
 
 export const useSearchMusics = (search: string) => {
+  // 유튜브 URL 붙여넣기는 canonical watch URL로 정규화(youtu.be·list·index 대응).
+  // 일반 검색어는 원본 유지. 데스크톱/모바일 공통 진입점이라 여기서 한 번에 처리한다.
+  const q = normalizeYoutubeSearchInput(search);
+
   return useQuery<SearchMusicsResponse, AxiosError<APIError>, Music[]>({
-    queryKey: [QueryKeys.Musics, search],
+    queryKey: [QueryKeys.Musics, q],
     queryFn: () =>
       playlistsService.searchMusics({
-        q: search,
+        q,
         platform: 'youtube',
       }),
     select: (data) => data.musicList,
-    enabled: !!search,
+    enabled: !!q,
     staleTime: 0,
     gcTime: FIVE_MINUTES,
   });

--- a/src/features/playlist/add-tracks/lib/normalize-youtube-search.test.ts
+++ b/src/features/playlist/add-tracks/lib/normalize-youtube-search.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeYoutubeSearchInput } from './normalize-youtube-search';
+
+const CANON = 'https://www.youtube.com/watch?v=7uqoJ1_spiQ';
+
+describe('normalizeYoutubeSearchInput', () => {
+  it('이미 canonical watch URL → 동일 canonical', () => {
+    expect(normalizeYoutubeSearchInput('https://www.youtube.com/watch?v=7uqoJ1_spiQ')).toBe(CANON);
+  });
+
+  it('youtu.be + list 파라미터 → canonical', () => {
+    expect(normalizeYoutubeSearchInput('https://youtu.be/7uqoJ1_spiQ?list=LL')).toBe(CANON);
+  });
+
+  it('watch + list + index 파라미터 → canonical', () => {
+    expect(
+      normalizeYoutubeSearchInput('https://www.youtube.com/watch?v=7uqoJ1_spiQ&list=LL&index=17')
+    ).toBe(CANON);
+  });
+
+  it('m./music. 서브도메인 → canonical', () => {
+    expect(normalizeYoutubeSearchInput('https://m.youtube.com/watch?v=7uqoJ1_spiQ')).toBe(CANON);
+    expect(normalizeYoutubeSearchInput('https://music.youtube.com/watch?v=7uqoJ1_spiQ')).toBe(
+      CANON
+    );
+  });
+
+  it('shorts URL도 canonical로 정규화된다(검색은 결과없음으로 degrade)', () => {
+    expect(normalizeYoutubeSearchInput('https://www.youtube.com/shorts/7uqoJ1_spiQ')).toBe(CANON);
+  });
+
+  it('일반 검색어는 그대로 반환(trim만)', () => {
+    expect(normalizeYoutubeSearchInput('아이유 밤편지')).toBe('아이유 밤편지');
+    expect(normalizeYoutubeSearchInput('  newjeans ditto  ')).toBe('newjeans ditto');
+  });
+
+  it('유튜브가 아닌 URL은 그대로 반환', () => {
+    expect(normalizeYoutubeSearchInput('https://www.google.com')).toBe('https://www.google.com');
+  });
+
+  it('빈 문자열 → 빈 문자열', () => {
+    expect(normalizeYoutubeSearchInput('   ')).toBe('');
+  });
+});

--- a/src/features/playlist/add-tracks/lib/normalize-youtube-search.ts
+++ b/src/features/playlist/add-tracks/lib/normalize-youtube-search.ts
@@ -1,0 +1,20 @@
+import { extractVideoIdFromUrl } from '@/entities/music-preview';
+
+/**
+ * 음악 검색 입력 정규화.
+ *
+ * 사용자가 유튜브 URL을 붙여넣으면 videoId를 추출해 canonical
+ * `https://www.youtube.com/watch?v={id}` 형태로 바꿔 검색어로 넘긴다.
+ * (`youtu.be/…?list=LL`, `watch?v=…&list=LL&index=17` 등 노이즈가 붙은 URL은
+ * 텍스트 검색이 빗나가는데, canonical 형태는 해당 영상을 정확히 반환함이 실측됨.)
+ *
+ * URL이 아니면(=videoId 추출 실패) 원본을 그대로 반환한다(일반 텍스트 검색).
+ *
+ * NOTE: shorts URL도 videoId는 추출되나, 유튜브 텍스트 검색이 shorts를
+ * 반환하지 않아 결과 없음으로 degrade한다(shorts 지원은 스코프 밖).
+ */
+export function normalizeYoutubeSearchInput(input: string): string {
+  const trimmed = input.trim();
+  const videoId = extractVideoIdFromUrl(trimmed);
+  return videoId ? `https://www.youtube.com/watch?v=${videoId}` : trimmed;
+}


### PR DESCRIPTION
## 개요
Closes #451

음악 검색에 유튜브 URL을 붙여넣을 때, `youtu.be/…?list=LL` · `watch?v=…&list=LL&index=17` 등 노이즈 붙은 URL이 검색에 빗나가던 문제를 정규화로 해결한다.

## 동작
- 입력이 유튜브 URL이면 videoId를 추출해 **canonical `https://www.youtube.com/watch?v={id}`** 로 바꿔 검색어로 전송. (실측: canonical 형태는 일반 영상을 `videoRenderer`+lengthText로 정확히 1등 반환.)
- `extractVideoIdFromUrl`을 shorts/embed/live/`m.`·`music.` 서브도메인까지 robust 확장(ID 문자만 캡처 → 뒤 파라미터 자동 절단).
- `useSearchMusics` **단일 진입점**에서 정규화 → 데스크톱·모바일 공통 커버. URL 아니면 원문 텍스트 검색.
- 백엔드/streaming **무변경**.

## 명시적 비스코프 — Shorts
실측 결과 유튜브 텍스트 검색이 shorts를 `shortsLockupViewModel` 등 별도 렌더러로만 반환 → streaming의 `videoRenderer`-only 필터가 전량 배제(실제 shorts 6개 검증). 유일한 by-id 조회 경로(`YouTube(url)`)도 pytube 15.0.0에서 전 영상 HTTP 400 파손. 따라서 shorts URL은 정규화되나 **결과없음으로 우아하게 degrade**(크래시 없음). shorts 실지원은 streaming yt-dlp 마이그레이션(pfplay/pfplay-streaming#11)에 의존.

## 테스트
- `normalizeYoutubeSearchInput` 유닛 8종(canonical/youtu.be+list/watch+list+index/서브도메인/shorts/일반검색어/비유튜브/빈값).
- `extractVideoIdFromUrl` 확장 케이스. tsc·eslint·prettier 통과.

## 로컬 라이브 e2e (추가)
mobile/add-tracks 스펙에 노이즈 URL 단언 추가 후 로컬 풀스택(로컬 pytube→실 유튜브)에서 GREEN:
`https://youtu.be/dQw4w9WgXcQ?list=LL&index=3` 입력 → 정규화 → `search-item-preview-dQw4w9WgXcQ`(정확히 그 영상) 노출 확인. 웹 전체 스위트도 GREEN.
