### PR TITLE
feat: Now DJing 빈 상태 모달 개편 및 곡 검색 DJ 등록 (#464)

### DIFF
--- a/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.integration.test.ts
+++ b/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.integration.test.ts
@@ -1,0 +1,52 @@
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/shared/api/__test__/msw-server';
+import { renderWithClient } from '@/shared/api/__test__/test-utils';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { useQuickRegisterMeToQueue } from './use-quick-register-me-to-queue.mutation';
+
+const TRACK = {
+  name: "BLACKPINK - 'Shut Down' M/V",
+  linkId: 'POe9SOEKotk',
+  duration: '03:01',
+  thumbnailImage: 'https://i.ytimg.com/vi/POe9SOEKotk/mqdefault.jpg',
+};
+
+describe('useQuickRegisterMeToQueue integration (hook → service → MSW)', () => {
+  it('partyroomId 를 뺀 트랙 4개 필드만 body 로 보낸다', async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(
+        'http://localhost:8080/api/v1/partyrooms/:id/dj-queue/quick',
+        async ({ request }) => {
+          requestBody = await request.json();
+          return new HttpResponse(null, { status: 201 });
+        }
+      )
+    );
+
+    const { result } = renderWithClient(() => useQuickRegisterMeToQueue());
+
+    result.current.mutate({ partyroomId: 1, ...TRACK });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requestBody).toEqual(TRACK);
+  });
+
+  it('성공 시 DjingQueue 와 Playlist 캐시를 무효화한다', async () => {
+    const { result, queryClient } = renderWithClient(() => useQuickRegisterMeToQueue());
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    result.current.mutate({ partyroomId: 1, ...TRACK });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [QueryKeys.DjingQueue, 1] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [QueryKeys.Playlist] })
+    );
+  });
+});

--- a/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
+++ b/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { djsService } from '@/shared/api/http/services';
+import { APIError } from '@/shared/api/http/types/@shared';
+import { QuickRegisterMeToQueuePayload } from '@/shared/api/http/types/djs';
+import { track } from '@/shared/lib/analytics';
+
+export const useQuickRegisterMeToQueue = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, AxiosError<APIError>, QuickRegisterMeToQueuePayload>({
+    mutationFn: (request) => djsService.quickRegisterMeToQueue(request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.DjingQueue, variables.partyroomId],
+      });
+      // 서버가 플레이리스트를 대신 만들어 담으므로 목록·곡 수가 함께 바뀐다
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.Playlist],
+      });
+      track('DJ Registered', {
+        partyroom_id: variables.partyroomId,
+        track_id: variables.linkId,
+      });
+    },
+  });
+};

--- a/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
+++ b/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
@@ -19,10 +19,7 @@ export const useQuickRegisterMeToQueue = () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist],
       });
-      track('DJ Registered', {
-        partyroom_id: variables.partyroomId,
-        track_id: variables.linkId,
-      });
+      track('DJ Registered', { partyroom_id: variables.partyroomId });
     },
   });
 };

--- a/src/features/partyroom/register-dj-with-track/index.ts
+++ b/src/features/partyroom/register-dj-with-track/index.ts
@@ -1,0 +1,1 @@
+export { default as useRegisterDjWithTrack } from './ui/use-register-dj-with-track.hook';

--- a/src/features/partyroom/register-dj-with-track/lib/today-playlist-name.ts
+++ b/src/features/partyroom/register-dj-with-track/lib/today-playlist-name.ts
@@ -1,4 +1,0 @@
-/** 'en-CA' 로케일이 곧 YYYY-MM-DD 포맷이다. 기준은 사용자 로컬 타임존. */
-export function todayPlaylistName(today = new Date()) {
-  return today.toLocaleDateString('en-CA');
-}

--- a/src/features/partyroom/register-dj-with-track/lib/today-playlist-name.ts
+++ b/src/features/partyroom/register-dj-with-track/lib/today-playlist-name.ts
@@ -1,0 +1,4 @@
+/** 'en-CA' 로케일이 곧 YYYY-MM-DD 포맷이다. 기준은 사용자 로컬 타임존. */
+export function todayPlaylistName(today = new Date()) {
+  return today.toLocaleDateString('en-CA');
+}

