### PR TITLE
fix(partyroom): 재연결 핸들러 누수 제거 — 재입장 resync를 단일 슬롯으로 (#469)

### DIFF
--- a/src/entities/partyroom-client/lib/partyroom-client.test.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.test.ts
@@ -103,6 +103,41 @@ describe('PartyroomClient', () => {
     expect(mockSocketInstance.unsubscribe).toHaveBeenCalledWith('/sub/partyrooms/10');
   });
 
+  describe('#469 재연결 resync 핸들러 — 단일 슬롯 + teardown 정리 (누수 차단)', () => {
+    test('setRoomReconnectHandler → socketClient.onConnect(cb, {skipCurrent:true}) 로 등록', () => {
+      const cb = vi.fn();
+      mockSocketInstance.onConnect.mockReturnValue(vi.fn());
+
+      client.setRoomReconnectHandler(cb);
+
+      expect(mockSocketInstance.onConnect).toHaveBeenCalledWith(cb, { skipCurrent: true });
+    });
+
+    test('두 번째 등록 시 이전 핸들러를 해제한다 (단일 슬롯, 방마다 누적 X)', () => {
+      const dispose1 = vi.fn();
+      const dispose2 = vi.fn();
+      mockSocketInstance.onConnect.mockReturnValueOnce(dispose1).mockReturnValueOnce(dispose2);
+
+      client.setRoomReconnectHandler(vi.fn());
+      client.setRoomReconnectHandler(vi.fn());
+
+      expect(dispose1).toHaveBeenCalledTimes(1); // 이전 방 핸들러 해제
+      expect(dispose2).not.toHaveBeenCalled();
+    });
+
+    test('unsubscribeCurrentRoom(=teardown 경로) 이 재연결 핸들러를 해제한다', () => {
+      const dispose = vi.fn();
+      mockSocketInstance.onConnect.mockReturnValue(dispose);
+      mockSocketInstance.subscriptions = [];
+      client.subscribe(10, vi.fn());
+      client.setRoomReconnectHandler(vi.fn());
+
+      client.unsubscribeCurrentRoom();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('sendChatMessage', () => {
     test('구독 전에 호출하면 Error를 throw한다', () => {
       expect(() => client.sendChatMessage('hello')).toThrow(

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -9,6 +9,9 @@ import { recordClientEvent } from '@/shared/lib/observability/client-events';
 export default class PartyroomClient {
   private socketClient: SocketClient;
   private subscribedRoomId: number | undefined;
+  // #469 현재 방의 "재연결 시 재입장(resync)" 핸들러 해제자. 단일 슬롯 — 방 전환 시 교체되고
+  // unsubscribeCurrentRoom(teardown 경로)에서 정리되므로 방마다 핸들러가 누적되지 않는다.
+  private roomReconnectDisposer: (() => void) | undefined;
 
   public constructor() {
     this.socketClient = new SocketClient();
@@ -25,7 +28,18 @@ export default class PartyroomClient {
   }
 
   public onConnect(callback: () => void, options?: OnConnectOptions) {
-    this.socketClient.onConnect(callback, options);
+    return this.socketClient.onConnect(callback, options);
+  }
+
+  /**
+   * #469 현재 방의 재연결 resync 핸들러를 단일 슬롯으로 등록한다. 이전 방의 핸들러는 교체(해제)되고,
+   * teardown 이 호출하는 {@link unsubscribeCurrentRoom} 에서 함께 정리되므로 `onConnectQueue` 에
+   * 방마다 핸들러가 누적되지 않는다 — 구독의 "destination당 1개 replace" 정책과 동일한 단일-방 생명주기.
+   */
+  public setRoomReconnectHandler(callback: () => void) {
+    this.roomReconnectDisposer?.();
+    // skipCurrent: 등록 시점의 연결엔 미발화(초기 enter 담당) → 이후 재연결에만 resync.
+    this.roomReconnectDisposer = this.socketClient.onConnect(callback, { skipCurrent: true });
   }
 
   /**
@@ -65,6 +79,10 @@ export default class PartyroomClient {
     const roomId = this.subscribedRoomId;
     this.socketClient.unsubscribe(`/sub/partyrooms/${roomId}`);
     this.subscribedRoomId = undefined;
+    // #469 재연결 resync 핸들러도 구독과 함께 정리 — 방을 떠나면 이 방의 재입장 핸들러가
+    // onConnectQueue 에 남아 재연결마다 stale enter 를 발사하던 누수를 차단.
+    this.roomReconnectDisposer?.();
+    this.roomReconnectDisposer = undefined;
     if (roomId != null) {
       recordClientEvent({ type: 'PARTYROOM_UNSUBSCRIBE', partyroomId: roomId });
     }

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -30,6 +30,7 @@ import { useEnterPartyroom } from './use-enter-partyroom';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
 
 const mockOnConnect = vi.fn();
+const mockSetRoomReconnectHandler = vi.fn();
 const mockMutate = vi.fn();
 const mockInit = vi.fn();
 const mockPush = vi.fn();
@@ -41,6 +42,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (usePartyroomClient as Mock).mockReturnValue({
     onConnect: mockOnConnect,
+    setRoomReconnectHandler: mockSetRoomReconnectHandler,
     subscribe: vi.fn(),
   });
   (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(vi.fn());
@@ -127,30 +129,32 @@ describe('useEnterPartyroom', () => {
   });
 });
 
-describe('useEnterPartyroom resync (#402)', () => {
-  // calls[0] = once enter, calls[1] = resync(non-once)
+describe('useEnterPartyroom 재연결 resync (#402/#469)', () => {
+  // #469: onConnect 는 초기 enter(once) 1회만 등록되고, resync 는 그 once 핸들러 실행 시
+  // setRoomReconnectHandler 로 단일 슬롯 등록된다(방마다 누적 X). 아래는 그 resync 콜백을 꺼내온다.
   const registerAndGetResync = (partyroomId: number) => {
     const { result } = renderHook(() => useEnterPartyroom(partyroomId));
     act(() => result.current());
-    return mockOnConnect.mock.calls[1][0] as () => void;
+    mockOnConnect.mock.calls[0][0](); // once 핸들러 → 초기 enter + resync 등록
+    mockMutate.mockClear(); // 초기 enter 호출 제거 → 이후 resync enter 가 calls[0]
+    return mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
   };
 
-  test('resync 핸들러를 비-once 로 등록한다 (2번째 onConnect, options 없음)', () => {
+  test('#469 onConnect 는 once 1회만(재연결 핸들러 누적 없음), resync 는 setRoomReconnectHandler 로 등록', () => {
     const { result } = renderHook(() => useEnterPartyroom(1));
     act(() => result.current());
-    expect(mockOnConnect).toHaveBeenNthCalledWith(2, expect.any(Function));
-  });
 
-  test('첫 연결은 skip — mutate 미호출', () => {
-    const resync = registerAndGetResync(7);
-    resync(); // 첫 발화 = firstConnect skip
-    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockOnConnect).toHaveBeenCalledTimes(1);
+    expect(mockOnConnect).toHaveBeenCalledWith(expect.any(Function), { once: true });
+    expect(mockSetRoomReconnectHandler).not.toHaveBeenCalled();
+
+    mockOnConnect.mock.calls[0][0](); // once 실행 시 resync 등록
+    expect(mockSetRoomReconnectHandler).toHaveBeenCalledWith(expect.any(Function));
   });
 
   test('재연결 시 enter(tryEnter) 호출', () => {
     const resync = registerAndGetResync(7);
-    resync(); // skip
-    resync(); // 재연결
+    resync();
     expect(mockMutate).toHaveBeenCalledWith(
       expect.objectContaining({ partyroomId: 7 }),
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
@@ -159,7 +163,6 @@ describe('useEnterPartyroom resync (#402)', () => {
 
   test('reactivated=false → setup 미호출, DJ큐 invalidate', () => {
     const resync = registerAndGetResync(7);
-    resync();
     resync();
     mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: false });
     expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
@@ -171,14 +174,12 @@ describe('useEnterPartyroom resync (#402)', () => {
     (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
     const resync = registerAndGetResync(7);
     resync();
-    resync();
     mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: true });
     expect(partyroomsService.getSetupInfo).toHaveBeenCalled();
   });
 
   test('enter onError → 로비', () => {
     const resync = registerAndGetResync(7);
-    resync();
     resync();
     mockMutate.mock.calls[0][1].onError();
     expect(mockPush).toHaveBeenCalledWith('/parties');
@@ -266,15 +267,15 @@ describe('플레이백 요약 추적기 배선 (#444)', () => {
     });
   });
 
-  test('L2: 재연결(비-once onConnect) 시 clear — 첫 연결 skip에서는 clear하지 않음', () => {
+  test('L2: 재연결 resync 발화 시 추적기를 clear한다 (#469 setRoomReconnectHandler)', () => {
     const { result } = renderHook(() => useEnterPartyroom(7));
     act(() => result.current());
-    const resync = mockOnConnect.mock.calls[1][0] as () => void;
+    mockOnConnect.mock.calls[0][0](); // once 핸들러 → resync 등록
+    const resync = mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
 
-    resync(); // 첫 연결 skip
-    expect(mockTrackerClear).not.toHaveBeenCalled();
+    expect(mockTrackerClear).not.toHaveBeenCalled(); // 등록만으론 clear 안 함
 
-    resync(); // 재연결
+    resync(); // 재연결 발화
     expect(mockTrackerClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   useHandlePartyroomSubscriptionEvent,
@@ -29,8 +28,6 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   const router = useAppRouter();
 
   const entrySource: EntrySource = options.entrySource ?? 'direct';
-  // 재연결 resync 의 첫 연결 skip 가드 (연결 간 보존). 첫 연결은 아래 once enter 가 담당. (#402)
-  const firstConnect = useRef(true);
 
   const setup = async (enterResponse: EnterResponse) => {
     // L1: 방 enter/재수화 시작 시 무조건 clear — 이전 방 스냅샷이 새 방 채팅에 방출되는 누출 방지
@@ -102,6 +99,36 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   return () => {
     client.onConnect(
       () => {
+        // #469 재연결 resync 를 단일 슬롯으로 등록한다. skipCurrent 라 현재 연결엔 미발화(초기 enter 가
+        // 담당)하고 이후 재연결에만 동작하며, teardown 의 unsubscribeCurrentRoom 이 해제하므로
+        // 방마다 onConnectQueue 에 누적되지 않는다 (기존 firstConnect ref 꼼수 제거).
+        client.setRoomReconnectHandler(() => {
+          // L2: 재연결마다 clear — 끊김이 곡 경계를 넘었을 때 낡은 스냅샷에 새 곡 counts가 오염된
+          // 틀린 구획 방출 방지. disconnect 콜백이 공개돼 있지 않아 재연결 시점 clear가 의미상 등가
+          // (끊김~재연결 사이엔 방출/시드 이벤트가 처리되지 않음). 놓친 경계는 기념하지 않는다.
+          useCurrentPartyroom.getState().playbackSummaryTracker.clear();
+          enter(
+            { partyroomId },
+            {
+              onSuccess: (enterResponse) => {
+                const invalidateDjQueue = () =>
+                  queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
+                if (enterResponse.reactivated) {
+                  // 멤버십 상실 → 풀 재수화(검정 해소). 룸 재구독은 추가하지 않음(handleConnect 가 이미 reconcile).
+                  silent(setup(enterResponse), {
+                    onSuccess: invalidateDjQueue,
+                    onError: () => router.push('/parties'),
+                  });
+                } else {
+                  // 멤버십 유지 → 경량(플레이어/구독 무영향)
+                  invalidateDjQueue();
+                }
+              },
+              onError: () => router.push('/parties'),
+            }
+          );
+        });
+
         enter(
           { partyroomId },
           {
@@ -128,38 +155,6 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
       },
       { once: true }
     );
-
-    // 재연결 resync (비-once). 첫 연결은 firstConnect ref 로 skip(이중 tryEnter 방지). (#402)
-    client.onConnect(() => {
-      if (firstConnect.current) {
-        firstConnect.current = false;
-        return;
-      }
-      // L2: 재연결마다 clear — 끊김이 곡 경계를 넘었을 때 낡은 스냅샷에 새 곡 counts가 오염된
-      // 틀린 구획 방출 방지. disconnect 콜백이 공개돼 있지 않아 재연결 시점 clear가 의미상 등가
-      // (끊김~재연결 사이엔 방출/시드 이벤트가 처리되지 않음). 놓친 경계는 기념하지 않는다.
-      useCurrentPartyroom.getState().playbackSummaryTracker.clear();
-      enter(
-        { partyroomId },
-        {
-          onSuccess: (enterResponse) => {
-            const invalidateDjQueue = () =>
-              queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
-            if (enterResponse.reactivated) {
-              // 멤버십 상실 → 풀 재수화(검정 해소). 룸 재구독은 추가하지 않음(handleConnect 가 이미 reconcile).
-              silent(setup(enterResponse), {
-                onSuccess: invalidateDjQueue,
-                onError: () => router.push('/parties'),
-              });
-            } else {
-              // 멤버십 유지 → 경량(플레이어/구독 무영향)
-              invalidateDjQueue();
-            }
-          },
-          onError: () => router.push('/parties'),
-        }
-      );
-    });
   };
 }
 

--- a/src/shared/api/websocket/client.test.ts
+++ b/src/shared/api/websocket/client.test.ts
@@ -113,6 +113,43 @@ describe('SocketClient', () => {
     });
   });
 
+  describe('onConnect 해제 함수 반환 + skipCurrent (#469)', () => {
+    test('반환된 해제 함수 호출 시 이후 (재)연결에서 콜백이 실행되지 않는다 (핸들러 누수 차단)', () => {
+      const sc = new SocketClient();
+      const callback = vi.fn();
+
+      const dispose = sc.onConnect(callback); // 비-once, 미연결 → 큐 등록
+      triggerConnect(sc);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      dispose();
+      callback.mockClear();
+      // disconnect → 재연결
+      getStompClient(sc).__config.onWebSocketClose();
+      triggerConnect(sc);
+      expect(callback).not.toHaveBeenCalled(); // 해제되어 재발화 없음
+    });
+
+    test('연결됨 + once → 반환값은 안전한 no-op (큐에 없음)', () => {
+      const sc = new SocketClient();
+      getStompClient(sc).connected = true;
+      const dispose = sc.onConnect(vi.fn(), { once: true });
+      expect(() => dispose()).not.toThrow();
+    });
+
+    test('skipCurrent: 이미 연결돼 있어도 즉시 실행하지 않고 다음 (재)연결에만 실행한다', () => {
+      const sc = new SocketClient();
+      getStompClient(sc).connected = true;
+      const callback = vi.fn();
+
+      sc.onConnect(callback, { skipCurrent: true });
+      expect(callback).not.toHaveBeenCalled(); // 현재 연결엔 미발화 (초기 enter 와 이중 발사 방지)
+
+      triggerConnect(sc); // 다음 (재)연결
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('handleConnect (내부)', () => {
     test('큐의 모든 콜백을 실행하고 once 항목을 제거한다', () => {
       const sc = new SocketClient();

--- a/src/shared/api/websocket/client.ts
+++ b/src/shared/api/websocket/client.ts
@@ -34,6 +34,13 @@ export type OnConnectOptions = {
    * @default false
    */
   once?: boolean;
+  /**
+   * `true`일 시, 등록 시점에 이미 연결돼 있어도 즉시 실행하지 않고 이후의 (재)연결에만 실행합니다.
+   * "현재 연결이 아니라 다음 연결부터" 동작해야 하는 재연결 resync 핸들러용(#469) — 이게 없으면
+   * 이미 연결된 상태에서 등록 시 즉시 발화해 초기 enter 와 이중 tryEnter 가 됩니다.
+   * @default false
+   */
+  skipCurrent?: boolean;
 };
 type OnConnect = {
   callback: () => void;
@@ -128,14 +135,22 @@ export default class SocketClient {
    * 커넥션이 맺히면 콜백을 실행합니다.
    * **이미 커넥션이 맺혔을 경우 즉시 실행됩니다.**
    * 기본적으론 매 연결(reconnect 등)마다 실행되지만, `options.once`가 `true`일 시 최초 connect 시에만 실행됩니다.
+   *
+   * @returns 등록을 해제하는 함수. 비-`once` 핸들러(재연결마다 실행)는 소비자 정리 시점에
+   *   반드시 해제해야 한다 — 미해제 시 `onConnectQueue`에 누적되어 재연결마다 stale 콜백이
+   *   발사된다(#469). 큐에 남지 않는 경우(연결됨+`once` 즉시 실행)에도 안전한 no-op 을 반환한다.
    */
-  public onConnect(callback: () => void, options?: OnConnectOptions) {
-    if (this.connected) {
+  public onConnect(callback: () => void, options?: OnConnectOptions): () => void {
+    if (this.connected && !options?.skipCurrent) {
       callback();
-      if (options?.once) return;
+      if (options?.once) return () => {};
     }
 
-    this.onConnectQueue.push({ callback, options });
+    const entry: OnConnect = { callback, options };
+    this.onConnectQueue.push(entry);
+    return () => {
+      this.onConnectQueue = this.onConnectQueue.filter((queued) => queued !== entry);
+    };
   }
 
   /**


### PR DESCRIPTION
## 배경 (#469)

파티룸을 옮겨다니면 `onConnect` 재연결 핸들러가 **방마다 누적**된다. `SocketClient.onConnect`는 콜백을 큐에 push 하고 재연결 시 전체 실행 후 `once`만 제거하는데, `useEnterPartyroom`가 등록하는 **비-`once` 재연결 resync 핸들러**를 `useTeardownPartyroom`가 제거하지 않아 잔존한다. → 재연결 한 번에 과거 방 전부의 `tryEnter`가 동시 발사.

## 심각도 (단순 최적화 아님)

플랫폼 #349(유저당 활성 방 1개 DB 불변식, PR #350) 배포 후 이 버스트의 증상이 **로비 강제 이탈**로 바뀐다: stale 핸들러들과 현재 방의 `enter`가 동시 발사 → 새 `uk_crew_active_user` 유니크로 하나만 이기고 나머지는 CRW-005 CONFLICT → `enter`의 `onError`(`router.push('/parties')`)가 발화해 정상적으로 방에 있던 유저가 로비로 튕긴다. + 재연결마다 N개 중복 `tryEnter` 부하.

## 변경 (프론트 단독)

재연결 resync를 **누적 핸들러 큐**가 아니라, 구독(`subscriptions[]` SoT + destination당 1개 replace)과 동일한 **단일 슬롯·교체·teardown 정리** 생명주기로 다룬다.

- `SocketClient.onConnect`: **해제 함수 반환** + `skipCurrent` 옵션(등록 시점에 이미 연결돼 있어도 즉시 실행하지 않고 이후 재연결에만 발화 — 초기 enter와 이중 발사 방지).
- `PartyroomClient`: 재연결 resync를 **단일 슬롯**(`setRoomReconnectHandler`)으로 소유. 방 전환 시 이전 핸들러 교체, `unsubscribeCurrentRoom`(teardown 경로)에서 함께 해제 → 방마다 누적 없음.
- `useEnterPartyroom`: resync를 초기 `enter`(once) 핸들러 안에서 단일 슬롯 등록. 기존 `firstConnect` ref 꼼수 제거(skipCurrent가 대체).

## 검증

- 유닛 55/55 (신규 회귀: 해제 함수로 재발화 차단 · `skipCurrent` 미즉시발화 · 단일 슬롯 교체 · `unsubscribeCurrentRoom` 정리)
- `tsc --noEmit` clean · **pre-push 전체 유닛 스위트 통과**
- E2E 스모크: 로컬 백엔드(#349 제약 적용) 대상 방 입장 플로우 green

## 관련
- 플랫폼 #349 / PR pfplay-platform#350 (서버 불변식) — 상호보완(서버=정합성 보장, 본 PR=버스트 제거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
