### PR TITLE
feat: 아바타 숨쉬기 애니메이션 타이밍을 아바타별로 분산 (#463)

### DIFF
--- a/src/entities/avatar/lib/breathing-rhythm.test.ts
+++ b/src/entities/avatar/lib/breathing-rhythm.test.ts
@@ -1,67 +1,71 @@
-import breathingRhythm, { BREATH_PERIOD_MAX, BREATH_PERIOD_MIN } from './breathing-rhythm';
+import breathingRhythmOf, {
+  BREATH_PERIOD_MAX_SECONDS,
+  BREATH_PERIOD_MIN_SECONDS,
+} from './breathing-rhythm';
 
-/** 값을 4등분 구간에 담아 쏠림을 본다. 한 구간이라도 비면 그만큼 같은 박자가 겹친다. */
-const bucketize = (ids: number[], pick: (id: number) => number) => {
-  const buckets = [0, 0, 0, 0];
-  ids.forEach((id) => buckets[Math.min(3, Math.floor(pick(id) * 4))]++);
-  return buckets;
+const periodRatioOf = (crewId: number) =>
+  (breathingRhythmOf(crewId).periodSeconds - BREATH_PERIOD_MIN_SECONDS) /
+  (BREATH_PERIOD_MAX_SECONDS - BREATH_PERIOD_MIN_SECONDS);
+
+const startOffsetRatioOf = (crewId: number) => {
+  const { periodSeconds, startOffsetSeconds } = breathingRhythmOf(crewId);
+  return startOffsetSeconds / periodSeconds;
 };
 
-const periodRatio = (id: number) =>
-  (breathingRhythm(id).period - BREATH_PERIOD_MIN) / (BREATH_PERIOD_MAX - BREATH_PERIOD_MIN);
-const phaseRatio = (id: number) => {
-  const { period, phase } = breathingRhythm(id);
-  return phase / period;
+const countPerQuarter = (crewIds: number[], ratioOf: (crewId: number) => number) => {
+  const quarters = [0, 0, 0, 0];
+  crewIds.forEach((crewId) => quarters[Math.min(3, Math.floor(ratioOf(crewId) * 4))]++);
+  return quarters;
 };
 
-const range = (start: number, step = 1) => Array.from({ length: 200 }, (_, i) => start + i * step);
+const crewIds = (startId: number, step = 1) =>
+  Array.from({ length: 200 }, (_, i) => startId + i * step);
 
-describe('breathingRhythm', () => {
-  test('같은 id 는 항상 같은 리듬을 준다', () => {
-    expect(breathingRhythm(42)).toEqual(breathingRhythm(42));
+describe('breathingRhythmOf', () => {
+  test('같은 crewId 는 항상 같은 리듬을 준다', () => {
+    expect(breathingRhythmOf(42)).toEqual(breathingRhythmOf(42));
   });
 
-  test('다른 id 는 다른 리듬을 준다', () => {
-    expect(breathingRhythm(1)).not.toEqual(breathingRhythm(2));
+  test('다른 crewId 는 다른 리듬을 준다', () => {
+    expect(breathingRhythmOf(1)).not.toEqual(breathingRhythmOf(2));
   });
 
   test('주기는 설정한 범위 안에 있다', () => {
-    range(0).forEach((id) => {
-      const { period } = breathingRhythm(id);
-      expect(period).toBeGreaterThanOrEqual(BREATH_PERIOD_MIN);
-      expect(period).toBeLessThanOrEqual(BREATH_PERIOD_MAX);
+    crewIds(0).forEach((crewId) => {
+      const { periodSeconds } = breathingRhythmOf(crewId);
+      expect(periodSeconds).toBeGreaterThanOrEqual(BREATH_PERIOD_MIN_SECONDS);
+      expect(periodSeconds).toBeLessThanOrEqual(BREATH_PERIOD_MAX_SECONDS);
     });
   });
 
-  test('시작 위상은 자기 주기 안에 있다', () => {
-    range(0).forEach((id) => {
-      const { period, phase } = breathingRhythm(id);
-      expect(phase).toBeGreaterThanOrEqual(0);
-      expect(phase).toBeLessThan(period);
+  test('시작 시점은 자기 주기 안에 있다', () => {
+    crewIds(0).forEach((crewId) => {
+      const { periodSeconds, startOffsetSeconds } = breathingRhythmOf(crewId);
+      expect(startOffsetSeconds).toBeGreaterThanOrEqual(0);
+      expect(startOffsetSeconds).toBeLessThan(periodSeconds);
     });
   });
 
-  // crewId 는 연속된 정수라, 옆 번호끼리 값이 비슷하면 실제 방에서 그대로 동시 호흡이 된다.
-  // 실제로 겪을 만한 id 분포를 모두 확인한다.
   describe.each([
-    ['연속된 작은 id', range(0)],
-    ['연속된 큰 id', range(5000)],
-    ['백만 단위 id', range(1_000_000)],
-    ['띄엄띄엄 떨어진 id', range(0, 37)],
+    ['연속된 작은 crewId', crewIds(0)],
+    ['연속된 큰 crewId', crewIds(5000)],
+    ['백만 단위 crewId', crewIds(1_000_000)],
+    ['띄엄띄엄 떨어진 crewId', crewIds(0, 37)],
   ])('%s', (_label, ids) => {
     test('주기가 한쪽으로 몰리지 않는다', () => {
-      bucketize(ids, periodRatio).forEach((count) => expect(count).toBeGreaterThan(20));
+      countPerQuarter(ids, periodRatioOf).forEach((count) => expect(count).toBeGreaterThan(20));
     });
 
-    test('시작 위상도 한쪽으로 몰리지 않는다', () => {
-      bucketize(ids, phaseRatio).forEach((count) => expect(count).toBeGreaterThan(20));
+    test('시작 시점도 한쪽으로 몰리지 않는다', () => {
+      countPerQuarter(ids, startOffsetRatioOf).forEach((count) =>
+        expect(count).toBeGreaterThan(20)
+      );
     });
   });
 
-  test('이웃한 id 끼리 리듬이 붙어 있지 않다', () => {
-    // 1번과 2번이 사실상 같은 박자면 옆에 선 두 사람이 겹쳐 보인다.
-    range(0).forEach((id) => {
-      expect(Math.abs(periodRatio(id) - periodRatio(id + 1))).toBeGreaterThan(0.05);
+  test('이웃한 crewId 끼리 리듬이 붙어 있지 않다', () => {
+    crewIds(0).forEach((crewId) => {
+      expect(Math.abs(periodRatioOf(crewId) - periodRatioOf(crewId + 1))).toBeGreaterThan(0.05);
     });
   });
 });

--- a/src/entities/avatar/lib/breathing-rhythm.test.ts
+++ b/src/entities/avatar/lib/breathing-rhythm.test.ts
@@ -1,0 +1,67 @@
+import breathingRhythm, { BREATH_PERIOD_MAX, BREATH_PERIOD_MIN } from './breathing-rhythm';
+
+/** 값을 4등분 구간에 담아 쏠림을 본다. 한 구간이라도 비면 그만큼 같은 박자가 겹친다. */
+const bucketize = (ids: number[], pick: (id: number) => number) => {
+  const buckets = [0, 0, 0, 0];
+  ids.forEach((id) => buckets[Math.min(3, Math.floor(pick(id) * 4))]++);
+  return buckets;
+};
+
+const periodRatio = (id: number) =>
+  (breathingRhythm(id).period - BREATH_PERIOD_MIN) / (BREATH_PERIOD_MAX - BREATH_PERIOD_MIN);
+const phaseRatio = (id: number) => {
+  const { period, phase } = breathingRhythm(id);
+  return phase / period;
+};
+
+const range = (start: number, step = 1) => Array.from({ length: 200 }, (_, i) => start + i * step);
+
+describe('breathingRhythm', () => {
+  test('같은 id 는 항상 같은 리듬을 준다', () => {
+    expect(breathingRhythm(42)).toEqual(breathingRhythm(42));
+  });
+
+  test('다른 id 는 다른 리듬을 준다', () => {
+    expect(breathingRhythm(1)).not.toEqual(breathingRhythm(2));
+  });
+
+  test('주기는 설정한 범위 안에 있다', () => {
+    range(0).forEach((id) => {
+      const { period } = breathingRhythm(id);
+      expect(period).toBeGreaterThanOrEqual(BREATH_PERIOD_MIN);
+      expect(period).toBeLessThanOrEqual(BREATH_PERIOD_MAX);
+    });
+  });
+
+  test('시작 위상은 자기 주기 안에 있다', () => {
+    range(0).forEach((id) => {
+      const { period, phase } = breathingRhythm(id);
+      expect(phase).toBeGreaterThanOrEqual(0);
+      expect(phase).toBeLessThan(period);
+    });
+  });
+
+  // crewId 는 연속된 정수라, 옆 번호끼리 값이 비슷하면 실제 방에서 그대로 동시 호흡이 된다.
+  // 실제로 겪을 만한 id 분포를 모두 확인한다.
+  describe.each([
+    ['연속된 작은 id', range(0)],
+    ['연속된 큰 id', range(5000)],
+    ['백만 단위 id', range(1_000_000)],
+    ['띄엄띄엄 떨어진 id', range(0, 37)],
+  ])('%s', (_label, ids) => {
+    test('주기가 한쪽으로 몰리지 않는다', () => {
+      bucketize(ids, periodRatio).forEach((count) => expect(count).toBeGreaterThan(20));
+    });
+
+    test('시작 위상도 한쪽으로 몰리지 않는다', () => {
+      bucketize(ids, phaseRatio).forEach((count) => expect(count).toBeGreaterThan(20));
+    });
+  });
+
+  test('이웃한 id 끼리 리듬이 붙어 있지 않다', () => {
+    // 1번과 2번이 사실상 같은 박자면 옆에 선 두 사람이 겹쳐 보인다.
+    range(0).forEach((id) => {
+      expect(Math.abs(periodRatio(id) - periodRatio(id + 1))).toBeGreaterThan(0.05);
+    });
+  });
+});

--- a/src/entities/avatar/lib/breathing-rhythm.ts
+++ b/src/entities/avatar/lib/breathing-rhythm.ts
@@ -1,10 +1,14 @@
+/** 가장 빠르게 숨쉬는 아바타의 주기. 이보다 짧으면 호흡보다 떨림으로 보인다. */
 export const BREATH_PERIOD_MIN_SECONDS = 1.05;
+/** 가장 느리게 숨쉬는 아바타의 주기. 이보다 길면 멈춘 것처럼 늘어져 보인다. */
 export const BREATH_PERIOD_MAX_SECONDS = 1.75;
 
+/** 주기를 흩는 데 쓰는 무리수. 연속 정수를 가장 고르게 퍼뜨리는 값으로 알려져 있다. */
 const GOLDEN_RATIO_CONJUGATE = 0.618033988749895;
+/** 시작 시점을 흩는 데 쓰는 무리수. 주기와 다른 값이어야 둘이 함께 움직이지 않는다. */
 const PLASTIC_NUMBER_CONJUGATE = 0.754877666246693;
 
-/** 무리수를 곱한 소수부는 연속된 정수를 고르게 흩는다. crewId 가 1, 2, 3… 으로 이어지므로 이 성질이 없으면 옆 번호끼리 리듬이 붙는다. */
+/** crewId 는 1, 2, 3… 으로 이어지므로 옆 번호끼리 값이 붙지 않게 무리수 곱의 소수부로 흩는다. */
 const evenlySpreadRatio = (crewId: number, irrational: number) => {
   const scaled = crewId * irrational;
   return scaled - Math.floor(scaled);

--- a/src/entities/avatar/lib/breathing-rhythm.ts
+++ b/src/entities/avatar/lib/breathing-rhythm.ts
@@ -1,51 +1,31 @@
-/**
- * 정지 아바타(MotionType.NONE)의 호흡 리듬을 아바타마다 다르게 만든다.
- *
- * 전원이 같은 박자로 부풀었다 줄어들면 군집이 한 몸처럼 호흡하는 인상이라 보기 불편하다(#463).
- * 그래서 사람마다 주기와 시작 위상을 따로 준다.
- *
- * crewId 로 값을 정하므로 리렌더·입퇴장에도 같은 사람은 같은 리듬을 유지한다.
- * 난수나 배열 index 를 쓰면 누가 들어오고 나갈 때마다 리듬이 통째로 재배치된다.
- */
+export const BREATH_PERIOD_MIN_SECONDS = 1.05;
+export const BREATH_PERIOD_MAX_SECONDS = 1.75;
 
-/**
- * 호흡 주기 범위 (초).
- *
- * 실제 사람 호흡(3~4초)에 맞춰봤더니 아바타가 늘어져 보였다. 화면 안에서는 사실성보다
- * 살아있는 느낌이 먼저라, 기존 1초 고정과 비슷한 템포를 유지하되 사람마다 폭을 준다.
- * 눈으로 보고 맞춘 값이라 조정해도 되는 숫자다 — 범위만 유지하면 분산은 알아서 따라온다.
- */
-export const BREATH_PERIOD_MIN = 1.05;
-export const BREATH_PERIOD_MAX = 1.75;
+const GOLDEN_RATIO_CONJUGATE = 0.618033988749895;
+const PLASTIC_NUMBER_CONJUGATE = 0.754877666246693;
 
-/**
- * 무리수를 곱한 소수부.
- *
- * crewId 는 1, 2, 3… 처럼 연속된 정수다. 무리수 곱의 소수부는 이런 연속값을 고르게 흩는
- * 성질이 있어서(저분산 수열), 해시 없이도 옆 번호끼리 멀리 떨어진다.
- */
-const frac = (n: number, irrational: number): number => {
-  const x = n * irrational;
-  return x - Math.floor(x);
+/** 무리수를 곱한 소수부는 연속된 정수를 고르게 흩는다. crewId 가 1, 2, 3… 으로 이어지므로 이 성질이 없으면 옆 번호끼리 리듬이 붙는다. */
+const evenlySpreadRatio = (crewId: number, irrational: number) => {
+  const scaled = crewId * irrational;
+  return scaled - Math.floor(scaled);
 };
-
-/** 황금비 켤레. 연속 정수를 가장 고르게 흩는 값으로 알려져 있다. */
-const GOLDEN = 0.618033988749895;
-/** 주기와 겹치지 않는 별개의 수열을 얻기 위한 두 번째 무리수. */
-const PLASTIC = 0.754877666246693;
 
 export type BreathingRhythm = {
-  /** 한 번 들이쉬고 내쉬는 데 걸리는 시간 (초) */
-  period: number;
-  /** 시작 시점 어긋내기 (초, 0 이상 period 미만) */
-  phase: number;
+  periodSeconds: number;
+  startOffsetSeconds: number;
 };
 
-/** crewId → 그 아바타의 호흡 리듬. 같은 id 는 항상 같은 결과. */
-const breathingRhythm = (crewId: number): BreathingRhythm => {
-  const period = BREATH_PERIOD_MIN + frac(crewId, GOLDEN) * (BREATH_PERIOD_MAX - BREATH_PERIOD_MIN);
+/** 아바타가 저마다 다른 박자로 숨쉬게 한다. 같은 crewId 는 항상 같은 리듬이라 입퇴장이나 리렌더에도 리듬이 바뀌지 않는다. */
+const breathingRhythmOf = (crewId: number): BreathingRhythm => {
+  const periodSeconds =
+    BREATH_PERIOD_MIN_SECONDS +
+    evenlySpreadRatio(crewId, GOLDEN_RATIO_CONJUGATE) *
+      (BREATH_PERIOD_MAX_SECONDS - BREATH_PERIOD_MIN_SECONDS);
 
-  return { period, phase: frac(crewId, PLASTIC) * period };
+  return {
+    periodSeconds,
+    startOffsetSeconds: evenlySpreadRatio(crewId, PLASTIC_NUMBER_CONJUGATE) * periodSeconds,
+  };
 };
 
-export default breathingRhythm;
+export default breathingRhythmOf;

--- a/src/entities/avatar/lib/breathing-rhythm.ts
+++ b/src/entities/avatar/lib/breathing-rhythm.ts
@@ -1,0 +1,51 @@
+/**
+ * 정지 아바타(MotionType.NONE)의 호흡 리듬을 아바타마다 다르게 만든다.
+ *
+ * 전원이 같은 박자로 부풀었다 줄어들면 군집이 한 몸처럼 호흡하는 인상이라 보기 불편하다(#463).
+ * 그래서 사람마다 주기와 시작 위상을 따로 준다.
+ *
+ * crewId 로 값을 정하므로 리렌더·입퇴장에도 같은 사람은 같은 리듬을 유지한다.
+ * 난수나 배열 index 를 쓰면 누가 들어오고 나갈 때마다 리듬이 통째로 재배치된다.
+ */
+
+/**
+ * 호흡 주기 범위 (초).
+ *
+ * 실제 사람 호흡(3~4초)에 맞춰봤더니 아바타가 늘어져 보였다. 화면 안에서는 사실성보다
+ * 살아있는 느낌이 먼저라, 기존 1초 고정과 비슷한 템포를 유지하되 사람마다 폭을 준다.
+ * 눈으로 보고 맞춘 값이라 조정해도 되는 숫자다 — 범위만 유지하면 분산은 알아서 따라온다.
+ */
+export const BREATH_PERIOD_MIN = 1.05;
+export const BREATH_PERIOD_MAX = 1.75;
+
+/**
+ * 무리수를 곱한 소수부.
+ *
+ * crewId 는 1, 2, 3… 처럼 연속된 정수다. 무리수 곱의 소수부는 이런 연속값을 고르게 흩는
+ * 성질이 있어서(저분산 수열), 해시 없이도 옆 번호끼리 멀리 떨어진다.
+ */
+const frac = (n: number, irrational: number): number => {
+  const x = n * irrational;
+  return x - Math.floor(x);
+};
+
+/** 황금비 켤레. 연속 정수를 가장 고르게 흩는 값으로 알려져 있다. */
+const GOLDEN = 0.618033988749895;
+/** 주기와 겹치지 않는 별개의 수열을 얻기 위한 두 번째 무리수. */
+const PLASTIC = 0.754877666246693;
+
+export type BreathingRhythm = {
+  /** 한 번 들이쉬고 내쉬는 데 걸리는 시간 (초) */
+  period: number;
+  /** 시작 시점 어긋내기 (초, 0 이상 period 미만) */
+  phase: number;
+};
+
+/** crewId → 그 아바타의 호흡 리듬. 같은 id 는 항상 같은 결과. */
+const breathingRhythm = (crewId: number): BreathingRhythm => {
+  const period = BREATH_PERIOD_MIN + frac(crewId, GOLDEN) * (BREATH_PERIOD_MAX - BREATH_PERIOD_MIN);
+
+  return { period, phase: frac(crewId, PLASTIC) * period };
+};
+
+export default breathingRhythm;

--- a/src/entities/avatar/ui/useAvatarDance.hook.ts
+++ b/src/entities/avatar/ui/useAvatarDance.hook.ts
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { MotionType } from '@/shared/api/http/types/@enums';
-import breathingRhythm, { BreathingRhythm } from '../lib/breathing-rhythm';
+import breathingRhythmOf, { BreathingRhythm } from '../lib/breathing-rhythm';
 
 const SIN_LUT = new Float32Array(360);
 for (let i = 0; i < 360; i++) {
@@ -10,19 +10,17 @@ for (let i = 0; i < 360; i++) {
 const normalizeAngle = (angle: number) => ((angle % 360) + 360) % 360;
 const fastSin = (angle: number) => SIN_LUT[normalizeAngle(Math.floor(angle))];
 
+/** 아바타마다 다르게 주면 서로 크기가 달라 보이므로 공통값으로 둔다. */
+const BREATH_DEPTH = 0.04;
+
 type AvatarEntry = {
   el: HTMLElement;
   motionType: MotionType;
   breathing: BreathingRhythm;
 };
 
-/**
- * 호흡 리듬의 기준값. 아바타를 감싸는 요소의 `data-crew-id` 를 쓴다 —
- * 사람마다 고유하고 세션 내내 안 바뀌므로 "같은 사람은 같은 리듬" 이 유지된다.
- * 배열 index 는 입퇴장 때마다 밀려서 못 쓴다.
- */
-const crewIdOf = (el: HTMLElement, fallback: number): number =>
-  Number(el.closest('[data-crew-id]')?.getAttribute('data-crew-id')) || fallback;
+const crewIdOf = (el: HTMLElement, fallbackId: number): number =>
+  Number(el.closest('[data-crew-id]')?.getAttribute('data-crew-id')) || fallbackId;
 
 export function useAvatarDance() {
   const avatarEntries = useRef<AvatarEntry[]>([]);
@@ -39,8 +37,7 @@ export function useAvatarDance() {
       avatarEntries.current.push({
         el,
         motionType,
-        // 프레임 루프에서 매번 계산하지 않도록 등록 시 1회만 구한다.
-        breathing: breathingRhythm(crewIdOf(el, avatarEntries.current.length)),
+        breathing: breathingRhythmOf(crewIdOf(el, avatarEntries.current.length)),
       });
     }
   };
@@ -91,12 +88,10 @@ export function useAvatarDance() {
 
           transform = `translateY(${-y}px) scale(${s})`;
         } else if (motionType === MotionType.NONE) {
-          // 숨쉬는 듯한 모션. 주기·시작 위상은 아바타마다 다르다 (#463).
-          const { period, phase } = breathing;
-          const breathPhase = ((t + phase) % period) / period;
-          const breathWave = (fastSin(breathPhase * 360) + 1) / 2;
-          const scaleChange = 0.04; // 크기 변화량 — 사람마다 같아야 크기가 달라 보이지 않는다
-          const scale = 1 + scaleChange * breathWave;
+          const { periodSeconds, startOffsetSeconds } = breathing;
+          const breathProgress = ((t + startOffsetSeconds) % periodSeconds) / periodSeconds;
+          const breathWave = (fastSin(breathProgress * 360) + 1) / 2;
+          const scale = 1 + BREATH_DEPTH * breathWave;
           transform = `scale(${scale})`;
         }
 

--- a/src/entities/avatar/ui/useAvatarDance.hook.ts
+++ b/src/entities/avatar/ui/useAvatarDance.hook.ts
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { MotionType } from '@/shared/api/http/types/@enums';
+import breathingRhythm, { BreathingRhythm } from '../lib/breathing-rhythm';
 
 const SIN_LUT = new Float32Array(360);
 for (let i = 0; i < 360; i++) {
@@ -12,7 +13,16 @@ const fastSin = (angle: number) => SIN_LUT[normalizeAngle(Math.floor(angle))];
 type AvatarEntry = {
   el: HTMLElement;
   motionType: MotionType;
+  breathing: BreathingRhythm;
 };
+
+/**
+ * 호흡 리듬의 기준값. 아바타를 감싸는 요소의 `data-crew-id` 를 쓴다 —
+ * 사람마다 고유하고 세션 내내 안 바뀌므로 "같은 사람은 같은 리듬" 이 유지된다.
+ * 배열 index 는 입퇴장 때마다 밀려서 못 쓴다.
+ */
+const crewIdOf = (el: HTMLElement, fallback: number): number =>
+  Number(el.closest('[data-crew-id]')?.getAttribute('data-crew-id')) || fallback;
 
 export function useAvatarDance() {
   const avatarEntries = useRef<AvatarEntry[]>([]);
@@ -29,6 +39,8 @@ export function useAvatarDance() {
       avatarEntries.current.push({
         el,
         motionType,
+        // 프레임 루프에서 매번 계산하지 않도록 등록 시 1회만 구한다.
+        breathing: breathingRhythm(crewIdOf(el, avatarEntries.current.length)),
       });
     }
   };
@@ -42,7 +54,7 @@ export function useAvatarDance() {
       const t = ((time - startTimeRef.current) / 1000) * speed;
 
       avatarEntries.current.forEach((entry, index) => {
-        const { el, motionType } = entry;
+        const { el, motionType, breathing } = entry;
         const offset = index * 36;
         const angle = t * 360 + offset;
 
@@ -79,11 +91,11 @@ export function useAvatarDance() {
 
           transform = `translateY(${-y}px) scale(${s})`;
         } else if (motionType === MotionType.NONE) {
-          // 숨쉬는 듯한 모션
-          const breathPeriod = 1; // 호흡 주기 (초)
-          const breathPhase = (t % breathPeriod) / breathPeriod;
+          // 숨쉬는 듯한 모션. 주기·시작 위상은 아바타마다 다르다 (#463).
+          const { period, phase } = breathing;
+          const breathPhase = ((t + phase) % period) / period;
           const breathWave = (fastSin(breathPhase * 360) + 1) / 2;
-          const scaleChange = 0.04; // 크기 변화량
+          const scaleChange = 0.04; // 크기 변화량 — 사람마다 같아야 크기가 달라 보이지 않는다
           const scale = 1 + scaleChange * breathWave;
           transform = `scale(${scale})`;
         }


### PR DESCRIPTION
### Summary

정지 상태 아바타들이 전부 같은 박자로 동시에 숨을 쉬어서, 군집이 한 몸처럼 호흡하는 것처럼 보이던 문제를 고칩니다.

- 호흡 주기와 시작 시점이 아바타마다 다릅니다 (주기 1.05~1.75초, 기존 전원 1초 고정)
- 숨의 깊이는 그대로 뒀습니다 — 이것까지 개별화하면 아바타들이 서로 다른 크기로 보입니다
- 춤 모션 2종은 손대지 않았습니다

### Decisions

리듬은 `crewId`로 정합니다. 같은 사람은 화면이 갱신되거나 다른 사람이 드나들어도 항상 같은 리듬이어야 하는데, 난수나 목록 순서를 쓰면 누가 나갈 때마다 남은 사람들의 리듬이 통째로 재배치됩니다.

### Todo

- [x] 육안 확인 — 작성자가 직접 화면에서 확인했고, 그 피드백으로 주기를 확정했습니다

주기 값(`BREATH_PERIOD_MIN/MAX`)은 눈으로 맞춘 숫자입니다. 리뷰 중 더 빠르거나 느린 게 낫다고 느끼시면 상수 두 줄만 바꾸면 됩니다.

### Issue

Closes #463

### Reference

- 검증: `tsc --noEmit` 오류 0, 전체 313개 파일 / 1746개 테스트 통과
