### PR TITLE
feat: 브라우저별 PWA 설치 안내 분기 (#461)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import '@/shared/ui/foundation/touch-reset.css';
 
 import { PropsWithChildren } from 'react';
 
+import { InstallPromptCapture } from '@/features/pwa-install';
 import { SystemAnnouncementSubscriber } from '@/features/system-announcement';
 import {
   AnnouncementSnapshot,
@@ -109,6 +110,7 @@ const RootLayout = async ({ children }: PropsWithChildren) => {
         </ReactQueryProvider>
 
         <ServiceWorkerRegister />
+        <InstallPromptCapture />
         <div id={DomId.DrawerRoot} />
         <div id={DomId.TooltipRoot} className='pointer-events-none fixed inset-0 z-tooltip' />
       </body>

--- a/src/features/push-notification/lib/push-support.ts
+++ b/src/features/push-notification/lib/push-support.ts
@@ -1,3 +1,8 @@
+import { isIOS, isStandalone } from '@/shared/lib/browser/browser-environment';
+
+// pwa-install feature 와 같은 판별을 쓰므로 shared 로 옮겼다. 기존 import 경로는 유지한다.
+export { isIOS, isStandalone };
+
 /**
  * base64url(VAPID 공개키) → Uint8Array.
  * PushManager.subscribe 의 applicationServerKey 는 raw bytes 를 요구한다.
@@ -15,14 +20,6 @@ export const isPushSupported = (): boolean =>
   'serviceWorker' in navigator &&
   'PushManager' in window &&
   'Notification' in window;
-
-export const isIOS = (ua: string): boolean => /iPhone|iPad|iPod/i.test(ua);
-
-/** PWA standalone(홈화면 추가) 모드 여부. (SSR-safe) */
-export const isStandalone = (): boolean =>
-  typeof window !== 'undefined' &&
-  (window.matchMedia('(display-mode: standalone)').matches ||
-    (window.navigator as unknown as { standalone?: boolean }).standalone === true);
 
 /** iOS Safari 는 홈화면 추가(standalone) 전에는 Web Push 불가 → 설치 유도 필요. */
 export const iosNeedsInstall = (ua: string, standalone: boolean): boolean =>

--- a/src/features/pwa-install/index.ts
+++ b/src/features/pwa-install/index.ts
@@ -1,0 +1,2 @@
+export { default as InstallPromptCapture } from './ui/install-prompt-capture.component';
+export { default as useInstallGuide } from './ui/use-install-guide.hook';

--- a/src/features/pwa-install/index.ts
+++ b/src/features/pwa-install/index.ts
@@ -1,2 +1,2 @@
+export { default as InstallFab } from './ui/install-fab.component';
 export { default as InstallPromptCapture } from './ui/install-prompt-capture.component';
-export { default as useInstallGuide } from './ui/use-install-guide.hook';

--- a/src/features/pwa-install/lib/install-environment.test.ts
+++ b/src/features/pwa-install/lib/install-environment.test.ts
@@ -40,9 +40,9 @@ describe('installEnvironment', () => {
     expect(env(ANDROID_KAKAO, { hasInstallPrompt: true })).toBe('in-app-browser');
   });
 
-  test('프롬프트를 못 잡은 Android·데스크톱은 unsupported (진입점 숨김)', () => {
-    expect(env(ANDROID_CHROME)).toBe('unsupported');
-    expect(env(DESKTOP)).toBe('unsupported');
+  test('프롬프트를 못 잡은 Android·데스크톱은 manual-guide (수동 안내로 노출)', () => {
+    expect(env(ANDROID_CHROME)).toBe('manual-guide');
+    expect(env(DESKTOP)).toBe('manual-guide');
   });
 
   test('설치 완료가 다른 모든 판정보다 우선한다', () => {

--- a/src/features/pwa-install/lib/install-environment.test.ts
+++ b/src/features/pwa-install/lib/install-environment.test.ts
@@ -1,0 +1,51 @@
+import { installEnvironment } from './install-environment';
+
+const IOS_SAFARI = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Version/17.0 Safari';
+const ANDROID_CHROME = 'Mozilla/5.0 (Linux; Android 14; SM-S911N) Chrome/120.0.0.0 Mobile Safari';
+const IOS_KAKAO = `${IOS_SAFARI} KAKAOTALK 10.4.0`;
+const ANDROID_KAKAO = 'Mozilla/5.0 (Linux; Android 14; wv) Chrome/120 KAKAOTALK/10.4.0';
+const INSTAGRAM = `${IOS_SAFARI} Instagram 300.0.0`;
+const DESKTOP = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0 Safari/537.36';
+
+const env = (userAgent: string, over: Partial<Parameters<typeof installEnvironment>[0]> = {}) =>
+  installEnvironment({ userAgent, standalone: false, hasInstallPrompt: false, ...over });
+
+describe('installEnvironment', () => {
+  test('이미 설치돼 standalone 이면 어떤 브라우저든 installed', () => {
+    [IOS_SAFARI, ANDROID_CHROME, DESKTOP].forEach((ua) => {
+      expect(env(ua, { standalone: true })).toBe('installed');
+    });
+  });
+
+  test('설치 프롬프트를 잡아둔 Android 는 prompt', () => {
+    expect(env(ANDROID_CHROME, { hasInstallPrompt: true })).toBe('prompt');
+  });
+
+  test('iOS Safari 는 설치 API 가 없으므로 ios-guide', () => {
+    expect(env(IOS_SAFARI)).toBe('ios-guide');
+  });
+
+  test('인앱 웹뷰는 in-app-browser', () => {
+    [IOS_KAKAO, ANDROID_KAKAO, INSTAGRAM].forEach((ua) => {
+      expect(env(ua)).toBe('in-app-browser');
+    });
+  });
+
+  test('iOS 카카오톡은 iOS 지만 설치가 불가능하므로 in-app-browser 가 우선한다', () => {
+    expect(env(IOS_KAKAO)).toBe('in-app-browser');
+    expect(env(IOS_KAKAO)).not.toBe('ios-guide');
+  });
+
+  test('인앱 웹뷰는 설치 프롬프트가 있다고 주장해도 in-app-browser', () => {
+    expect(env(ANDROID_KAKAO, { hasInstallPrompt: true })).toBe('in-app-browser');
+  });
+
+  test('프롬프트를 못 잡은 Android·데스크톱은 unsupported (진입점 숨김)', () => {
+    expect(env(ANDROID_CHROME)).toBe('unsupported');
+    expect(env(DESKTOP)).toBe('unsupported');
+  });
+
+  test('설치 완료가 다른 모든 판정보다 우선한다', () => {
+    expect(env(IOS_KAKAO, { standalone: true })).toBe('installed');
+  });
+});

--- a/src/features/pwa-install/lib/install-environment.ts
+++ b/src/features/pwa-install/lib/install-environment.ts
@@ -17,8 +17,8 @@ export type InstallEnvironment =
   | 'ios-guide'
   /** 외부 브라우저로 여는 법을 안내한다 */
   | 'in-app-browser'
-  /** 설치 개념이 없거나 지원하지 않는 환경 — 진입점을 숨긴다 */
-  | 'unsupported';
+  /** 네이티브 설치창이 없는 브라우저 — 홈 화면 추가 경로를 브라우저별로 안내한다 */
+  | 'manual-guide';
 
 type Input = {
   userAgent: string;
@@ -41,5 +41,5 @@ export const installEnvironment = ({
 
   if (isIOS(userAgent)) return 'ios-guide';
 
-  return 'unsupported';
+  return 'manual-guide';
 };

--- a/src/features/pwa-install/lib/install-environment.ts
+++ b/src/features/pwa-install/lib/install-environment.ts
@@ -1,0 +1,45 @@
+import { isIOS, isInAppBrowser } from '@/shared/lib/browser/browser-environment';
+
+/**
+ * 설치 안내를 어떤 방식으로 보여줘야 하는지.
+ *
+ * 브라우저마다 설치 경로가 달라서 하나의 안내로는 커버가 안 된다 (#461).
+ * - Android Chromium 은 beforeinstallprompt 로 네이티브 설치창을 띄울 수 있다
+ * - iOS Safari 는 설치 API 자체가 없어서 공유 → 홈 화면에 추가를 손으로 눌러야 한다
+ * - 인앱 웹뷰는 설치 수단이 없어서 외부 브라우저로 나가야 한다
+ */
+export type InstallEnvironment =
+  /** 이미 홈 화면에서 실행 중 — 안내할 게 없다 */
+  | 'installed'
+  /** 네이티브 설치창을 띄울 수 있다 */
+  | 'prompt'
+  /** 수동 설치 단계를 안내한다 */
+  | 'ios-guide'
+  /** 외부 브라우저로 여는 법을 안내한다 */
+  | 'in-app-browser'
+  /** 설치 개념이 없거나 지원하지 않는 환경 — 진입점을 숨긴다 */
+  | 'unsupported';
+
+type Input = {
+  userAgent: string;
+  standalone: boolean;
+  /** beforeinstallprompt 이벤트를 잡아둔 상태인지 */
+  hasInstallPrompt: boolean;
+};
+
+export const installEnvironment = ({
+  userAgent,
+  standalone,
+  hasInstallPrompt,
+}: Input): InstallEnvironment => {
+  if (standalone) return 'installed';
+
+  // 인앱 웹뷰를 iOS 판별보다 먼저 본다 — iOS 카카오톡은 둘 다 참이지만 설치는 불가능하다.
+  if (isInAppBrowser(userAgent)) return 'in-app-browser';
+
+  if (hasInstallPrompt) return 'prompt';
+
+  if (isIOS(userAgent)) return 'ios-guide';
+
+  return 'unsupported';
+};

--- a/src/features/pwa-install/lib/install-prompt.test.ts
+++ b/src/features/pwa-install/lib/install-prompt.test.ts
@@ -1,0 +1,75 @@
+import { hasInstallPrompt, showInstallPrompt, subscribeInstallPrompt } from './install-prompt';
+
+/** beforeinstallprompt 를 흉내낸다. jsdom 에는 이 이벤트가 없다. */
+const fireBeforeInstallPrompt = (outcome: 'accepted' | 'dismissed' = 'accepted') => {
+  const event = new Event('beforeinstallprompt') as Event & {
+    prompt: () => Promise<void>;
+    userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+  };
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome });
+  window.dispatchEvent(event);
+  return event;
+};
+
+beforeEach(async () => {
+  // 앞 테스트가 남긴 이벤트를 비운다.
+  window.dispatchEvent(new Event('appinstalled'));
+});
+
+describe('install-prompt', () => {
+  test('이벤트가 오기 전에는 띄울 프롬프트가 없다', () => {
+    expect(hasInstallPrompt()).toBe(false);
+  });
+
+  test('beforeinstallprompt 를 잡아두면 사용 가능해진다', () => {
+    fireBeforeInstallPrompt();
+    expect(hasInstallPrompt()).toBe(true);
+  });
+
+  test('사용자가 설치를 수락하면 true', async () => {
+    fireBeforeInstallPrompt('accepted');
+    await expect(showInstallPrompt()).resolves.toBe(true);
+  });
+
+  test('사용자가 설치를 거절하면 false', async () => {
+    fireBeforeInstallPrompt('dismissed');
+    await expect(showInstallPrompt()).resolves.toBe(false);
+  });
+
+  test('프롬프트는 1회용이다 — 한 번 띄우면 다시 못 쓴다', async () => {
+    const event = fireBeforeInstallPrompt();
+
+    await showInstallPrompt();
+    expect(hasInstallPrompt()).toBe(false);
+
+    await expect(showInstallPrompt()).resolves.toBe(false);
+    // 브라우저가 거부하므로 두 번째는 아예 호출하지 않는다.
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('잡아둔 프롬프트가 없으면 아무 일도 없이 false', async () => {
+    await expect(showInstallPrompt()).resolves.toBe(false);
+  });
+
+  test('설치가 끝나면(appinstalled) 프롬프트를 버린다', () => {
+    fireBeforeInstallPrompt();
+    window.dispatchEvent(new Event('appinstalled'));
+    expect(hasInstallPrompt()).toBe(false);
+  });
+
+  test('상태가 바뀌면 구독자에게 알린다', async () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeInstallPrompt(onChange);
+
+    fireBeforeInstallPrompt();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    await showInstallPrompt();
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    fireBeforeInstallPrompt();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/pwa-install/lib/install-prompt.ts
+++ b/src/features/pwa-install/lib/install-prompt.ts
@@ -1,0 +1,54 @@
+/**
+ * Android Chromium 의 `beforeinstallprompt` 이벤트를 잡아두는 모듈 단위 저장소.
+ *
+ * 이 이벤트는 페이지 로드 직후 딱 한 번 발생한다. 사용자가 메뉴를 여는 시점에 리스너를 붙이면
+ * 이미 지나가 버려서 설치창을 띄울 수 없다. 그래서 모듈이 로드되는 즉시 리스너를 건다
+ * (루트 레이아웃에서 import 하므로 앱 부팅 시점이다).
+ */
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+};
+
+let deferred: BeforeInstallPromptEvent | null = null;
+const subscribers = new Set<() => void>();
+
+const notify = () => subscribers.forEach((fn) => fn());
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (event) => {
+    // 브라우저 기본 미니 배너를 막고, 우리 진입점에서 원하는 시점에 띄운다.
+    event.preventDefault();
+    deferred = event as BeforeInstallPromptEvent;
+    notify();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferred = null;
+    notify();
+  });
+}
+
+export const subscribeInstallPrompt = (onChange: () => void) => {
+  subscribers.add(onChange);
+  return () => {
+    subscribers.delete(onChange);
+  };
+};
+
+export const hasInstallPrompt = () => deferred !== null;
+
+/** 네이티브 설치창을 띄우고, 사용자가 설치를 수락했는지 반환한다. */
+export const showInstallPrompt = async (): Promise<boolean> => {
+  if (!deferred) return false;
+
+  // 프롬프트는 1회용이다. 같은 이벤트를 두 번 쓰면 브라우저가 거부한다.
+  const event = deferred;
+  deferred = null;
+  notify();
+
+  await event.prompt();
+  const { outcome } = await event.userChoice;
+  return outcome === 'accepted';
+};

--- a/src/features/pwa-install/lib/use-install-environment.hook.ts
+++ b/src/features/pwa-install/lib/use-install-environment.hook.ts
@@ -9,11 +9,11 @@ import { hasInstallPrompt, subscribeInstallPrompt } from './install-prompt';
  * 지금 브라우저에 어떤 설치 안내를 보여줘야 하는지.
  *
  * userAgent·standalone 은 클라이언트에만 있으므로 마운트 후에 계산한다.
- * 서버 렌더와 첫 페인트에서는 'unsupported' — 진입점이 잠깐 보였다 사라지는 것보다
+ * 서버 렌더와 첫 페인트에서는 null — 진입점이 잠깐 보였다 사라지는 것보다
  * 늦게 나타나는 편이 낫다.
  */
-export default function useInstallEnvironment(): InstallEnvironment {
-  const [environment, setEnvironment] = useState<InstallEnvironment>('unsupported');
+export default function useInstallEnvironment(): InstallEnvironment | null {
+  const [environment, setEnvironment] = useState<InstallEnvironment | null>(null);
 
   useEffect(() => {
     const update = () =>

--- a/src/features/pwa-install/lib/use-install-environment.hook.ts
+++ b/src/features/pwa-install/lib/use-install-environment.hook.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import { isStandalone } from '@/shared/lib/browser/browser-environment';
+import { installEnvironment, InstallEnvironment } from './install-environment';
+import { hasInstallPrompt, subscribeInstallPrompt } from './install-prompt';
+
+/**
+ * 지금 브라우저에 어떤 설치 안내를 보여줘야 하는지.
+ *
+ * userAgent·standalone 은 클라이언트에만 있으므로 마운트 후에 계산한다.
+ * 서버 렌더와 첫 페인트에서는 'unsupported' — 진입점이 잠깐 보였다 사라지는 것보다
+ * 늦게 나타나는 편이 낫다.
+ */
+export default function useInstallEnvironment(): InstallEnvironment {
+  const promptAvailable = useSyncExternalStore(
+    subscribeInstallPrompt,
+    hasInstallPrompt,
+    () => false
+  );
+  const [environment, setEnvironment] = useState<InstallEnvironment>('unsupported');
+
+  useEffect(() => {
+    setEnvironment(
+      installEnvironment({
+        userAgent: navigator.userAgent,
+        standalone: isStandalone(),
+        hasInstallPrompt: promptAvailable,
+      })
+    );
+  }, [promptAvailable]);
+
+  return environment;
+}

--- a/src/features/pwa-install/lib/use-install-environment.hook.ts
+++ b/src/features/pwa-install/lib/use-install-environment.hook.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useEffect, useState } from 'react';
 import { isStandalone } from '@/shared/lib/browser/browser-environment';
 import { installEnvironment, InstallEnvironment } from './install-environment';
 import { hasInstallPrompt, subscribeInstallPrompt } from './install-prompt';
@@ -13,22 +13,21 @@ import { hasInstallPrompt, subscribeInstallPrompt } from './install-prompt';
  * 늦게 나타나는 편이 낫다.
  */
 export default function useInstallEnvironment(): InstallEnvironment {
-  const promptAvailable = useSyncExternalStore(
-    subscribeInstallPrompt,
-    hasInstallPrompt,
-    () => false
-  );
   const [environment, setEnvironment] = useState<InstallEnvironment>('unsupported');
 
   useEffect(() => {
-    setEnvironment(
-      installEnvironment({
-        userAgent: navigator.userAgent,
-        standalone: isStandalone(),
-        hasInstallPrompt: promptAvailable,
-      })
-    );
-  }, [promptAvailable]);
+    const update = () =>
+      setEnvironment(
+        installEnvironment({
+          userAgent: navigator.userAgent,
+          standalone: isStandalone(),
+          hasInstallPrompt: hasInstallPrompt(),
+        })
+      );
+
+    update();
+    return subscribeInstallPrompt(update);
+  }, []);
 
   return environment;
 }

--- a/src/features/pwa-install/ui/install-fab.component.test.tsx
+++ b/src/features/pwa-install/ui/install-fab.component.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import InstallFab from './install-fab.component';
+
+const openInstallGuideMock = vi.fn();
+/** 설치 진입점은 환경에 따라 숨겨진다 — 테스트마다 갈아끼운다. */
+let canInstall = true;
+
+vi.mock('./use-install-guide.hook', () => ({
+  __esModule: true,
+  default: () => ({ canInstall, openInstallGuide: openInstallGuideMock }),
+}));
+
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    pwa: {
+      menu_label: '앱 설치하기',
+    },
+  }),
+}));
+
+describe('InstallFab', () => {
+  beforeEach(() => {
+    openInstallGuideMock.mockClear();
+    canInstall = true;
+  });
+
+  test('설치 가능하면 버튼이 보인다', () => {
+    render(<InstallFab />);
+    expect(screen.getByRole('button', { name: '앱 설치하기' })).toBeInTheDocument();
+  });
+
+  test('이미 설치했거나 설치 불가 환경이면 아무것도 렌더하지 않는다', () => {
+    canInstall = false;
+    const { container } = render(<InstallFab />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('클릭 → 설치 안내를 연다', async () => {
+    render(<InstallFab />);
+    await userEvent.click(screen.getByRole('button', { name: '앱 설치하기' }));
+    expect(openInstallGuideMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/pwa-install/ui/install-fab.component.tsx
+++ b/src/features/pwa-install/ui/install-fab.component.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { FC } from 'react';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import useInstallGuide from './use-install-guide.hook';
+
+/**
+ * 모바일 로비 우측 하단에 떠 있는 설치 진입점.
+ *
+ * 로비에만 둔다 — 파티룸은 화면이 이미 꽉 차 있고, 설치를 권할 만한 시점은 앱을 계속
+ * 쓸 마음이 생기는 로비다. 로비 한 화면뿐이라 닫기 버튼은 두지 않았다: 설치하면
+ * `canInstall` 이 false 가 되어 알아서 사라진다.
+ *
+ * `z-drawer`(30) 미만이라 드로어·다이얼로그가 열리면 그 아래로 가려진다.
+ */
+const InstallFab: FC = () => {
+  const t = useI18n();
+  const { canInstall, openInstallGuide } = useInstallGuide();
+
+  if (!canInstall) return null;
+
+  return (
+    <Button
+      size='lg'
+      onClick={openInstallGuide}
+      className='fixed bottom-6 right-4 z-10 rounded-full shadow-lg'
+    >
+      {t.pwa.menu_label}
+    </Button>
+  );
+};
+
+export default InstallFab;

--- a/src/features/pwa-install/ui/install-fab.component.tsx
+++ b/src/features/pwa-install/ui/install-fab.component.tsx
@@ -5,15 +5,7 @@ import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { Button } from '@/shared/ui/components/button';
 import useInstallGuide from './use-install-guide.hook';
 
-/**
- * 모바일 로비 우측 하단에 떠 있는 설치 진입점.
- *
- * 로비에만 둔다 — 파티룸은 화면이 이미 꽉 차 있고, 설치를 권할 만한 시점은 앱을 계속
- * 쓸 마음이 생기는 로비다. 로비 한 화면뿐이라 닫기 버튼은 두지 않았다: 설치하면
- * `canInstall` 이 false 가 되어 알아서 사라진다.
- *
- * `z-drawer`(30) 미만이라 드로어·다이얼로그가 열리면 그 아래로 가려진다.
- */
+// z-10 은 드로어(30)·다이얼로그(1000) 미만 — 그것들이 열리면 FAB 가 그 아래로 가려진다.
 const InstallFab: FC = () => {
   const t = useI18n();
   const { canInstall, openInstallGuide } = useInstallGuide();

--- a/src/features/pwa-install/ui/install-guide.component.test.tsx
+++ b/src/features/pwa-install/ui/install-guide.component.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import InstallGuide from './install-guide.component';
+
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({
+    common: { btn: { confirm: '확인', cancel: '취소' } },
+    pwa: {
+      description: '설명',
+      install_now: '설치하기',
+      manual_title: '홈 화면에 앱을 추가해 주세요',
+      manual_chrome: 'CHROME_STEP',
+      manual_samsung: 'SAMSUNG_STEP',
+      manual_firefox: 'FIREFOX_STEP',
+      manual_other: 'OTHER_STEP',
+    },
+  }),
+}));
+
+const SAMSUNG = 'Android 13; SM-S911N SamsungBrowser/23.0 Chrome/115 Mobile';
+const FIREFOX = 'Android 14; Mobile; rv:120.0 Firefox/120.0';
+const CHROME = 'Android 14; SM-S911N Chrome/120.0.0.0 Mobile';
+const GENERIC = 'Android 14 Mobile Safari/537.36';
+
+const setUserAgent = (ua: string) =>
+  Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+
+describe('InstallGuide · manual-guide', () => {
+  afterEach(() => setUserAgent(CHROME));
+
+  test.each([
+    [SAMSUNG, 'SAMSUNG_STEP'],
+    [FIREFOX, 'FIREFOX_STEP'],
+    [CHROME, 'CHROME_STEP'],
+    [GENERIC, 'OTHER_STEP'],
+  ])('브라우저별 홈 화면 추가 경로를 안내한다 (%s)', (ua, expected) => {
+    setUserAgent(ua);
+    render(<InstallGuide environment='manual-guide' onClose={vi.fn()} />);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(screen.getByText('홈 화면에 앱을 추가해 주세요')).toBeInTheDocument();
+  });
+});

--- a/src/features/pwa-install/ui/install-guide.component.tsx
+++ b/src/features/pwa-install/ui/install-guide.component.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { BoldProcessor } from '@/shared/lib/localization/renderer';
+import { Trans } from '@/shared/lib/localization/renderer/index.ui';
+import Dialog from '@/shared/ui/components/dialog/dialog.component';
+import { Typography } from '@/shared/ui/components/typography';
+import type { InstallEnvironment } from '../lib/install-environment';
+import { showInstallPrompt } from '../lib/install-prompt';
+
+type Props = {
+  environment: InstallEnvironment;
+  onClose: () => void;
+};
+
+const IOS_STEP_KEYS = ['pwa.ios_step_1', 'pwa.ios_step_2', 'pwa.ios_step_3'] as const;
+
+/** iOS 는 설치 API 가 없어서 사용자가 직접 눌러야 한다. 어디를 누르는지만 정확히 알려준다. */
+const IosGuide = () => {
+  const t = useI18n();
+
+  return (
+    <div className='flexCol gap-4'>
+      <Typography type='detail1' className='text-white'>
+        {t.pwa.ios_guide_title}
+      </Typography>
+      <ol className='flexCol gap-3'>
+        {IOS_STEP_KEYS.map((key, index) => (
+          <li key={key} className='flex gap-3 items-start'>
+            <span className='shrink-0 w-5 h-5 rounded-full bg-gray-600 text-white flexRowCenter text-[11px]'>
+              {index + 1}
+            </span>
+            <Typography type='detail2' className='text-gray-200'>
+              <Trans i18nKey={key} processors={[new BoldProcessor()]} />
+            </Typography>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+/** 인앱 웹뷰는 설치 수단 자체가 없다. 외부 브라우저로 나가는 것 말고는 방법이 없다. */
+const InAppBrowserGuide = () => {
+  const t = useI18n();
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+    } catch (error) {
+      console.warn('[pwa] 링크 복사 실패', error);
+    }
+  };
+
+  return (
+    <div className='flexCol gap-4'>
+      <Typography type='detail1' className='text-white'>
+        {t.pwa.in_app_title}
+      </Typography>
+      <Typography type='detail2' className='text-gray-300'>
+        {t.pwa.in_app_description}
+      </Typography>
+      <button
+        type='button'
+        onClick={copyLink}
+        className='h-11 rounded border border-gray-600 text-white active:bg-gray-900'
+        data-testid='pwa-copy-link'
+      >
+        {copied ? t.pwa.copied : t.pwa.copy_link}
+      </button>
+    </div>
+  );
+};
+
+const InstallGuide = ({ environment, onClose }: Props) => {
+  const t = useI18n();
+
+  const install = async () => {
+    await showInstallPrompt();
+    onClose();
+  };
+
+  return (
+    <div className='flexCol gap-6' data-testid={`pwa-install-guide-${environment}`}>
+      {environment === 'prompt' && (
+        <Typography type='detail2' className='text-gray-300'>
+          {t.pwa.description}
+        </Typography>
+      )}
+      {environment === 'ios-guide' && <IosGuide />}
+      {environment === 'in-app-browser' && <InAppBrowserGuide />}
+
+      <Dialog.ButtonGroup>
+        {environment === 'prompt' ? (
+          <>
+            <Dialog.Button onClick={onClose} color='secondary'>
+              {t.common.btn.cancel}
+            </Dialog.Button>
+            <Dialog.Button onClick={install} data-testid='pwa-install-confirm'>
+              {t.pwa.install_now}
+            </Dialog.Button>
+          </>
+        ) : (
+          <Dialog.Button onClick={onClose}>{t.common.btn.confirm}</Dialog.Button>
+        )}
+      </Dialog.ButtonGroup>
+    </div>
+  );
+};
+
+export default InstallGuide;

--- a/src/features/pwa-install/ui/install-guide.component.tsx
+++ b/src/features/pwa-install/ui/install-guide.component.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { androidBrowser, type AndroidBrowser } from '@/shared/lib/browser/browser-environment';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { BoldProcessor } from '@/shared/lib/localization/renderer';
 import { Trans } from '@/shared/lib/localization/renderer/index.ui';
@@ -75,6 +76,30 @@ const InAppBrowserGuide = () => {
   );
 };
 
+const MANUAL_STEP_KEY = {
+  chrome: 'pwa.manual_chrome',
+  samsung: 'pwa.manual_samsung',
+  firefox: 'pwa.manual_firefox',
+  other: 'pwa.manual_other',
+} as const satisfies Record<AndroidBrowser, string>;
+
+/** 네이티브 설치창이 없는 브라우저. 홈 화면 추가 메뉴 경로가 브라우저마다 달라 분기한다. */
+const ManualGuide = () => {
+  const t = useI18n();
+  const browser = typeof navigator !== 'undefined' ? androidBrowser(navigator.userAgent) : 'other';
+
+  return (
+    <div className='flexCol gap-4'>
+      <Typography type='detail1' className='text-white'>
+        {t.pwa.manual_title}
+      </Typography>
+      <Typography type='detail2' className='text-gray-200'>
+        <Trans i18nKey={MANUAL_STEP_KEY[browser]} processors={[new BoldProcessor()]} />
+      </Typography>
+    </div>
+  );
+};
+
 const InstallGuide = ({ environment, onClose }: Props) => {
   const t = useI18n();
 
@@ -92,6 +117,7 @@ const InstallGuide = ({ environment, onClose }: Props) => {
       )}
       {environment === 'ios-guide' && <IosGuide />}
       {environment === 'in-app-browser' && <InAppBrowserGuide />}
+      {environment === 'manual-guide' && <ManualGuide />}
 
       <Dialog.ButtonGroup>
         {environment === 'prompt' ? (

--- a/src/features/pwa-install/ui/install-prompt-capture.component.tsx
+++ b/src/features/pwa-install/ui/install-prompt-capture.component.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+// import 만으로 리스너가 붙는다 (install-prompt 모듈 최상단 참고).
+import '../lib/install-prompt';
+
+/**
+ * 렌더하는 것은 없다. 루트 레이아웃에 두어 `beforeinstallprompt` 리스너를 앱 부팅 시점에
+ * 붙이는 것이 목적이다. 이 이벤트는 로드 직후 한 번만 발생해서, 메뉴가 열릴 때 붙이면 늦는다.
+ */
+const InstallPromptCapture = () => null;
+
+export default InstallPromptCapture;

--- a/src/features/pwa-install/ui/use-install-guide.hook.tsx
+++ b/src/features/pwa-install/ui/use-install-guide.hook.tsx
@@ -6,8 +6,8 @@ import InstallGuide from './install-guide.component';
 import useInstallEnvironment from '../lib/use-install-environment.hook';
 
 /**
- * 설치 안내 진입점. `canInstall` 이 false 면 메뉴 항목 자체를 노출하지 않는다 —
- * 이미 설치했거나(installed) 설치라는 개념이 없는 환경(unsupported)에서는 보여줄 게 없다.
+ * 설치 안내 진입점. 이미 설치했거나(installed) 판정 전(null)이 아니면 노출한다 —
+ * 네이티브 설치창이 없는 브라우저도 수동 안내로 이어주므로 숨기지 않는다.
  */
 export default function useInstallGuide() {
   const t = useI18n();
@@ -17,11 +17,14 @@ export default function useInstallGuide() {
   const openInstallGuide = () =>
     openDialog((_, onCancel) => ({
       title: t.pwa.title,
-      Body: () => (onCancel ? <InstallGuide environment={environment} onClose={onCancel} /> : null),
+      Body: () =>
+        environment && onCancel ? (
+          <InstallGuide environment={environment} onClose={onCancel} />
+        ) : null,
     }));
 
   return {
-    canInstall: environment !== 'installed' && environment !== 'unsupported',
+    canInstall: environment !== null && environment !== 'installed',
     openInstallGuide,
   };
 }

--- a/src/features/pwa-install/ui/use-install-guide.hook.tsx
+++ b/src/features/pwa-install/ui/use-install-guide.hook.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import InstallGuide from './install-guide.component';
+import useInstallEnvironment from '../lib/use-install-environment.hook';
+
+/**
+ * 설치 안내 진입점. `canInstall` 이 false 면 메뉴 항목 자체를 노출하지 않는다 —
+ * 이미 설치했거나(installed) 설치라는 개념이 없는 환경(unsupported)에서는 보여줄 게 없다.
+ */
+export default function useInstallGuide() {
+  const t = useI18n();
+  const environment = useInstallEnvironment();
+  const { openDialog } = useDialog();
+
+  const openInstallGuide = () =>
+    openDialog((_, onCancel) => ({
+      title: t.pwa.title,
+      Body: () => (onCancel ? <InstallGuide environment={environment} onClose={onCancel} /> : null),
+    }));
+
+  return {
+    canInstall: environment !== 'installed' && environment !== 'unsupported',
+    openInstallGuide,
+  };
+}

--- a/src/shared/lib/browser/browser-environment.test.ts
+++ b/src/shared/lib/browser/browser-environment.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import { androidBrowser } from './browser-environment';
+
+const SAMSUNG =
+  'Mozilla/5.0 (Linux; Android 13; SM-S911N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36';
+const FIREFOX = 'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0';
+const CHROME =
+  'Mozilla/5.0 (Linux; Android 14; SM-S911N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+const GENERIC = 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Mobile Safari/537.36';
+
+describe('androidBrowser', () => {
+  test('SamsungBrowser 는 UA 에 Chrome 이 섞여 있어도 samsung', () => {
+    expect(androidBrowser(SAMSUNG)).toBe('samsung');
+  });
+
+  test('Firefox 는 firefox', () => {
+    expect(androidBrowser(FIREFOX)).toBe('firefox');
+  });
+
+  test('순수 Chrome 은 chrome', () => {
+    expect(androidBrowser(CHROME)).toBe('chrome');
+  });
+
+  test('식별 토큰이 없으면 other', () => {
+    expect(androidBrowser(GENERIC)).toBe('other');
+  });
+});

--- a/src/shared/lib/browser/browser-environment.ts
+++ b/src/shared/lib/browser/browser-environment.ts
@@ -21,3 +21,18 @@ export const isStandalone = (): boolean =>
  */
 export const isInAppBrowser = (ua: string): boolean =>
   /KAKAOTALK|Instagram|FBAN|FBAV|Line\/|NAVER\(inapp|DaumApps|everytimeApp|wv\)/i.test(ua);
+
+export type AndroidBrowser = 'samsung' | 'firefox' | 'chrome' | 'other';
+
+/**
+ * 수동 설치 안내를 브라우저별 메뉴 경로에 맞추기 위한 판별.
+ *
+ * SamsungBrowser·Firefox UA 에도 'Chrome' 토큰이 섞여 있어 순서가 중요하다 —
+ * 더 구체적인 브라우저를 먼저 걸러야 한다.
+ */
+export const androidBrowser = (ua: string): AndroidBrowser => {
+  if (/SamsungBrowser/i.test(ua)) return 'samsung';
+  if (/Firefox|FxiOS/i.test(ua)) return 'firefox';
+  if (/Chrome/i.test(ua)) return 'chrome';
+  return 'other';
+};

--- a/src/shared/lib/browser/browser-environment.ts
+++ b/src/shared/lib/browser/browser-environment.ts
@@ -1,0 +1,23 @@
+/**
+ * 브라우저 환경 판별 원시 함수들.
+ *
+ * push-notification 과 pwa-install 두 feature 가 같은 판별을 필요로 해서 shared 로 올렸다.
+ * 전부 SSR-safe 여야 한다 — 서버 렌더 중에도 호출된다.
+ */
+
+export const isIOS = (ua: string): boolean => /iPhone|iPad|iPod/i.test(ua);
+
+/** PWA standalone(홈화면 추가) 모드 여부. (SSR-safe) */
+export const isStandalone = (): boolean =>
+  typeof window !== 'undefined' &&
+  (window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true);
+
+/**
+ * 카카오톡·인스타그램 등 앱 안에 내장된 웹뷰인지.
+ *
+ * 이 웹뷰들은 홈 화면 추가 자체를 제공하지 않아서, 안내를 아무리 잘 해도 설치가 불가능하다.
+ * 외부 브라우저로 여는 길을 알려주는 것 말고는 방법이 없다.
+ */
+export const isInAppBrowser = (ua: string): boolean =>
+  /KAKAOTALK|Instagram|FBAN|FBAV|Line\/|NAVER\(inapp|DaumApps|everytimeApp|wv\)/i.test(ua);

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -432,6 +432,11 @@
     "in_app_title": "You can't install from here",
     "in_app_description": "You're in an in-app browser, which can't add to the home screen. Copy the link and open it in Safari or Chrome.",
     "copy_link": "Copy link",
-    "copied": "Copied"
+    "copied": "Copied",
+    "manual_title": "Add the app to your home screen",
+    "manual_chrome": "Tap <b>⋮</b> in the top right → <b>Install app</b> (or Add to Home screen).",
+    "manual_samsung": "Tap <b>≡</b> at the bottom → <b>Add page to</b> → <b>Home screen</b>.",
+    "manual_firefox": "Tap <b>⋮</b> → <b>Add to Home screen</b>.",
+    "manual_other": "Open your browser menu and choose <b>Add to Home screen</b> (or Install app)."
   }
 }

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -419,5 +419,19 @@
       "too_short": "Please enter at least 5 characters",
       "too_long": "Up to 2000 characters allowed"
     }
+  },
+  "pwa": {
+    "menu_label": "Install app",
+    "title": "Install PFPlay",
+    "description": "Add it to your home screen to open it like an app and get notifications.",
+    "install_now": "Install",
+    "ios_guide_title": "Add to home screen in Safari",
+    "ios_step_1": "Tap the <b>Share</b> button below the address bar.",
+    "ios_step_2": "Choose <b>Add to Home Screen</b> from the list.",
+    "ios_step_3": "Tap <b>Add</b> in the top right. That's it.",
+    "in_app_title": "You can't install from here",
+    "in_app_description": "You're in an in-app browser, which can't add to the home screen. Copy the link and open it in Safari or Chrome.",
+    "copy_link": "Copy link",
+    "copied": "Copied"
   }
 }

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -432,6 +432,11 @@
     "in_app_title": "여기서는 설치할 수 없어요",
     "in_app_description": "지금 앱 안에 있는 브라우저라 홈 화면에 추가할 수 없어요. 주소를 복사해 Safari나 Chrome에서 열어 주세요.",
     "copy_link": "주소 복사하기",
-    "copied": "복사했어요"
+    "copied": "복사했어요",
+    "manual_title": "홈 화면에 앱을 추가해 주세요",
+    "manual_chrome": "오른쪽 위 <b>⋮</b> → <b>앱 설치</b>(또는 홈 화면에 추가)를 누르세요.",
+    "manual_samsung": "아래쪽 <b>≡</b> → <b>현재 페이지 추가</b> → <b>홈 화면</b>을 누르세요.",
+    "manual_firefox": "<b>⋮</b> → <b>홈 화면에 추가</b>를 누르세요.",
+    "manual_other": "브라우저 메뉴에서 <b>홈 화면에 추가</b>(또는 앱 설치)를 선택하세요."
   }
 }

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -419,5 +419,19 @@
       "too_short": "최소 5자 이상 입력해주세요",
       "too_long": "최대 2000자까지 입력할 수 있어요"
     }
+  },
+  "pwa": {
+    "menu_label": "앱 설치하기",
+    "title": "PFPlay 앱으로 설치하기",
+    "description": "홈 화면에 추가하면 앱처럼 바로 열고, 알림도 받을 수 있어요.",
+    "install_now": "설치하기",
+    "ios_guide_title": "Safari에서 홈 화면에 추가해 주세요",
+    "ios_step_1": "주소창 아래 <b>공유</b> 버튼을 누르세요.",
+    "ios_step_2": "목록에서 <b>홈 화면에 추가</b>를 고르세요.",
+    "ios_step_3": "오른쪽 위 <b>추가</b>를 누르면 끝이에요.",
+    "in_app_title": "여기서는 설치할 수 없어요",
+    "in_app_description": "지금 앱 안에 있는 브라우저라 홈 화면에 추가할 수 없어요. 주소를 복사해 Safari나 Chrome에서 열어 주세요.",
+    "copy_link": "주소 복사하기",
+    "copied": "복사했어요"
   }
 }

--- a/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.test.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.test.tsx
@@ -5,6 +5,9 @@ import LobbyMenu from './lobby-menu.component';
 
 const pushMock = vi.fn();
 const signOutMock = vi.fn();
+const openInstallGuideMock = vi.fn();
+/** 설치 진입점은 환경에 따라 숨겨진다 — 테스트마다 갈아끼운다. */
+let canInstall = true;
 
 vi.mock('@/shared/lib/router/use-app-router.hook', () => ({
   useAppRouter: () => ({ push: pushMock }),
@@ -12,6 +15,10 @@ vi.mock('@/shared/lib/router/use-app-router.hook', () => ({
 
 vi.mock('@/features/sign-out', () => ({
   useSignOut: () => signOutMock,
+}));
+
+vi.mock('@/features/pwa-install', () => ({
+  useInstallGuide: () => ({ canInstall, openInstallGuide: openInstallGuideMock }),
 }));
 
 vi.mock('@/shared/lib/localization/i18n.context', () => ({
@@ -24,6 +31,9 @@ vi.mock('@/shared/lib/localization/i18n.context', () => ({
       btn: {
         logout: '로그아웃',
       },
+    },
+    pwa: {
+      menu_label: '앱 설치하기',
     },
   }),
 }));
@@ -38,6 +48,8 @@ describe('LobbyMenu', () => {
   beforeEach(() => {
     pushMock.mockClear();
     signOutMock.mockClear();
+    openInstallGuideMock.mockClear();
+    canInstall = true;
   });
 
   test('초기에는 메뉴 항목이 보이지 않는다', () => {
@@ -65,5 +77,28 @@ describe('LobbyMenu', () => {
     await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
     await userEvent.click(screen.getByText('로그아웃'));
     expect(signOutMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('설치 가능하면 앱 설치하기 항목이 보인다', async () => {
+    render(<LobbyMenu />);
+    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
+    expect(screen.getByText('앱 설치하기')).toBeInTheDocument();
+  });
+
+  test('이미 설치했거나 설치 불가 환경이면 항목을 숨긴다', async () => {
+    canInstall = false;
+    render(<LobbyMenu />);
+    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
+    expect(screen.queryByText('앱 설치하기')).toBeNull();
+    // 다른 항목은 그대로여야 한다.
+    expect(screen.getByText('알림 설정')).toBeInTheDocument();
+  });
+
+  test('앱 설치하기 클릭 → 설치 안내를 연다', async () => {
+    render(<LobbyMenu />);
+    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
+    await userEvent.click(screen.getByText('앱 설치하기'));
+
+    expect(openInstallGuideMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.test.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.test.tsx
@@ -5,20 +5,12 @@ import LobbyMenu from './lobby-menu.component';
 
 const pushMock = vi.fn();
 const signOutMock = vi.fn();
-const openInstallGuideMock = vi.fn();
-/** 설치 진입점은 환경에 따라 숨겨진다 — 테스트마다 갈아끼운다. */
-let canInstall = true;
-
 vi.mock('@/shared/lib/router/use-app-router.hook', () => ({
   useAppRouter: () => ({ push: pushMock }),
 }));
 
 vi.mock('@/features/sign-out', () => ({
   useSignOut: () => signOutMock,
-}));
-
-vi.mock('@/features/pwa-install', () => ({
-  useInstallGuide: () => ({ canInstall, openInstallGuide: openInstallGuideMock }),
 }));
 
 vi.mock('@/shared/lib/localization/i18n.context', () => ({
@@ -31,9 +23,6 @@ vi.mock('@/shared/lib/localization/i18n.context', () => ({
       btn: {
         logout: '로그아웃',
       },
-    },
-    pwa: {
-      menu_label: '앱 설치하기',
     },
   }),
 }));
@@ -48,8 +37,6 @@ describe('LobbyMenu', () => {
   beforeEach(() => {
     pushMock.mockClear();
     signOutMock.mockClear();
-    openInstallGuideMock.mockClear();
-    canInstall = true;
   });
 
   test('초기에는 메뉴 항목이 보이지 않는다', () => {
@@ -77,28 +64,5 @@ describe('LobbyMenu', () => {
     await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
     await userEvent.click(screen.getByText('로그아웃'));
     expect(signOutMock).toHaveBeenCalledTimes(1);
-  });
-
-  test('설치 가능하면 앱 설치하기 항목이 보인다', async () => {
-    render(<LobbyMenu />);
-    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
-    expect(screen.getByText('앱 설치하기')).toBeInTheDocument();
-  });
-
-  test('이미 설치했거나 설치 불가 환경이면 항목을 숨긴다', async () => {
-    canInstall = false;
-    render(<LobbyMenu />);
-    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
-    expect(screen.queryByText('앱 설치하기')).toBeNull();
-    // 다른 항목은 그대로여야 한다.
-    expect(screen.getByText('알림 설정')).toBeInTheDocument();
-  });
-
-  test('앱 설치하기 클릭 → 설치 안내를 연다', async () => {
-    render(<LobbyMenu />);
-    await userEvent.click(screen.getByRole('button', { name: '메뉴' }));
-    await userEvent.click(screen.getByText('앱 설치하기'));
-
-    expect(openInstallGuideMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FC, useState } from 'react';
+import { useInstallGuide } from '@/features/pwa-install';
 import { useSignOut } from '@/features/sign-out';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
@@ -19,6 +20,7 @@ const LobbyMenu: FC = () => {
   const t = useI18n();
   const router = useAppRouter();
   const signOut = useSignOut();
+  const { canInstall, openInstallGuide } = useInstallGuide();
   const [isOpen, setIsOpen] = useState(false);
 
   const open = () => setIsOpen(true);
@@ -27,6 +29,11 @@ const LobbyMenu: FC = () => {
   const goNotificationSettings = () => {
     close();
     router.push('/settings/notifications');
+  };
+
+  const handleInstall = () => {
+    close();
+    openInstallGuide();
   };
 
   const handleSignOut = () => {
@@ -45,6 +52,16 @@ const LobbyMenu: FC = () => {
       </button>
       <Drawer title={t.common.menu.title} isOpen={isOpen} close={close}>
         <nav className='flexCol'>
+          {canInstall && (
+            <button
+              type='button'
+              onClick={handleInstall}
+              data-testid='lobby-menu-install-app'
+              className='h-12 flex items-center text-left text-white active:bg-gray-900 -mx-7 px-7'
+            >
+              {t.pwa.menu_label}
+            </button>
+          )}
           <button
             type='button'
             onClick={goNotificationSettings}

--- a/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby-menu.component.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { FC, useState } from 'react';
-import { useInstallGuide } from '@/features/pwa-install';
 import { useSignOut } from '@/features/sign-out';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
@@ -20,7 +19,6 @@ const LobbyMenu: FC = () => {
   const t = useI18n();
   const router = useAppRouter();
   const signOut = useSignOut();
-  const { canInstall, openInstallGuide } = useInstallGuide();
   const [isOpen, setIsOpen] = useState(false);
 
   const open = () => setIsOpen(true);
@@ -29,11 +27,6 @@ const LobbyMenu: FC = () => {
   const goNotificationSettings = () => {
     close();
     router.push('/settings/notifications');
-  };
-
-  const handleInstall = () => {
-    close();
-    openInstallGuide();
   };
 
   const handleSignOut = () => {
@@ -52,16 +45,6 @@ const LobbyMenu: FC = () => {
       </button>
       <Drawer title={t.common.menu.title} isOpen={isOpen} close={close}>
         <nav className='flexCol'>
-          {canInstall && (
-            <button
-              type='button'
-              onClick={handleInstall}
-              data-testid='lobby-menu-install-app'
-              className='h-12 flex items-center text-left text-white active:bg-gray-900 -mx-7 px-7'
-            >
-              {t.pwa.menu_label}
-            </button>
-          )}
           <button
             type='button'
             onClick={goNotificationSettings}

--- a/src/widgets-mobile/partyroom-page-mobile/lobby.component.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby.component.tsx
@@ -11,7 +11,7 @@ import LobbyMenu from './lobby-menu.component';
  *
  * 데스크탑 `<Header />` 는 page.tsx 가 desktop 분기에서만 렌더 — 모바일 로비는 자체
  * 헤더("파티 찾기" + ⋮) 가짐 (스펙 §4.5). ⋮ 는 `LobbyMenu` 가 소유 — 알림 설정/로그아웃
- * 진입점(Web Push 설정). PWA 설치는 드로어 대신 우측 하단 `InstallFab` 이 맡는다.
+ * 진입점(Web Push 설정).
  *
  * `MobilePartyroomList` 내부의 `useSuspenseFetchMainPartyroom` (Main Stage 카드) 가
  * Suspense boundary 를 요구. 데스크탑 lobby 와 동일 패턴.
@@ -23,7 +23,7 @@ const MobileLobby: FC = () => {
         <h1 className='text-base font-semibold text-white'>파티 찾기</h1>
         <LobbyMenu />
       </header>
-      {/* FAB 가 마지막 카드를 가리지 않도록 하단 여백을 넉넉히 둔다. */}
+      {/* pb-24: 하단 고정 InstallFab 이 마지막 카드를 가리지 않도록 확보 */}
       <div className='flex-1 px-app pt-4 pb-24'>
         <SuspenseWithErrorBoundary enableReload>
           <MobilePartyroomList />

--- a/src/widgets-mobile/partyroom-page-mobile/lobby.component.tsx
+++ b/src/widgets-mobile/partyroom-page-mobile/lobby.component.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FC } from 'react';
+import { InstallFab } from '@/features/pwa-install';
 import { MobilePartyroomList } from '@/features-mobile/partyroom/list';
 import SuspenseWithErrorBoundary from '@/shared/api/http/error/suspense-with-error-boundary.component';
 import LobbyMenu from './lobby-menu.component';
@@ -10,7 +11,7 @@ import LobbyMenu from './lobby-menu.component';
  *
  * 데스크탑 `<Header />` 는 page.tsx 가 desktop 분기에서만 렌더 — 모바일 로비는 자체
  * 헤더("파티 찾기" + ⋮) 가짐 (스펙 §4.5). ⋮ 는 `LobbyMenu` 가 소유 — 알림 설정/로그아웃
- * 진입점(Web Push 설정).
+ * 진입점(Web Push 설정). PWA 설치는 드로어 대신 우측 하단 `InstallFab` 이 맡는다.
  *
  * `MobilePartyroomList` 내부의 `useSuspenseFetchMainPartyroom` (Main Stage 카드) 가
  * Suspense boundary 를 요구. 데스크탑 lobby 와 동일 패턴.
@@ -22,11 +23,13 @@ const MobileLobby: FC = () => {
         <h1 className='text-base font-semibold text-white'>파티 찾기</h1>
         <LobbyMenu />
       </header>
-      <div className='flex-1 px-app pt-4 pb-8'>
+      {/* FAB 가 마지막 카드를 가리지 않도록 하단 여백을 넉넉히 둔다. */}
+      <div className='flex-1 px-app pt-4 pb-24'>
         <SuspenseWithErrorBoundary enableReload>
           <MobilePartyroomList />
         </SuspenseWithErrorBoundary>
       </div>
+      <InstallFab />
     </main>
   );
 };


### PR DESCRIPTION
feat: 브라우저별 PWA 설치 안내 분기 (#461)

## Summary

모바일 로비에 앱 설치 진입점을 둔다. 우측 하단 floating 버튼(FAB)으로, 이미 설치한 경우가 아니면 OS·브라우저와 무관하게 항상 노출한다. 클릭하면 환경에 맞춰 안내가 갈린다 — 네이티브 설치창이 가능하면 바로 설치, 없으면 브라우저별 홈 화면 추가 경로를 안내한다.

<img height="300" alt="PFPlay" src="https://github.com/user-attachments/assets/498cded6-f670-4495-b953-2d3f3fa4509b" />
<img  height="300" alt="HandOff" src="https://github.com/user-attachments/assets/ba6e03aa-ca17-4fa7-bdfe-d2490e07b45e" />
<img  height="300" alt="PFPlay" src="https://github.com/user-attachments/assets/6f176e92-59ba-4e41-9478-ca1632bbe979" />
<img  height="300" alt="image" src="https://github.com/user-attachments/assets/ff75aa18-ec25-4af0-be9d-2a9ee6d75622" />

## Decisions

- 진입점을 드로어(⋮) 안이 아니라 로비 우측 하단 FAB로 둔다 — 설치 유도는 눈에 띄어야 의미가 있는데 드로어 두 단계 안은 너무 깊었다
- 설치 전이면 항상 노출한다(숨김은 `installed`뿐) — 네이티브 설치창이 없는 브라우저도 수동 안내로 이어주므로 진입점을 없앨 이유가 없다
- 수동 안내는 브라우저별로 분기한다(Chrome·삼성인터넷·Firefox·기타) — 홈 화면 추가 메뉴 경로가 브라우저마다 다르다
- 인앱 웹뷰를 iOS보다 먼저 판별한다 — iOS 카카오톡은 둘 다 참인데 홈 화면 추가가 불가능하다
- `isIOS`·`isStandalone`을 `shared/lib/browser`로 옮긴다 — push-notification과 공유한다. re-export로 기존 호출부는 무변경

## Review Points

- `browser-environment.ts` `androidBrowser` — 삼성·Firefox UA에도 'Chrome'이 섞여 판별 순서가 계약. 순서가 바뀌면 안내가 틀어진다
- `install-environment.ts` — 분기 순서가 계약. 바꿔도 테스트 밖에선 회귀가 안 보인다
- `browser-environment.ts` 인앱 UA 정규식 — 오탐하면 정상 사용자가 설치를 못 한다
- `install-prompt.ts` — 모듈 최상단 side-effect로 전역 리스너. SSR·테스트 오염 여부

## Known limitations

- stg.pfplay.xyz는 Vercel 배포 보호(SSO) 뒤라 매니페스트·SW·아이콘이 전부 302로 리다이렉트된다 → Chrome이 설치 가능 판정을 못 해 Android 네이티브 설치창(`prompt`) 경로는 stg에서 검증 불가. 보호 없는 URL(프로덕션)에서만 확인된다. FAB 노출·수동 안내 경로는 stg에서도 확인 가능
- 이미 설치했는데 브라우저 탭으로 열면 `installed` 판정이 안 돼 FAB가 다시 뜰 수 있다(재설치 유도). 감지 한계로 감수

## Todo

- [x] 실기기 검증은 이 PR의 preview URL로 (SW는 유효 인증서 필요, LAN IP 불가)
  - iOS Safari 홈 화면 추가 → 재실행 시 진입점이 사라지는지
  - 카카오톡으로 열어 인앱 안내가 뜨는지 (UA 정규식 실검증)
- [ ] `shared/lib/browser/` 위치가 팀 관례에 맞는지 확인
- [ ] `docs/superpowers/`의 PWA spec/plan(#424 소관)을 지금 제거할 시점인지 판단

## Issue

Closes #461

## Reference

- 검증: `yarn test` 1760건 · `yarn test:type` · `yarn lint` 통과
