### PR TITLE
test(e2e): dj-register flake 근본 해결 — 스펙 간 플리 오염 차단(이름 선택) + 큐 refetch 견고화 (#471)

### DIFF
--- a/e2e/mobile/dj-register.spec.ts
+++ b/e2e/mobile/dj-register.spec.ts
@@ -29,6 +29,12 @@ test.describe('mobile DJ register flow', () => {
   let desktopCtx: BrowserContext;
   let user2DesktopCtx: BrowserContext;
   let partyroomUrl: string;
+  // #471 본 spec 이 만든 fresh 플레이리스트의 이름 — SelectPlaylistSheet 에서 이름으로 정확히
+  // 선택하기 위해 보관. `.first()` 선택은 풀스위트에서 다른 프로젝트/스펙(desktop e2e-a 도 같은
+  // a-user2 를 씀)이 기본 플리("내 플레이리스트")에 추가한 트랙에 오염된 카드를 집을 수 있고,
+  // 그 트랙이 방 재생제한(7분)을 넘으면 백엔드가 등록 직후 DJ_NO_PLAYABLE_TRACK 으로 큐에서
+  // 제거해 본 spec 이 실패한다(계측으로 확정: POST 201 → DEACTIVATE djs:[] → GET djs:[]).
+  let djPlaylistName: string;
   // #471 호스트(user1) page 를 테스트 내내 열어두기 위한 참조. 셋업이 이 page 를 닫으면
   // 호스트 presence grace(10s) 카운트다운이 시작돼, cold/풀스위트 부하에서 grace 만료 →
   // 방 TERMINATED 로 붕괴하며 user2 의 DJ 등록이 유실된다(dj-queue 빈 채로 단언 실패).
@@ -69,7 +75,8 @@ test.describe('mobile DJ register flow', () => {
     user2DesktopCtx = await newDesktopUserContext(browser, 'a-user2.json');
     const user2SetupPage = await user2DesktopCtx.newPage();
     attachErrorTracing(user2SetupPage, log);
-    await createPlaylistWithTracks(user2SetupPage, chunk4PlaylistName('MDJpl'));
+    djPlaylistName = chunk4PlaylistName('MDJpl');
+    await createPlaylistWithTracks(user2SetupPage, djPlaylistName);
     log('user2 playlist created');
     await user2SetupPage.close();
     await user2DesktopCtx.close();
@@ -93,6 +100,36 @@ test.describe('mobile DJ register flow', () => {
     const page: Page = await user2Context.newPage();
     attachErrorTracing(page, log);
 
+    // ── #471 진단 로깅(유지): 실패 시 원인 즉시 판별용 — 로그 전용, 동작 무영향 ────────
+    // 1) register POST 요청/응답 status+body — 등록 API 성공 여부를 직접 확정
+    //    (가이드 모달 노출은 mutation 성공의 증거가 아닐 수 있음)
+    // 2) 모든 dj-queue GET 응답 body — enqueue 후 GET이 비었는지 vs GET 자체가 안 떴는지
+    // 3) WS 프레임 중 DJ_QUEUE 관련 — 이벤트가 클라에 실제 도달했는지
+    page.on('request', (req) => {
+      if (req.url().includes('dj-queue')) {
+        log(`[NET→] ${req.method()} ${req.url()} post=${(req.postData() ?? '').slice(0, 120)}`);
+      }
+    });
+    page.on('response', (res) => {
+      if (res.url().includes('dj-queue')) {
+        res
+          .text()
+          .catch(() => '(body read fail)')
+          .then((body) =>
+            log(
+              `[NET←] ${res.request().method()} ${res.status()} ${res.url()} body=${body.slice(0, 300)}`
+            )
+          );
+      }
+    });
+    page.on('websocket', (ws) => {
+      ws.on('framereceived', (frame) => {
+        const p = typeof frame.payload === 'string' ? frame.payload : '';
+        if (/DJ_QUEUE|dj_queue/i.test(p)) log(`[WS←] ${p.replace(/\s+/g, ' ').slice(0, 400)}`);
+      });
+    });
+    // ── 계측 끝 ──────────────────────────────────────────────────────────────
+
     log('mobile enter');
     await enterMobileRoomAndWaitReady(page, partyroomUrl);
     log('queue tab');
@@ -100,11 +137,14 @@ test.describe('mobile DJ register flow', () => {
     log('register click');
     await page.getByTestId('member-action-register').click();
 
-    // SelectPlaylistSheet 의 musicCount>0 카드 (disabled 아님) 선택.
+    // SelectPlaylistSheet 에서 **본 spec 이 만든 플리를 이름으로 정확히** 선택 (#471).
+    // `.first()` 는 다른 스펙이 오염시킨 기본 플리(재생제한 초과 트랙 포함 가능)를 집어
+    // 등록 직후 백엔드 DJ_NO_PLAYABLE_TRACK 제거 → flake 였다. 상세는 describe 상단 주석.
     const enabledCard = page
       .locator(
         '[data-testid^="mobile-playlist-card-"]:not([data-testid$="-add-tracks"]):not([disabled])'
       )
+      .filter({ hasText: djPlaylistName })
       .first();
     await expect(enabledCard).toBeVisible({ timeout: 15_000 });
     await enabledCard.click();

--- a/e2e/mobile/dj-register.spec.ts
+++ b/e2e/mobile/dj-register.spec.ts
@@ -29,6 +29,10 @@ test.describe('mobile DJ register flow', () => {
   let desktopCtx: BrowserContext;
   let user2DesktopCtx: BrowserContext;
   let partyroomUrl: string;
+  // #471 호스트(user1) page 를 테스트 내내 열어두기 위한 참조. 셋업이 이 page 를 닫으면
+  // 호스트 presence grace(10s) 카운트다운이 시작돼, cold/풀스위트 부하에서 grace 만료 →
+  // 방 TERMINATED 로 붕괴하며 user2 의 DJ 등록이 유실된다(dj-queue 빈 채로 단언 실패).
+  let hostPage: Page;
 
   test.beforeAll(async ({ browser }) => {
     // chunk 3.1 Mode C pattern: cold-start 여파 + me-pending guard 바운스 대비.
@@ -37,8 +41,8 @@ test.describe('mobile DJ register flow', () => {
     const log = (m: string) => console.log(`[dj-register beforeAll][${Date.now() - t0}ms] ${m}`);
 
     desktopCtx = await newDesktopUserContext(browser, 'a-user1.json');
-    const setupPage = await desktopCtx.newPage();
-    attachErrorTracing(setupPage, log);
+    hostPage = await desktopCtx.newPage();
+    attachErrorTracing(hostPage, log);
 
     // backend '1 user 1 host' 제약 회피용 cleanup. user1 host 로 stale 잡혀있으면
     // createPartyroom 이 '이미 다른 파티룸의 호스트입니다' 로 fail.
@@ -47,15 +51,18 @@ test.describe('mobile DJ register flow', () => {
     log('cleanup done');
 
     log('goto /parties');
-    await setupPage.goto('/parties');
+    await hostPage.goto('/parties');
     log('createPartyroom');
     partyroomUrl = await createPartyroom(
-      setupPage,
+      hostPage,
       chunk4PartyroomName('MDJ'),
       'mobile dj register'
     );
     log(`partyroom created: ${partyroomUrl}`);
-    await setupPage.close();
+    // #471 hostPage.close() 를 하지 않는다 — createPartyroom 이 호스트를 방 안(/parties/{id})까지
+    // 진입시키므로, page 를 닫으면 호스트 WS 끊김 → presence PENDING_EXIT → grace 만료 →
+    // forceOffline 퇴장 → 방 TERMINATED 로 이어진다. 호스트를 present 로 유지해 방을 테스트
+    // 내내 살리고, afterAll 의 desktopCtx.close() 가 이 page 를 정리한다.
 
     // user2 의 playlist (musicCount>0) fresh 생성 — 데스크탑 viewport 에서.
     log('setup user2 playlist (desktop)');

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.test.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.test.ts
@@ -76,6 +76,21 @@ describe('useDjQueueChangedCallback', () => {
     expect(queryClient.getQueryData([QueryKeys.DjingQueue, undefined])).toBeUndefined();
   });
 
+  test('#471 캐시가 비어있으면(prev undefined) refetchType:"all"로 invalidate — inactive 큐도 강제 refetch', () => {
+    const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    // setQueryData 하지 않음 → prev undefined. event.djs 만으론 DjingQueue 전체를 못 만들어
+    // refetch 로 채우는데, 큐 쿼리가 inactive(시트/모달에 가려짐)면 기본 'active' refetch 가
+    // 안 뛰어 등록이 UI 에 반영되지 않던 문제(#471). refetchType:'all' 로 강제해야 한다.
+    result.current(createEvent());
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.DjingQueue, 123],
+      refetchType: 'all',
+    });
+  });
+
   test('orderNumber가 가장 낮은 DJ를 현재 DJ로 갱신한다', () => {
     const { result, queryClient } = renderWithClient(() => useDjQueueChangedCallback());
     queryClient.setQueryData([QueryKeys.DjingQueue, 123], createQueue());

--- a/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts
+++ b/src/entities/partyroom-client/lib/subscription-callbacks/use-dj-queue-changed-callback.hook.ts
@@ -52,7 +52,10 @@ export default function useDjQueueChangedCallback() {
     updateCurrentDj(currentDj ? { crewId: currentDj.crewId } : undefined);
     queryClient.setQueryData<DjingQueue>(queryKey, (prev) => {
       if (!prev) {
-        queryClient.invalidateQueries({ queryKey });
+        // #471 event.djs 만으론 DjingQueue 전체(playbackActivated/queueStatus/registered/playback)를
+        // 구성할 수 없어 refetch 로 채운다. 단 큐 쿼리가 inactive(시트/모달에 가려짐)면 기본 'active'
+        // refetch 가 안 뛰어 캐시가 빈 채로 남으므로 refetchType:'all' 로 inactive 까지 강제한다.
+        queryClient.invalidateQueries({ queryKey, refetchType: 'all' });
         return prev;
       }
 

--- a/src/features/partyroom/register-me-to-queue/api/use-register-me-to-queue.mutation.ts
+++ b/src/features/partyroom/register-me-to-queue/api/use-register-me-to-queue.mutation.ts
@@ -14,6 +14,10 @@ export const useRegisterMeToQueue = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.DjingQueue, variables.partyroomId],
+        // #471 refetchType:'all' — 등록 시점 DjingQueue 쿼리가 SelectPlaylistSheet/가이드 모달에
+        // 가려 inactive 이면 기본 'active' refetch 가 동작하지 않아 등록이 UI 에 반영되지 않는다
+        // (백엔드 enqueue 성공·DjQueueChanged 발행에도 큐 캐시가 빈 채로 남음). inactive 까지 강제.
+        refetchType: 'all',
       });
       track('DJ Registered', {
         partyroom_id: variables.partyroomId,


### PR DESCRIPTION
## 요약 (#471)

`dj-register.spec.ts` 풀스위트 flake의 근본원인을 계측(POST/GET/WS 캡처 + 백엔드 로그 + DB)으로 확정하고 해결. 부수적으로 발견된 실제 제품 견고성 버그(inactive 큐 쿼리 미갱신) 수정 포함.

## 확정된 근본원인 — 스펙 간 데이터 오염 (커밋 3)

- SelectPlaylistSheet 의 `.first()` 선택이, 풀스위트에서 **다른 프로젝트/스펙(desktop e2e-a 도 같은 a-user2 계정 사용)이 기본 플리("내 플레이리스트")에 추가한 트랙**에 오염된 카드를 집는다.
- 그 트랙이 방 재생제한(7분)을 초과(실측 10:42 "Song Quiz" 영상)하면, 백엔드가 등록 직후 **정상 로직**으로 DJ 를 제거한다: `[enqueueDj] SAVED` → `DJ_NO_PLAYABLE_TRACK(limitMin=7)` → `removing 1 DJ(s) from queue`.
- 클라 계측: `POST 201 {djId}` → `WS DEACTIVATE djs:[]` → `GET djs:[]` — **클라/캐시 무죄, 큐가 진짜 비워진 것**.
- 단독 warm 실행이 항상 통과한 이유 = 오염을 만드는 다른 스펙이 안 돌아서. **부하/타이밍 문제가 아니었음.**

**수정**: beforeAll 이 만든 fresh 플리(<5분 트랙 3개) 이름을 보관해 `filter({ hasText })` 로 **정확히 그 플리를 선택**. 오염 유무와 무관하게 결정적으로 통과. NET/WS 진단 로깅은 재발 시 즉시 판별용으로 유지(로그 전용).

## 동반 수정

- **(커밋 2, src) DJ 등록 inactive 큐 쿼리 미갱신** — 실제 제품 견고성 버그: 등록 시점 DjingQueue 쿼리가 시트/모달에 가려 inactive 면 `invalidateQueries` 기본 `refetchType:'active'` 가 refetch 를 안 해 등록이 UI 에 반영되지 않을 수 있음. `refetchType:'all'` 로 강제(+회귀 테스트). flake 의 원인은 아니었지만 조사 중 발견된 정당한 수정.
- **(커밋 1, e2e) 호스트 page keep-alive** — 셋업 후 호스트 page 를 닫으면 방이 presence grace(10s)로만 연명. 방-조기종료라는 별개 실패모드에 대한 테스트 위생 방어(이번 flake 의 원인은 아니었음).

## 검증

- 풀 E2E 에서 dj-register 통과 — 계측으로 전체 건강 흐름 확인(`POST 201 → WS ENQUEUE djs:[crew] → registered:true → 재생 시작 → unregister`), **DB 오염이 존재하는 상태에서** 검증.
- 동일 run 유일 실패는 무관한 문서화된 display-board IFrame 플레이크(직후 warm 재실행 6/6 green).
- pre-push(typecheck + 전체 유닛 스위트) 통과.

## 관련
- #471 (조사 전 과정은 이슈 코멘트). #349(platform#350)·#469(web#470)와 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