--- a/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
@@ -1,0 +1,122 @@
+'use client';
+import { useCallback, useState } from 'react';
+import { useSearchMusics } from '@/features/playlist/add-tracks/api/use-search-musics.query';
+import SearchInput from '@/features/playlist/add-tracks/ui/search-input.component';
+import SearchListItem from '@/features/playlist/add-tracks/ui/search-list-item.component';
+import { Music } from '@/shared/api/http/types/playlists';
+import { track } from '@/shared/lib/analytics';
+import { cn } from '@/shared/lib/functions/cn';
+import { safeDecodeURI } from '@/shared/lib/functions/safe-decode-uri';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import LoadingPanel from '@/shared/ui/components/loading/loading-panel.component';
+import { TextButton } from '@/shared/ui/components/text-button';
+import { Typography } from '@/shared/ui/components/typography';
+import { PFArrowLeft, PFClose } from '@/shared/ui/icons';
+
+type Props = {
+  onSelectTrack: (music: Music) => void;
+  onBackToDjingDialog: () => void;
+  onCloseAll: () => void;
+};
+
+export default function SearchTrackForDjing({
+  onSelectTrack,
+  onBackToDjingDialog,
+  onCloseAll,
+}: Props) {
+  const t = useI18n();
+  const [search, setSearch] = useState('');
+  const [selectedTrack, setSelectedTrack] = useState<Music>();
+  const { data: musics, isFetching } = useSearchMusics(search);
+
+  const handleSearch = useCallback((value: string) => {
+    setSearch(value);
+    setSelectedTrack(undefined);
+    if (value) {
+      track('Music Searched', { query: value });
+    }
+  }, []);
+
+  const hasNoResult = !isFetching && !musics?.length;
+
+  return (
+    <div className='flexCol text-start'>
+      <header className='flex items-center gap-7 px-[40px] pt-[36px] pb-[24px]'>
+        <TextButton
+          onClick={onBackToDjingDialog}
+          Icon={<PFArrowLeft width={24} height={24} />}
+          data-testid='djing-track-search-back'
+        />
+        <Typography type='title2'>{t.playlist.btn.add_song}</Typography>
+        <SearchInput onSearch={handleSearch} />
+        <TextButton
+          onClick={onCloseAll}
+          Icon={<PFClose width={24} height={24} />}
+          data-testid='djing-track-search-close'
+        />
+      </header>
+
+      <div className='h-[420px] overflow-y-auto px-[40px]'>
+        {isFetching && <LoadingPanel />}
+
+        {hasNoResult && (
+          <div className='h-full flexRowCenter'>
+            <Typography type='body2' className='text-gray-300'>
+              {t.dj.para.search_song_to_dj}
+            </Typography>
+          </div>
+        )}
+
+        {!isFetching &&
+          musics?.map((music) => {
+            const isSelected = selectedTrack?.videoId === music.videoId;
+
+            return (
+              <div
+                key={music.videoId}
+                role='button'
+                tabIndex={0}
+                onClick={() => setSelectedTrack(music)}
+                className={cn(
+                  'my-1 rounded border px-[12px] py-[12px] cursor-pointer transition-colors',
+                  isSelected
+                    ? 'border-red-300 bg-red-500/40'
+                    : 'border-transparent hover:bg-gray-800'
+                )}
+                data-testid={isSelected ? 'djing-track-selected' : 'djing-track-item'}
+              >
+                <SearchListItem music={music} Suffix={null} />
+              </div>
+            );
+          })}
+      </div>
+
+      <footer className='flex items-center justify-between gap-4 border-t border-gray-700 px-[40px] py-[24px]'>
+        {selectedTrack ? (
+          <div className='flexCol gap-1 min-w-0'>
+            <Typography type='body1' overflow='ellipsis'>
+              {safeDecodeURI(selectedTrack.videoTitle)}
+            </Typography>
+            <Typography type='detail1' className='text-gray-300'>
+              {t.dj.para.start_djing_with_this_song}
+            </Typography>
+          </div>
+        ) : (
+          <Typography type='body2' className='text-gray-300'>
+            {t.dj.para.select_song_to_dj}
+          </Typography>
+        )}
+
+        <Button
+          size='lg'
+          disabled={!selectedTrack}
+          onClick={() => selectedTrack && onSelectTrack(selectedTrack)}
+          data-testid='djing-track-confirm'
+        >
+          {t.dj.btn.register_with_this_song}
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
@@ -77,6 +77,7 @@ export default function SearchTrackForDjing({
                 key={music.videoId}
                 role='button'
                 tabIndex={0}
+                aria-pressed={isSelected}
                 onClick={() => setSelectedTrack(music)}
                 className={cn(
                   'my-1 rounded border px-[12px] py-[12px] cursor-pointer transition-colors',
@@ -84,7 +85,7 @@ export default function SearchTrackForDjing({
                     ? 'border-red-300 bg-red-500/40'
                     : 'border-transparent hover:bg-gray-800'
                 )}
-                data-testid={isSelected ? 'djing-track-selected' : 'djing-track-item'}
+                data-testid='djing-track-item'
               >
                 <SearchListItem music={music} Suffix={null} />
               </div>

--- a/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
@@ -1,0 +1,65 @@
+import { useCreatePlaylist } from '@/features/playlist/add/api/use-create-playlist.mutation';
+import { useAddPlaylistTrack } from '@/features/playlist/add-tracks';
+import { useFetchPlaylists } from '@/features/playlist/list';
+import { Music } from '@/shared/api/http/types/playlists';
+import { useDialog } from '@/shared/ui/components/dialog';
+import theme from '@/shared/ui/foundation/theme';
+import SearchTrackForDjing from './search-track-for-djing.component';
+import { useRegisterMeToQueue } from '../../register-me-to-queue';
+import { todayPlaylistName } from '../lib/today-playlist-name';
+
+type RegisterDjWithTrackParams = {
+  partyroomId: number;
+  closeDjingDialog?: () => void;
+};
+
+export default function useRegisterDjWithTrack() {
+  const { openDialog } = useDialog();
+  const { data: playlists = [] } = useFetchPlaylists();
+  const { mutateAsync: createPlaylist } = useCreatePlaylist();
+  const { mutateAsync: addTrackToPlaylist } = useAddPlaylistTrack();
+  const { mutate: registerMeToQueue } = useRegisterMeToQueue();
+
+  const openTrackSearchDialog = (closeDjingDialog?: () => void) =>
+    openDialog<Music>((onSelect, onCancel) => ({
+      zIndex: theme.zIndex.dialog + 1,
+      closeWhenOverlayClicked: false,
+      classNames: { container: '!p-[unset] w-[1000px] bg-black border border-gray-700' },
+      Body: (
+        <SearchTrackForDjing
+          onSelectTrack={onSelect}
+          onBackToDjingDialog={() => onCancel?.()}
+          onCloseAll={() => {
+            onCancel?.();
+            closeDjingDialog?.();
+          }}
+        />
+      ),
+    }));
+
+  // 대기열 등록은 플레이리스트 단위로만 가능하다. 곡 하나로 등록하려면 담을 그릇이 필요해
+  // 오늘 날짜 이름의 플레이리스트를 쓰고, 같은 날 재등록 시엔 목록이 불어나지 않게 재사용한다.
+  const getPlaylistForToday = async () => {
+    const name = todayPlaylistName();
+
+    return playlists.find((playlist) => playlist.name === name) ?? (await createPlaylist({ name }));
+  };
+
+  return async ({ partyroomId, closeDjingDialog }: RegisterDjWithTrackParams) => {
+    const selectedTrack = await openTrackSearchDialog(closeDjingDialog);
+    if (!selectedTrack) return;
+
+    const playlist = await getPlaylistForToday();
+
+    await addTrackToPlaylist({
+      listId: playlist.id,
+      linkId: selectedTrack.videoId,
+      name: selectedTrack.videoTitle,
+      duration: selectedTrack.runningTime,
+      thumbnailImage: selectedTrack.thumbnailUrl,
+    });
+
+    registerMeToQueue({ partyroomId, playlistId: playlist.id });
+    closeDjingDialog?.();
+  };
+}

--- a/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
@@ -6,7 +6,6 @@ import { useDialog } from '@/shared/ui/components/dialog';
 import theme from '@/shared/ui/foundation/theme';
 import SearchTrackForDjing from './search-track-for-djing.component';
 import { useRegisterMeToQueue } from '../../register-me-to-queue';
-import { todayPlaylistName } from '../lib/today-playlist-name';
 
 type RegisterDjWithTrackParams = {
   partyroomId: number;
@@ -40,7 +39,7 @@ export default function useRegisterDjWithTrack() {
   // 대기열 등록은 플레이리스트 단위로만 가능하다. 곡 하나로 등록하려면 담을 그릇이 필요해
   // 오늘 날짜 이름의 플레이리스트를 쓰고, 같은 날 재등록 시엔 목록이 불어나지 않게 재사용한다.
   const getPlaylistForToday = async () => {
-    const name = todayPlaylistName();
+    const name = new Date().toLocaleDateString('en-CA'); // 'en-CA' = YYYY-MM-DD
 
     return playlists.find((playlist) => playlist.name === name) ?? (await createPlaylist({ name }));
   };

--- a/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
@@ -1,11 +1,8 @@
-import { useCreatePlaylist } from '@/features/playlist/add/api/use-create-playlist.mutation';
-import { useAddPlaylistTrack } from '@/features/playlist/add-tracks';
-import { useFetchPlaylists } from '@/features/playlist/list';
 import { Music } from '@/shared/api/http/types/playlists';
 import { useDialog } from '@/shared/ui/components/dialog';
 import theme from '@/shared/ui/foundation/theme';
 import SearchTrackForDjing from './search-track-for-djing.component';
-import { useRegisterMeToQueue } from '../../register-me-to-queue';
+import { useQuickRegisterMeToQueue } from '../api/use-quick-register-me-to-queue.mutation';
 
 type RegisterDjWithTrackParams = {
   partyroomId: number;
@@ -14,10 +11,7 @@ type RegisterDjWithTrackParams = {
 
 export default function useRegisterDjWithTrack() {
   const { openDialog } = useDialog();
-  const { data: playlists = [] } = useFetchPlaylists();
-  const { mutateAsync: createPlaylist } = useCreatePlaylist();
-  const { mutateAsync: addTrackToPlaylist } = useAddPlaylistTrack();
-  const { mutate: registerMeToQueue } = useRegisterMeToQueue();
+  const { mutate: quickRegisterMeToQueue } = useQuickRegisterMeToQueue();
 
   const openTrackSearchDialog = (closeDjingDialog?: () => void) =>
     openDialog<Music>((onSelect, onCancel) => ({
@@ -36,29 +30,18 @@ export default function useRegisterDjWithTrack() {
       ),
     }));
 
-  // 대기열 등록은 플레이리스트 단위로만 가능하다. 곡 하나로 등록하려면 담을 그릇이 필요해
-  // 오늘 날짜 이름의 플레이리스트를 쓰고, 같은 날 재등록 시엔 목록이 불어나지 않게 재사용한다.
-  const getPlaylistForToday = async () => {
-    const name = new Date().toLocaleDateString('en-CA'); // 'en-CA' = YYYY-MM-DD
-
-    return playlists.find((playlist) => playlist.name === name) ?? (await createPlaylist({ name }));
-  };
-
   return async ({ partyroomId, closeDjingDialog }: RegisterDjWithTrackParams) => {
     const selectedTrack = await openTrackSearchDialog(closeDjingDialog);
     if (!selectedTrack) return;
 
-    const playlist = await getPlaylistForToday();
-
-    await addTrackToPlaylist({
-      listId: playlist.id,
-      linkId: selectedTrack.videoId,
+    quickRegisterMeToQueue({
+      partyroomId,
       name: selectedTrack.videoTitle,
+      linkId: selectedTrack.videoId,
       duration: selectedTrack.runningTime,
       thumbnailImage: selectedTrack.thumbnailUrl,
     });
 
-    registerMeToQueue({ partyroomId, playlistId: playlist.id });
     closeDjingDialog?.();
   };
 }

--- a/src/shared/api/__test__/handlers.ts
+++ b/src/shared/api/__test__/handlers.ts
@@ -248,6 +248,11 @@ export const handlers = [
     return new HttpResponse(null, { status: 201 });
   }),
 
+  // POST /v1/partyrooms/:id/dj-queue/quick — quickRegisterMeToQueue
+  http.post(`${BASE_URL}/v1/partyrooms/:id/dj-queue/quick`, () => {
+    return new HttpResponse(null, { status: 201 });
+  }),
+
   // DELETE /v1/partyrooms/:id/dj-queue/me — unregisterMeFromQueue
   http.delete(`${BASE_URL}/v1/partyrooms/:id/dj-queue/me`, () => {
     return new HttpResponse(null, { status: 204 });

--- a/src/shared/api/http/services/djs.ts
+++ b/src/shared/api/http/services/djs.ts
@@ -1,5 +1,6 @@
 import {
   RegisterMeToQueuePayload,
+  QuickRegisterMeToQueuePayload,
   ChangeMyPlaylistPayload,
   UnregisterMeFromQueuePayload,
   UnregisterDjFromQueuePayload,
@@ -17,6 +18,10 @@ export default class DjsService extends HTTPClient implements DjsClient {
 
   public registerMeToQueue({ partyroomId, ...body }: RegisterMeToQueuePayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue`, body);
+  }
+
+  public quickRegisterMeToQueue({ partyroomId, ...body }: QuickRegisterMeToQueuePayload) {
+    return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue/quick`, body);
   }
 
   public changeMyPlaylist({ partyroomId, ...body }: ChangeMyPlaylistPayload) {

--- a/src/shared/api/http/types/djs.ts
+++ b/src/shared/api/http/types/djs.ts
@@ -5,6 +5,14 @@ export type RegisterMeToQueuePayload = {
   playlistId: Playlist['id'];
 };
 
+export type QuickRegisterMeToQueuePayload = {
+  partyroomId: number;
+  name: string;
+  linkId: string;
+  duration: string;
+  thumbnailImage: string;
+};
+
 export type ChangeMyPlaylistPayload = {
   partyroomId: number;
   playlistId: Playlist['id'];
@@ -35,6 +43,7 @@ export type SkipPlaybackPayload = {
 
 export interface DjsClient {
   registerMeToQueue: (payload: RegisterMeToQueuePayload) => Promise<void>;
+  quickRegisterMeToQueue: (payload: QuickRegisterMeToQueuePayload) => Promise<void>;
   changeMyPlaylist: (payload: ChangeMyPlaylistPayload) => Promise<void>;
   unregisterMeFromQueue: (payload: UnregisterMeFromQueuePayload) => Promise<void>;
   unregisterDjFromQueue: (payload: UnregisterDjFromQueuePayload) => Promise<void>;

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -63,7 +63,9 @@ export type EventPropertyMap = {
   };
   'DJ Registered': {
     partyroom_id: number;
-    playlist_id: number;
+    // 곡 검색 즉시 등록은 서버가 플레이리스트를 만들어 담아 클라이언트가 id 를 모른다
+    playlist_id?: number;
+    track_id?: string;
   };
   'DJ Playlist Changed': {
     partyroom_id: number;

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -65,7 +65,6 @@ export type EventPropertyMap = {
     partyroom_id: number;
     // 곡 검색 즉시 등록은 서버가 플레이리스트를 만들어 담아 클라이언트가 id 를 모른다
     playlist_id?: number;
-    track_id?: string;
   };
   'DJ Playlist Changed': {
     partyroom_id: number;

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -240,10 +240,13 @@
       "register_queue": "Register for DJ Queue",
       "add_dj": "Add DJ",
       "selection_completed": "Selection Complete",
-      "select_dj_playlist": "Select DJ Playlist"
+      "select_dj_playlist": "Select DJ Playlist",
+      "search_and_register_dj": "Search a song and be a DJ",
+      "pick_from_my_playlist": "Choose from my playlist",
+      "register_with_this_song": "Be a DJ"
     },
     "para": {
-      "no_dj_crew": "No one is DJing now.\nWhy not become the DJ and make some noise!",
+      "no_dj_crew": "No one is DJing right now.\nPlay the first song!",
       "create_playlist_song": "Before you join the queue, please create a playlist with at least one song.",
       "cancel_dj_queue": "Cancel DJ queue registration",
       "cancel_dj_queue_confirm": "Do you want to remove yourself from the DJ queue?",
@@ -261,7 +264,10 @@
       "queue_lock_detail": "Locking prevents new DJ registrations and keeps the current queue as-is.",
       "playback_stopped_time_limit": "Playback stopped: a track exceeds this room's time limit ({{minutes}} min).",
       "playback_stopped_no_limit": "Playback stopped: no playable track.",
-      "not_playable_in_room": "Not playable here (exceeds this room's time limit)"
+      "not_playable_in_room": "Not playable here (exceeds this room's time limit)",
+      "search_song_to_dj": "Search for a song to DJ",
+      "select_song_to_dj": "Choose a song to DJ",
+      "start_djing_with_this_song": "Let's start DJing with this song"
     }
   },
   "db": {

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -240,10 +240,13 @@
       "register_queue": "DJ 대기 등록",
       "add_dj": "DJ 추가",
       "selection_completed": "선택완료",
-      "select_dj_playlist": "디제잉 플레이리스트 선택"
+      "select_dj_playlist": "디제잉 플레이리스트 선택",
+      "search_and_register_dj": "곡 검색하고 DJ 등록",
+      "pick_from_my_playlist": "내 플레이리스트에서 고르기",
+      "register_with_this_song": "이 곡으로 DJ 등록"
     },
     "para": {
-      "no_dj_crew": "현재 디제잉 인원이 없어요\n파티의 흥을 책임질 DJ가 되어보세요!",
+      "no_dj_crew": "현재 디제잉하는 사람이 없어요.\n첫 곡을 틀어보세요!",
       "create_playlist_song": "대기 등록을 위해 최소 1곡이 담긴 플레이리스트가 필요해요",
       "cancel_dj_queue": "DJ 대기 등록 취소",
       "cancel_dj_queue_confirm": "DJ 대기 등록을 취소하시겠습니까?",
@@ -261,7 +264,10 @@
       "queue_lock_detail": "잠그면 새 DJ 등록이 막히고, 현재 대기열만 유지돼요.",
       "playback_stopped_time_limit": "재생 시간 제한({{minutes}}분)을 초과하는 곡으로 재생이 중단되었습니다",
       "playback_stopped_no_limit": "재생 가능한 곡이 없어 재생이 중단되었습니다",
-      "not_playable_in_room": "이 방에선 재생 안 돼요 (재생 시간 제한 초과)"
+      "not_playable_in_room": "이 방에선 재생 안 돼요 (재생 시간 제한 초과)",
+      "search_song_to_dj": "디제잉할 곡을 검색하세요.",
+      "select_song_to_dj": "디제잉할 곡을 선택해 주세요",
+      "start_djing_with_this_song": "이 곡으로 디제잉을 시작해요"
     }
   },
   "db": {

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -231,7 +231,7 @@
   },
   "dj": {
     "title": {
-      "current_dj": "현재 디제잉",
+      "current_dj": "Now DJing",
       "dj_queue": "DJ 대기열",
       "time_limit": "디제잉 1회당 제한시간 : **{{minutes}}**분",
       "rule_guide": "디제잉 규칙 안내"

--- a/src/widgets/partyroom-djing-dialog/ui/dialog.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/dialog.component.tsx
@@ -16,15 +16,21 @@ export default function DjingDialog({ partyroomId, open, close }: Props) {
 
   if (!djingQueue) return;
 
+  const hasDj = !!djingQueue.djs.length;
+
   return (
     <Dialog
       open={open}
       onClose={close}
-      classNames={{ container: 'w-[800px] py-[36px] px-[40px] bg-black' }}
+      classNames={{
+        container: hasDj
+          ? 'w-[800px] py-[36px] px-[40px] bg-black'
+          : 'w-[520px] py-[36px] px-[40px]',
+      }}
       Body={
         <PartyroomIdContext.Provider value={partyroomId}>
           <DjingQueueContext.Provider value={djingQueue}>
-            {djingQueue.djs.length ? <Body onCancel={close} /> : <EmptyBody onCancel={close} />}
+            {hasDj ? <Body onCancel={close} /> : <EmptyBody onCancel={close} />}
           </DjingQueueContext.Provider>
         </PartyroomIdContext.Provider>
       }

--- a/src/widgets/partyroom-djing-dialog/ui/empty-body.component.test.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/empty-body.component.test.tsx
@@ -4,10 +4,20 @@ vi.mock('@/shared/lib/localization/renderer/index.ui', () => ({
 }));
 vi.mock('@/shared/ui/icons', () => ({
   PFClose: (props: any) => <svg data-testid='close-icon' {...props} />,
+  PFSearch: (props: any) => <svg data-testid='search-icon' {...props} />,
+  PFAddPlaylist: (props: any) => <svg data-testid='add-playlist-icon' {...props} />,
 }));
 vi.mock('./register-button.component', () => ({
   __esModule: true,
   default: () => <button data-testid='register-btn'>Register</button>,
+}));
+vi.mock('../lib/partyroom-id.context', () => ({
+  usePartyroomId: () => 1,
+}));
+
+const registerDjWithTrack = vi.fn();
+vi.mock('@/features/partyroom/register-dj-with-track', () => ({
+  useRegisterDjWithTrack: () => registerDjWithTrack,
 }));
 
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -16,7 +26,13 @@ import EmptyBody from './empty-body.component';
 
 beforeEach(() => {
   (useI18n as Mock).mockReturnValue({
-    dj: { title: { current_dj: 'Current DJ' } },
+    dj: {
+      title: { current_dj: 'Current DJ' },
+      btn: {
+        search_and_register_dj: 'Search a song and be a DJ',
+        pick_from_my_playlist: 'Choose from my playlist',
+      },
+    },
   });
 });
 
@@ -34,6 +50,16 @@ describe('EmptyBody', () => {
   test('RegisterButton을 렌더링한다', () => {
     render(<EmptyBody onCancel={vi.fn()} />);
     expect(screen.getByTestId('register-btn')).toBeTruthy();
+  });
+
+  test('곡 검색하고 DJ 등록 클릭 시 검색 등록 플로우를 연다', () => {
+    const onCancel = vi.fn();
+    render(<EmptyBody onCancel={onCancel} />);
+    fireEvent.click(screen.getByTestId('search-and-register-dj'));
+    expect(registerDjWithTrack).toHaveBeenCalledWith({
+      partyroomId: 1,
+      closeDjingDialog: onCancel,
+    });
   });
 
   test('닫기 아이콘 클릭 시 onCancel을 호출한다', () => {

--- a/src/widgets/partyroom-djing-dialog/ui/empty-body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/empty-body.component.tsx
@@ -1,17 +1,22 @@
+import { useRegisterDjWithTrack } from '@/features/partyroom/register-dj-with-track';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { LineBreakProcessor } from '@/shared/lib/localization/renderer';
 import { Trans } from '@/shared/lib/localization/renderer/index.ui';
+import { Button } from '@/shared/ui/components/button';
 import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
-import { PFClose } from '@/shared/ui/icons';
+import { PFAddPlaylist, PFClose, PFSearch } from '@/shared/ui/icons';
 import RegisterButton from './register-button.component';
+import { usePartyroomId } from '../lib/partyroom-id.context';
 
 export default function EmptyBody({ onCancel }: { onCancel: () => void | undefined }) {
   const t = useI18n();
+  const partyroomId = usePartyroomId();
+  const registerDjWithTrack = useRegisterDjWithTrack();
 
   return (
     <>
-      <header className='flex justify-between items-center h-[48px] pt-[12px]'>
+      <header className='flex justify-between items-center'>
         <Typography type='title2' className='text-start'>
           {t.dj.title.current_dj}
         </Typography>
@@ -23,14 +28,28 @@ export default function EmptyBody({ onCancel }: { onCancel: () => void | undefin
         />
       </header>
 
-      <div className='h-[388px] flexRowCenter'>
-        <div className='flexColCenter gap-[24px]'>
-          <Typography type='body2' className='text-center'>
-            <Trans i18nKey='dj.para.no_dj_crew' processors={[new LineBreakProcessor()]} />
-          </Typography>
+      <Typography type='body2' className='my-[40px] text-center text-gray-300'>
+        <Trans i18nKey='dj.para.no_dj_crew' processors={[new LineBreakProcessor()]} />
+      </Typography>
 
-          <RegisterButton />
-        </div>
+      <div className='flexCol gap-[12px]'>
+        <Button
+          size='xl'
+          className='w-full'
+          Icon={<PFSearch />}
+          onClick={() => registerDjWithTrack({ partyroomId, closeDjingDialog: onCancel })}
+          data-testid='search-and-register-dj'
+        >
+          {t.dj.btn.search_and_register_dj}
+        </Button>
+
+        <RegisterButton
+          size='xl'
+          color='secondary'
+          className='w-full'
+          Icon={<PFAddPlaylist />}
+          label={t.dj.btn.pick_from_my_playlist}
+        />
       </div>
     </>
   );

--- a/src/widgets/partyroom-djing-dialog/ui/register-button.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/register-button.component.tsx
@@ -4,13 +4,15 @@ import useDjingGuide from '@/features/playlist/djing-guide/ui/use-djing-guide.ho
 import { useFetchPlaylists } from '@/features/playlist/list';
 import { QueueStatus } from '@/shared/api/http/types/@enums';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
-import { Button } from '@/shared/ui/components/button';
+import { Button, ButtonProps } from '@/shared/ui/components/button';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { TooltipTrigger } from '@/shared/ui/components/tooltip';
 import { useDjingQueue } from '../lib/djing-queue.context';
 import { usePartyroomId } from '../lib/partyroom-id.context';
 
-export default function RegisterButton() {
+type Props = Omit<ButtonProps, 'onClick' | 'children'> & { label?: string };
+
+export default function RegisterButton({ label, ...buttonProps }: Props) {
   const t = useI18n();
   const { data: playlists = [] } = useFetchPlaylists();
   const { openAlertDialog } = useDialog();
@@ -40,8 +42,13 @@ export default function RegisterButton() {
 
   return (
     <TooltipTrigger title={isLocked ? t.dj.para.queue_lock_detail : undefined}>
-      <Button size='lg' onClick={registerMeToDjQueue} data-testid='register-dj-queue'>
-        {t.dj.btn.register_queue}
+      <Button
+        size='lg'
+        onClick={registerMeToDjQueue}
+        data-testid='register-dj-queue'
+        {...buttonProps}
+      >
+        {label ?? t.dj.btn.register_queue}
       </Button>
     </TooltipTrigger>
   );


### PR DESCRIPTION
## Summary

디제잉 중인 사람이 없을 때 뜨는 모달을 신규 시안대로 다시 퍼블리싱하고, 진입 경로를 둘로 나눴다.
`곡 검색하고 DJ 등록`은 곡 하나만 골라 바로 대기열에 등록한다. `내 플레이리스트에서 고르기`는
기존 플레이리스트 선택 다이얼로그를 그대로 쓴다.

## Decisions

- 곡 검색 등록은 quick API 단일 호출로 처리한다 — 플레이리스트 생성·곡 추가를 서버가 맡아 클라이언트가 중간 상태를 들고 있지 않는다

## Review Points

- `src/shared/lib/analytics/events.ts` — `DJ Registered` 의 `playlist_id` 를 optional 로 바꿨다. 대시보드가 이 필드를 필수로 가정하면 영향
- `src/shared/api/http/services/djs.ts` — quick 엔드포인트 응답을 `void` 로 뒀다. 서버가 body 를 준다면 수정 필요
- `src/shared/lib/localization/dictionaries/ko.json` — `dj.title.current_dj` 를 바꿨다. 이 모달 외 파티룸 상세 패널에서도 쓰인다

## Issue

Closes #464

## Reference

- 검증: `yarn test` 1736 passed, `tsc --noEmit`, `eslint` 통과
- 검증: 빈 방에서 두 진입 경로 브라우저 수동 확인 (작성자)
- 못 한 것: quick API 실서버 연동 확인, e2e 시나리오 미추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGDBZbNQYD9ziiCjsPL1de
