### PR TITLE
feat(partyroom): 재연결 resync를 스냅샷 분기로 교체 — 세션 되훔침 방지 (#477)

### DIFF
--- a/e2e/e2e-a.multi-device-supersede.spec.ts
+++ b/e2e/e2e-a.multi-device-supersede.spec.ts
@@ -95,6 +95,11 @@ test('멀티 디바이스 승계: 밀려난 기기가 재연결해도 옛 방을
     expect(await subscribedRoomId(pageB)).toBe(idY);
     log(`device B(user1) entered room Y=${idY} → server autoExits user1 from X`);
 
+    // STOMP heartbeatIncoming=10s: A 의 워치독이 죽은 커넥션을 감지하고 재연결 루프에 진입할 만큼
+    // 오프라인을 충분히 유지해야 한다. 너무 짧으면(<10s) WS 가 안 끊겨 온라인 복귀해도 재연결(=resync)이 안 돈다.
+    log('holding device A offline ≥ heartbeat window to force STOMP reconnect...');
+    await pageA.waitForTimeout(20_000);
+
     // ─── device A: 온라인 (WS 재연결) → 스냅샷 분기로 로비 이탈 ────────
     await ctxA.setOffline(false);
     log('device A online — reconnecting, resync should snapshot Y≠X and leave to lobby');

--- a/e2e/e2e-a.multi-device-supersede.spec.ts
+++ b/e2e/e2e-a.multi-device-supersede.spec.ts
@@ -1,0 +1,121 @@
+import path from 'path';
+import type { BrowserContext, Page } from '@playwright/test';
+import { expect, test } from './fixtures/auth.fixtures';
+import { ETHEREUM_MOCK_SCRIPT } from './fixtures/ethereum-mock';
+import {
+  closePartyroom,
+  createPartyroom,
+  enterPartyroomAndWaitUntilReady,
+  leavePartyroom,
+} from './helpers/partyroom.helpers';
+
+/**
+ * E2E-A: 멀티 디바이스 세션 승계 — 재연결 시 되훔침(핑퐁) 금지 (#477)
+ *
+ * 정책: new-session-wins. 같은 계정이 다른 기기에서 방에 입장하면 서버가 이전 기기의 crew 를
+ * 자동 EXIT(autoExit)한다. 이때 위험한 함정은, 밀려난(옛) 기기가 WS 재연결하는 순간
+ * 재연결 핸들러가 "기억하던 방"을 tryEnter 로 재주장해 새 기기의 방을 역으로 밀어내는
+ * 세션 되훔침(핑퐁)이다.
+ *
+ * #477 은 재연결 resync 를 tryEnter 재주장 대신 서버 권위 스냅샷(GET /me/active) 조회 후
+ * 분기로 바꿨다. 이 테스트는 되훔침이 사라졌음을 증명한다:
+ *
+ *   1. host(user2): 방 Y 생성·입장·유지
+ *   2. device A(user1): 방 X 생성·입장 (active crew in X)
+ *   3. device A: 오프라인 (WS 단절)
+ *   4. device B(user1, 같은 계정): 방 Y 입장 → 서버가 user1 을 X 에서 autoExit, 이제 Y 가 활성 방
+ *   5. device A: 온라인 (WS 재연결) → resync 는 스냅샷(Y ≠ X)을 보고 X 를 재점유하지 않고 로비로 이탈
+ *
+ * 검증: device A 는 로비(/parties)로 이탈하고 방 X 를 재점유하지 않으며,
+ *      device B 는 방 Y 구독을 유지한다(되훔김 없음).
+ */
+test('멀티 디바이스 승계: 밀려난 기기가 재연결해도 옛 방을 되훔치지 않고 로비로 이탈한다', async ({
+  browser,
+}) => {
+  test.setTimeout(150_000);
+
+  const startedAt = Date.now();
+  const log = (message: string) => {
+    const elapsed = `${Date.now() - startedAt}ms`.padStart(8, ' ');
+    console.log(`[E2E-supersede][${elapsed}] ${message}`);
+  };
+
+  const AUTH_DIR = path.join(__dirname, '.auth');
+  const makeContext = async (storageFile: string) => {
+    const ctx = await browser.newContext({
+      storageState: path.join(AUTH_DIR, storageFile),
+      ignoreHTTPSErrors: true,
+    });
+    await ctx.addInitScript(ETHEREUM_MOCK_SCRIPT);
+    return ctx;
+  };
+
+  const subscribedRoomId = (page: Page) =>
+    page.evaluate(
+      () =>
+        (window as Window & { __PFPLAY_E2E__?: { subscribedRoomId?: number } }).__PFPLAY_E2E__
+          ?.subscribedRoomId
+    );
+
+  // host(user2) + device A/B(user1, 같은 계정 두 기기)
+  const hostCtx = await makeContext('a-user2.json');
+  const ctxA = await makeContext('a-user1.json');
+  const ctxB = await makeContext('a-user1.json');
+
+  const hostPage = await hostCtx.newPage();
+  const pageA = await ctxA.newPage();
+  const pageB = await ctxB.newPage();
+
+  let roomXUrl: string | undefined;
+  let roomYUrl: string | undefined;
+
+  try {
+    // ─── host(user2): 방 Y 생성·입장 ───────────────────────────────────
+    await hostPage.goto('/parties');
+    roomYUrl = await createPartyroom(hostPage, `Y${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(hostPage, roomYUrl);
+    const idY = Number(roomYUrl.match(/\/parties\/(\d+)/)?.[1]);
+    log(`host created+entered room Y=${idY}`);
+
+    // ─── device A(user1): 방 X 생성·입장 ──────────────────────────────
+    await pageA.goto('/parties');
+    roomXUrl = await createPartyroom(pageA, `X${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(pageA, roomXUrl);
+    const idX = Number(roomXUrl.match(/\/parties\/(\d+)/)?.[1]);
+    expect(await subscribedRoomId(pageA)).toBe(idX);
+    log(`device A created+entered room X=${idX}`);
+
+    // ─── device A: 오프라인 (WS 단절) ─────────────────────────────────
+    await ctxA.setOffline(true);
+    log('device A offline (WS dropped)');
+
+    // ─── device B(user1): 방 Y 입장 → 서버가 user1 을 X 에서 autoExit ──
+    await pageB.goto('/parties');
+    await enterPartyroomAndWaitUntilReady(pageB, roomYUrl);
+    expect(await subscribedRoomId(pageB)).toBe(idY);
+    log(`device B(user1) entered room Y=${idY} → server autoExits user1 from X`);
+
+    // ─── device A: 온라인 (WS 재연결) → 스냅샷 분기로 로비 이탈 ────────
+    await ctxA.setOffline(false);
+    log('device A online — reconnecting, resync should snapshot Y≠X and leave to lobby');
+
+    // ★ 핵심: A 는 X 를 재점유하지 않고 로비로 이탈한다 (되훔침/핑퐁 없음).
+    //   STOMP reconnectDelay(5s) + 스냅샷 조회 왕복을 고려해 넉넉한 타임아웃.
+    await pageA.waitForURL(/\/parties$/, { timeout: 60_000 });
+    log('device A left to lobby (did NOT re-occupy X) ✅');
+
+    // ★ device B 는 여전히 Y 구독 유지 — A 의 재연결이 Y 를 되훔치지 않았다.
+    await expect.poll(() => subscribedRoomId(pageB), { timeout: 10_000 }).toBe(idY);
+    log('device B still subscribed to Y (no re-steal) ✅');
+  } finally {
+    log('cleanup');
+    await leavePartyroom(pageB).catch(() => null);
+    await (roomXUrl ? closePartyroom(pageA, roomXUrl) : leavePartyroom(pageA)).catch(() => null);
+    await (roomYUrl ? closePartyroom(hostPage, roomYUrl) : leavePartyroom(hostPage)).catch(
+      () => null
+    );
+    await Promise.all(
+      [hostCtx, ctxA, ctxB].map((c: BrowserContext) => c.close().catch(() => null))
+    );
+  }
+});

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -10,7 +10,7 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   };
 });
 vi.mock('@/shared/api/http/services', () => ({
-  partyroomsService: { getSetupInfo: vi.fn(), getNotice: vi.fn() },
+  partyroomsService: { getSetupInfo: vi.fn(), getNotice: vi.fn(), getMyActiveRoom: vi.fn() },
 }));
 vi.mock('@/shared/lib/analytics/room-tracking', () => ({
   trackPartyroomEntered: vi.fn(),
@@ -31,6 +31,8 @@ import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter
 
 const mockOnConnect = vi.fn();
 const mockSetRoomReconnectHandler = vi.fn();
+const mockUnsubscribeCurrentRoom = vi.fn();
+const mockGetMyActiveRoom = partyroomsService.getMyActiveRoom as Mock;
 const mockMutate = vi.fn();
 const mockInit = vi.fn();
 const mockPush = vi.fn();
@@ -43,6 +45,7 @@ beforeEach(() => {
   (usePartyroomClient as Mock).mockReturnValue({
     onConnect: mockOnConnect,
     setRoomReconnectHandler: mockSetRoomReconnectHandler,
+    unsubscribeCurrentRoom: mockUnsubscribeCurrentRoom,
     subscribe: vi.fn(),
   });
   (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(vi.fn());
@@ -129,14 +132,14 @@ describe('useEnterPartyroom', () => {
   });
 });
 
-describe('useEnterPartyroom 재연결 resync (#402/#469)', () => {
+describe('useEnterPartyroom 재연결 resync — 스냅샷 분기 (#477/#469/#402)', () => {
   // #469: onConnect 는 초기 enter(once) 1회만 등록되고, resync 는 그 once 핸들러 실행 시
   // setRoomReconnectHandler 로 단일 슬롯 등록된다(방마다 누적 X). 아래는 그 resync 콜백을 꺼내온다.
   const registerAndGetResync = (partyroomId: number) => {
     const { result } = renderHook(() => useEnterPartyroom(partyroomId));
     act(() => result.current());
     mockOnConnect.mock.calls[0][0](); // once 핸들러 → 초기 enter + resync 등록
-    mockMutate.mockClear(); // 초기 enter 호출 제거 → 이후 resync enter 가 calls[0]
+    mockMutate.mockClear(); // 초기 enter 호출 제거 → 재연결에서 되훔침 여부를 mockMutate 로 검증
     return mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
   };
 
@@ -152,37 +155,49 @@ describe('useEnterPartyroom 재연결 resync (#402/#469)', () => {
     expect(mockSetRoomReconnectHandler).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  test('재연결 시 enter(tryEnter) 호출', () => {
+  test('#477 재연결 resync 는 enter(tryEnter) 를 재주장하지 않고 내 활성 방 스냅샷을 조회한다 (되훔침 금지)', async () => {
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 7, crewId: 1 });
     const resync = registerAndGetResync(7);
     resync();
-    expect(mockMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ partyroomId: 7 }),
-      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    await vi.waitFor(() => expect(mockGetMyActiveRoom).toHaveBeenCalledTimes(1));
+    expect(mockMutate).not.toHaveBeenCalled(); // tryEnter 재주장 소멸 (CRW-005 유발 경로 제거)
+  });
+
+  test('스냅샷 활성 방 == 현재 방 → 경량 resync (DJ큐 invalidate), 이탈/teardown 없음', async () => {
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 7, crewId: 1 });
+    const resync = registerAndGetResync(7);
+    resync();
+    await vi.waitFor(() =>
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.DjingQueue, 7] })
     );
-  });
-
-  test('reactivated=false → setup 미호출, DJ큐 invalidate', () => {
-    const resync = registerAndGetResync(7);
-    resync();
-    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: false });
     expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.DjingQueue, 7] });
+    expect(mockUnsubscribeCurrentRoom).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
-  test('reactivated=true → setup(재수화) 호출', () => {
-    (partyroomsService.getSetupInfo as Mock).mockReturnValue(new Promise(() => {}));
-    (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
+  test('스냅샷 활성 방 != 현재 방(밀려남) → 구독 teardown + 로비, enter/exit 미호출', async () => {
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 99, crewId: 2 });
     const resync = registerAndGetResync(7);
     resync();
-    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: true });
-    expect(partyroomsService.getSetupInfo).toHaveBeenCalled();
+    await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
+    expect(mockUnsubscribeCurrentRoom).toHaveBeenCalledTimes(1);
+    expect(mockMutate).not.toHaveBeenCalled(); // 되훔침 금지
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
 
-  test('enter onError → 로비', () => {
+  test('스냅샷 활성 방 없음(null) → 구독 teardown + 로비', async () => {
+    mockGetMyActiveRoom.mockResolvedValue(null);
     const resync = registerAndGetResync(7);
     resync();
-    mockMutate.mock.calls[0][1].onError();
-    expect(mockPush).toHaveBeenCalledWith('/parties');
+    await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
+    expect(mockUnsubscribeCurrentRoom).toHaveBeenCalledTimes(1);
+  });
+
+  test('스냅샷 조회 실패 → 로비 이동 (fail-safe)', async () => {
+    mockGetMyActiveRoom.mockRejectedValue(new Error('network'));
+    const resync = registerAndGetResync(7);
+    resync();
+    await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
   });
 });
 

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -107,26 +107,25 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
           // 틀린 구획 방출 방지. disconnect 콜백이 공개돼 있지 않아 재연결 시점 clear가 의미상 등가
           // (끊김~재연결 사이엔 방출/시드 이벤트가 처리되지 않음). 놓친 경계는 기념하지 않는다.
           useCurrentPartyroom.getState().playbackSummaryTracker.clear();
-          enter(
-            { partyroomId },
-            {
-              onSuccess: (enterResponse) => {
-                const invalidateDjQueue = () =>
-                  queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
-                if (enterResponse.reactivated) {
-                  // 멤버십 상실 → 풀 재수화(검정 해소). 룸 재구독은 추가하지 않음(handleConnect 가 이미 reconcile).
-                  silent(setup(enterResponse), {
-                    onSuccess: invalidateDjQueue,
-                    onError: () => router.push('/parties'),
-                  });
-                } else {
-                  // 멤버십 유지 → 경량(플레이어/구독 무영향)
-                  invalidateDjQueue();
-                }
-              },
-              onError: () => router.push('/parties'),
-            }
-          );
+          // #477 재연결 resync 는 기억하던 방을 tryEnter 로 재주장하지 않는다 —
+          // 멀티 디바이스 승계(new-session-wins)에서 밀려난 브라우저가 재연결 순간 새 기기의 방을
+          // 역으로 밀어내는 세션 되훔침(핑퐁)의 발원지였다. 대신 서버 권위 스냅샷("내 활성 방")을
+          // 조회하고 그 결과로만 분기한다(level-triggered, 재연결=이벤트 재생 아닌 스냅샷 재취득).
+          silent(partyroomsService.getMyActiveRoom(), {
+            onSuccess: (snapshot) => {
+              if (snapshot && snapshot.partyroomId === partyroomId) {
+                // 활성 방 == 현재 화면의 방 → 멤버십 유지. 경량 resync
+                // (구독은 handleConnect 가 subscriptions[] 기준으로 이미 재구독 복원).
+                queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
+              } else {
+                // 활성 방 != 현재 방(밀려남) 또는 활성 방 없음 → 로컬 teardown 후 이탈.
+                // 서버가 밀어냄을 이미 완결(명시 EXIT)했으므로 exit API 를 호출하지 않는다.
+                client.unsubscribeCurrentRoom();
+                router.push('/parties');
+              }
+            },
+            onError: () => router.push('/parties'),
+          });
         });
 
         enter(

--- a/src/shared/api/http/services/partyrooms.ts
+++ b/src/shared/api/http/services/partyrooms.ts
@@ -15,6 +15,7 @@ import type {
   GetNoticeResponse,
   GetSetupInfoPayload,
   GetSetUpInfoResponse,
+  MyActivePartyroom,
   PartyroomsClient,
   PartyroomDetailSummary,
   ReactionPayload,
@@ -86,6 +87,17 @@ export default class PartyroomsService extends HTTPClient implements PartyroomsC
   })
   public enter({ partyroomId }: EnterPayload) {
     return this.post<EnterResponse>(`${this.ROUTE_V1}/${partyroomId}/crews`);
+  }
+
+  /**
+   * 내 활성 파티룸 스냅샷 조회 (web#477). 활성 방 없으면 서버가 204(본문 없음)를 주며,
+   * 이때 응답 인터셉터(unwrapResponse)는 falsy(빈 문자열/undefined)를 반환하므로 `null` 로 정규화한다.
+   * — 200 + {data:null} 로 주면 `response.data?.data ?? response.data` 가 래퍼를 벗기지 못하는 풋건이 있어
+   *   서버 계약을 204 로 잡았다.
+   */
+  public async getMyActiveRoom() {
+    const data = await this.get<MyActivePartyroom | '' | null>(`${this.ROUTE_V1}/me/active`);
+    return data ? (data as MyActivePartyroom) : null;
   }
 
   public exit({ partyroomId }: ExitPayload) {

--- a/src/shared/api/http/types/partyrooms.ts
+++ b/src/shared/api/http/types/partyrooms.ts
@@ -203,6 +203,15 @@ export type ExitPayload = {
   partyroomId: number;
 };
 
+/**
+ * 내 활성 파티룸 스냅샷 (web#477). 재연결 resync 가 기억하던 방을 되훔침(재입장)하는 대신
+ * 서버 권위 스냅샷으로 분기하기 위한 조회 결과. 활성 방이 없으면 `null`.
+ */
+export type MyActivePartyroom = {
+  partyroomId: number;
+  crewId: number;
+};
+
 export type AdjustGradePayload = {
   partyroomId: number;
   crewId: number;
@@ -310,6 +319,10 @@ export interface PartyroomsClient {
    * 파티룸 입장
    */
   enter: (payload: EnterPayload) => Promise<EnterResponse>;
+  /**
+   * 내 활성 파티룸 스냅샷 조회 (web#477). 활성 방 없으면 `null`.
+   */
+  getMyActiveRoom: () => Promise<MyActivePartyroom | null>;
   /**
    * 파티룸 퇴장
    */


### PR DESCRIPTION
## 개요
멀티 디바이스 세션 승계(new-session-wins) 3종 세트 중 **정합성 핵심(#477)**.

밀려난 옛 브라우저의 재연결 핸들러가 기억하던 방을 `tryEnter`로 재주장하면, 재연결 순간 새 기기의 방을 역으로 밀어내는 **세션 되훔침(핑퐁)**이 발생한다. 발원지는 `use-enter-partyroom.ts` 재연결 핸들러가 매 재연결마다 `enter()`를 무조건 재호출하던 부분.

## 변경
재연결 resync를 서버 권위 스냅샷(`GET /me/active`) 조회 후 분기로 교체 (level-triggered: 재연결=이벤트 재생 아닌 스냅샷 재취득):
- 활성 방 == 현재 방 → 경량 resync(DJ큐 invalidate). 구독은 handleConnect가 이미 복원
- 활성 방 != 현재 방(밀려남) / 활성 방 없음 → 로컬 teardown + 로비. **exit API 미호출**(서버가 이미 EXIT 완결)
- 스냅샷 조회 실패 → 로비(fail-safe)
- `partyroomsService.getMyActiveRoom()` 추가(204→null 정규화) + `MyActivePartyroom` 타입

## 검증
- 훅 단위 테스트 4분기(같은방/다른방/없음/실패)로 교체, 되훔침(enter 미호출) 단언
- 전체 단위 GREEN(1754), tsc/lint 클린
- 멀티 디바이스 승계 e2e 스펙 추가(`e2e/e2e-a.multi-device-supersede.spec.ts`): A 단절→B 다른 방 입장→A 재연결 시 X 재점유 없이 로비

## ⚠️ 머지 보류
- platform#370(`GET /me/active`)과 세트. **라이브 멀티 디바이스 e2e 실행 후 머지 예정**.

관련: #477