### PR TITLE
feat(partyroom): 멀티 디바이스 승계 UX — 밀려난 모달 + 새 기기 사전 컨펌 (#476)

### DIFF
--- a/e2e/e2e-a.multi-device-supersede-ux.spec.ts
+++ b/e2e/e2e-a.multi-device-supersede-ux.spec.ts
@@ -1,0 +1,134 @@
+import path from 'path';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { expect, test } from './fixtures/auth.fixtures';
+import { ETHEREUM_MOCK_SCRIPT } from './fixtures/ethereum-mock';
+import {
+  closePartyroom,
+  createPartyroom,
+  enterPartyroomAndWaitUntilReady,
+  leavePartyroom,
+} from './helpers/partyroom.helpers';
+
+/**
+ * E2E-A: 멀티 디바이스 세션 승계 UX (#476)
+ *
+ * platform#369(SESSION_SUPERSEDED 발행) + web#477(getMyActiveRoom 스냅샷)과 세트.
+ * ⚠️ 라이브 실행에는 #477(/me/active) + #369(알림)를 모두 포함한 백엔드가 필요하다.
+ *
+ * 두 흐름을 검증한다:
+ *   1) 새 기기 사전 컨펌: 다른 세션이 활성 방 점유 중일 때 입장 전 확인 다이얼로그, 취소 시 미입장
+ *   2) 밀려난 브라우저 모달: 다른 기기가 입장해 이 방이 밀려나면 안내 모달 + 로비 이동(재연결 불필요)
+ */
+
+const AUTH_DIR = path.join(__dirname, '.auth');
+
+async function makeContext(browser: Browser, storageFile: string): Promise<BrowserContext> {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, storageFile),
+    ignoreHTTPSErrors: true,
+  });
+  await ctx.addInitScript(ETHEREUM_MOCK_SCRIPT);
+  return ctx;
+}
+
+const subscribedRoomId = (page: Page) =>
+  page.evaluate(
+    () =>
+      (window as Window & { __PFPLAY_E2E__?: { subscribedRoomId?: number } }).__PFPLAY_E2E__
+        ?.subscribedRoomId
+  );
+
+test('사전 컨펌: 다른 기기가 활성 방 점유 중 → 새 기기 입장 시 확인, 취소하면 입장하지 않는다', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+
+  const hostCtx = await makeContext(browser, 'a-user2.json');
+  const ctxA = await makeContext(browser, 'a-user1.json');
+  const ctxB = await makeContext(browser, 'a-user1.json');
+  const hostPage = await hostCtx.newPage();
+  const pageA = await ctxA.newPage();
+  const pageB = await ctxB.newPage();
+
+  let roomXUrl: string | undefined;
+  let roomYUrl: string | undefined;
+
+  try {
+    // host(user2) 방 Y 준비
+    await hostPage.goto('/parties');
+    roomYUrl = await createPartyroom(hostPage, `Y${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(hostPage, roomYUrl);
+
+    // device A(user1) 방 X 입장 (활성 방 점유)
+    await pageA.goto('/parties');
+    roomXUrl = await createPartyroom(pageA, `X${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(pageA, roomXUrl);
+    const idX = Number(roomXUrl.match(/\/parties\/(\d+)/)?.[1]);
+
+    // device B(user1, 새 세션) 방 Y 로 이동 → 사전 컨펌 노출
+    await pageB.goto(roomYUrl);
+    const confirmDialog = pageB.locator('[data-testid="dialog-panel"]').first();
+    await expect(confirmDialog).toBeVisible({ timeout: 15_000 });
+    // 취소 → 입장하지 않고 로비로
+    await confirmDialog.locator('[data-testid="confirm-dialog-cancel-button"]').click();
+    await pageB.waitForURL(/\/parties(?:\?.*)?$/, { timeout: 15_000 });
+
+    // A 는 여전히 방 X 유지 (B 가 밀어내지 않았다)
+    await expect.poll(() => subscribedRoomId(pageA), { timeout: 10_000 }).toBe(idX);
+  } finally {
+    await leavePartyroom(pageB).catch(() => null);
+    await (roomXUrl ? closePartyroom(pageA, roomXUrl) : leavePartyroom(pageA)).catch(() => null);
+    await (roomYUrl ? closePartyroom(hostPage, roomYUrl) : leavePartyroom(hostPage)).catch(
+      () => null
+    );
+    await Promise.all([hostCtx, ctxA, ctxB].map((c) => c.close().catch(() => null)));
+  }
+});
+
+test('밀려난 모달: 다른 기기가 입장해 이 방이 밀려나면 안내 모달 + 로비 이동 (재연결 불필요)', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+
+  const hostCtx = await makeContext(browser, 'a-user2.json');
+  const ctxA = await makeContext(browser, 'a-user1.json');
+  const ctxB = await makeContext(browser, 'a-user1.json');
+  const hostPage = await hostCtx.newPage();
+  const pageA = await ctxA.newPage();
+  const pageB = await ctxB.newPage();
+
+  let roomXUrl: string | undefined;
+  let roomYUrl: string | undefined;
+
+  try {
+    await hostPage.goto('/parties');
+    roomYUrl = await createPartyroom(hostPage, `Y${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(hostPage, roomYUrl);
+    const idY = Number(roomYUrl.match(/\/parties\/(\d+)/)?.[1]);
+
+    // device A(user1) 방 X 입장 후 접속 유지
+    await pageA.goto('/parties');
+    roomXUrl = await createPartyroom(pageA, `X${Date.now().toString(36)}`);
+    await enterPartyroomAndWaitUntilReady(pageA, roomXUrl);
+
+    // device B(user1) 방 Y 입장 — 사전 컨펌이 뜨면 승인하고 진행
+    await pageB.goto(roomYUrl);
+    const confirmDialog = pageB.locator('[data-testid="dialog-panel"]').first();
+    if (await confirmDialog.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await confirmDialog.locator('[data-testid="confirm-dialog-confirm-button"]').click();
+    }
+    await expect.poll(() => subscribedRoomId(pageB), { timeout: 15_000 }).toBe(idY);
+
+    // ★ A 는 SESSION_SUPERSEDED 수신 → 안내 모달 노출 + 로비 이동 (오프라인/재연결 없이)
+    const alertDialog = pageA.locator('[data-testid="dialog-panel"]').first();
+    await expect(alertDialog).toBeVisible({ timeout: 15_000 });
+    await pageA.waitForURL(/\/parties(?:\?.*)?$/, { timeout: 15_000 });
+  } finally {
+    await leavePartyroom(pageB).catch(() => null);
+    await (roomXUrl ? closePartyroom(pageA, roomXUrl) : leavePartyroom(pageA)).catch(() => null);
+    await (roomYUrl ? closePartyroom(hostPage, roomYUrl) : leavePartyroom(hostPage)).catch(
+      () => null
+    );
+    await Promise.all([hostCtx, ctxA, ctxB].map((c) => c.close().catch(() => null)));
+  }
+});

--- a/src/app/parties/(room)/[id]/layout.test.tsx
+++ b/src/app/parties/(room)/[id]/layout.test.tsx
@@ -12,6 +12,10 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace }),
 }));
 
+vi.mock('@/entities/partyroom-client', () => ({
+  useSupersededSessionListener: vi.fn(),
+}));
+
 vi.mock('@/features/partyroom/enter', () => ({
   useEnterPartyroom: () => mockEnter,
 }));

--- a/src/app/parties/(room)/[id]/layout.tsx
+++ b/src/app/parties/(room)/[id]/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { PropsWithChildren } from 'react';
+import { useSupersededSessionListener } from '@/entities/partyroom-client';
 import { useEnterPartyroom } from '@/features/partyroom/enter';
 import { useTeardownPartyroom } from '@/features/partyroom/exit';
 import { parseEntrySource } from '@/shared/lib/analytics/room-tracking';
@@ -15,6 +16,9 @@ export default function PartyroomLayout({ children }: PropsWithChildren) {
   const entrySource = parseEntrySource(searchParams.get('source'));
   const enter = useEnterPartyroom(partyroomId, { entrySource });
   const teardown = useTeardownPartyroom(partyroomId);
+
+  // #476 멀티 디바이스 승계 수신 — 다른 기기/탭이 입장해 이 방이 밀려나면 안내 후 로비로.
+  useSupersededSessionListener();
 
   useDidMountEffect(() => {
     enter();

--- a/src/entities/partyroom-client/index.ts
+++ b/src/entities/partyroom-client/index.ts
@@ -1,4 +1,5 @@
 export { default as PartyroomClient } from './lib/partyroom-client';
 export { PartyroomClientContext, usePartyroomClient } from './lib/partyroom-client.context';
 export { default as useHandlePartyroomSubscriptionEvent } from './lib/handle-subscription-event';
+export { useSupersededSessionListener } from './lib/use-superseded-session-listener.hook';
 export { GRADE_TYPE_LABEL } from './config/grade-type-label';

--- a/src/entities/partyroom-client/lib/partyroom-client.test.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.test.ts
@@ -156,4 +156,36 @@ describe('PartyroomClient', () => {
       });
     });
   });
+
+  describe('#476 멀티 디바이스 승계 지원', () => {
+    test('markEnteredRoom → myEnteredRoomId 로 노출된다', () => {
+      expect(client.myEnteredRoomId).toBeUndefined();
+      client.markEnteredRoom(42);
+      expect(client.myEnteredRoomId).toBe(42);
+    });
+
+    test('subscribeUserSession → /user/sub/session 구독, 중복 호출은 멱등(no-op)', () => {
+      const handler = vi.fn();
+      client.subscribeUserSession(handler);
+      client.subscribeUserSession(handler); // 중복
+
+      const sessionSubs = mockSocketInstance.subscriptions.filter(
+        (s) => s.destination === '/user/sub/session'
+      );
+      expect(sessionSubs).toHaveLength(1); // 중복 SoT 엔트리 없음
+    });
+
+    test('unsubscribeUserSession → 구독 해지, 이후 재구독 가능', () => {
+      client.subscribeUserSession(vi.fn());
+      client.unsubscribeUserSession();
+      expect(
+        mockSocketInstance.subscriptions.filter((s) => s.destination === '/user/sub/session')
+      ).toHaveLength(0);
+
+      client.subscribeUserSession(vi.fn());
+      expect(
+        mockSocketInstance.subscriptions.filter((s) => s.destination === '/user/sub/session')
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/src/entities/partyroom-client/lib/partyroom-client.ts
+++ b/src/entities/partyroom-client/lib/partyroom-client.ts
@@ -6,12 +6,19 @@ import { recordClientEvent } from '@/shared/lib/observability/client-events';
  * Socket Client를 캡슐화하여 최소한의 인터페이스만을 노출하며,
  * partyroom 구독에 대한 정책을 포함하는 클래스
  */
+/** 유저 개인 세션 큐 destination — 멀티 디바이스 승계 알림 수신용(#476). */
+const USER_SESSION_DESTINATION = '/user/sub/session';
+
 export default class PartyroomClient {
   private socketClient: SocketClient;
   private subscribedRoomId: number | undefined;
   // #469 현재 방의 "재연결 시 재입장(resync)" 핸들러 해제자. 단일 슬롯 — 방 전환 시 교체되고
   // unsubscribeCurrentRoom(teardown 경로)에서 정리되므로 방마다 핸들러가 누적되지 않는다.
   private roomReconnectDisposer: (() => void) | undefined;
+  // #476 이 탭이 마지막으로 입장 성공한 방. teardown 으로 지우지 않는다(다음 입장 시 덮어씀).
+  // 사전 컨펌 판별에 쓰인다 — 서버 활성 방이 이 값과 다르면 "다른 세션(탭/기기)"이 점유 중이란 뜻.
+  private enteredRoomId: number | undefined;
+  private userSessionSubscribed = false;
 
   public constructor() {
     this.socketClient = new SocketClient();
@@ -87,6 +94,35 @@ export default class PartyroomClient {
       recordClientEvent({ type: 'PARTYROOM_UNSUBSCRIBE', partyroomId: roomId });
     }
     this.syncE2EDebugState();
+  }
+
+  /**
+   * 이 탭이 입장 성공한 방을 기록한다(#476 사전 컨펌 판별용). 입장 성공 시 호출.
+   * teardown 으로 지워지지 않으므로 같은 탭의 방 전환(X→Y)에서 X 는 "내 세션 방"으로 인식돼
+   * 사전 컨펌이 뜨지 않는다. 다른 탭/기기는 이 값이 비어 있거나 달라 컨펌 대상이 된다.
+   */
+  public markEnteredRoom(partyroomId: number) {
+    this.enteredRoomId = partyroomId;
+  }
+
+  public get myEnteredRoomId() {
+    return this.enteredRoomId;
+  }
+
+  /**
+   * 유저 개인 세션 큐(/user/sub/session)를 구독한다(#476 승계 알림). destination 당 1개 — 중복 구독을
+   * 멱등 no-op 처리하며, 재연결 시 SocketClient 가 subscriptions[] 기준으로 자동 복원한다.
+   */
+  public subscribeUserSession(handler: (message: IMessage) => void) {
+    if (this.userSessionSubscribed) return;
+    this.socketClient.subscribe(USER_SESSION_DESTINATION, handler);
+    this.userSessionSubscribed = true;
+  }
+
+  public unsubscribeUserSession() {
+    if (!this.userSessionSubscribed) return;
+    this.socketClient.unsubscribe(USER_SESSION_DESTINATION);
+    this.userSessionSubscribed = false;
   }
 
   public sendChatMessage(message: string) {

--- a/src/entities/partyroom-client/lib/use-superseded-session-listener.hook.test.tsx
+++ b/src/entities/partyroom-client/lib/use-superseded-session-listener.hook.test.tsx
@@ -1,0 +1,123 @@
+vi.mock('./partyroom-client.context');
+vi.mock('@/entities/current-partyroom');
+vi.mock('@/shared/lib/store/stores.context');
+vi.mock('@/shared/lib/router/use-app-router.hook');
+vi.mock('@/shared/ui/components/dialog');
+vi.mock('@/shared/lib/localization/i18n.context');
+
+import { renderHook } from '@testing-library/react';
+import { useRemoveCurrentPartyroomCaches } from '@/entities/current-partyroom';
+import { SessionEventType } from '@/shared/api/websocket/types/session';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import { usePartyroomClient } from './partyroom-client.context';
+import { useSupersededSessionListener } from './use-superseded-session-listener.hook';
+
+const mockSubscribeUserSession = vi.fn();
+const mockUnsubscribeUserSession = vi.fn();
+const mockUnsubscribeCurrentRoom = vi.fn();
+const mockReset = vi.fn();
+const mockRemoveCaches = vi.fn();
+const mockPush = vi.fn();
+const mockOpenAlertDialog = vi.fn();
+
+let currentRoomId: number | null;
+
+const message = (payload: unknown) => ({ body: JSON.stringify(payload) }) as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentRoomId = 10;
+  (usePartyroomClient as Mock).mockReturnValue({
+    subscribeUserSession: mockSubscribeUserSession,
+    unsubscribeUserSession: mockUnsubscribeUserSession,
+    unsubscribeCurrentRoom: mockUnsubscribeCurrentRoom,
+  });
+  (useRemoveCurrentPartyroomCaches as Mock).mockReturnValue(mockRemoveCaches);
+  const state = { id: currentRoomId, reset: mockReset };
+  (useStores as Mock).mockReturnValue({
+    useCurrentPartyroom: Object.assign((selector: (...args: any[]) => any) => selector(state), {
+      getState: () => ({ ...state, id: currentRoomId }),
+    }),
+  });
+  (useAppRouter as Mock).mockReturnValue({ push: mockPush });
+  (useDialog as Mock).mockReturnValue({ openAlertDialog: mockOpenAlertDialog });
+  (useI18n as Mock).mockReturnValue({ party: { para: { superseded: '밀려남' } } });
+});
+
+const getHandler = () => {
+  renderHook(() => useSupersededSessionListener());
+  return mockSubscribeUserSession.mock.calls[0][0] as (m: any) => void;
+};
+
+describe('useSupersededSessionListener (#476)', () => {
+  test('마운트 시 유저 세션 큐를 구독하고, 언마운트 시 해지한다', () => {
+    const { unmount } = renderHook(() => useSupersededSessionListener());
+    expect(mockSubscribeUserSession).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mockUnsubscribeUserSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('현재 방 == supersededPartyroomId → 로컬 teardown + 로비 + 안내 모달, exit API 미호출', () => {
+    currentRoomId = 10;
+    const handler = getHandler();
+
+    handler(
+      message({
+        type: SessionEventType.SESSION_SUPERSEDED,
+        newPartyroomId: 20,
+        supersededPartyroomId: 10,
+        occurredAt: 1,
+      })
+    );
+
+    expect(mockUnsubscribeCurrentRoom).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockRemoveCaches).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/parties');
+    expect(mockOpenAlertDialog).toHaveBeenCalledTimes(1);
+  });
+
+  test('현재 방 != supersededPartyroomId (새 세션 B) → 무시', () => {
+    currentRoomId = 20; // 이 세션은 새 방 20 에 있음
+    const handler = getHandler();
+
+    handler(
+      message({
+        type: SessionEventType.SESSION_SUPERSEDED,
+        newPartyroomId: 20,
+        supersededPartyroomId: 10,
+        occurredAt: 1,
+      })
+    );
+
+    expect(mockUnsubscribeCurrentRoom).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockOpenAlertDialog).not.toHaveBeenCalled();
+  });
+
+  test('현재 방 없음(로비) → 무시', () => {
+    currentRoomId = null;
+    const handler = getHandler();
+
+    handler(
+      message({
+        type: SessionEventType.SESSION_SUPERSEDED,
+        newPartyroomId: 20,
+        supersededPartyroomId: 10,
+        occurredAt: 1,
+      })
+    );
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('SESSION_SUPERSEDED 가 아닌/파싱 불가 메시지 → 무시', () => {
+    const handler = getHandler();
+    handler(message({ type: 'SOMETHING_ELSE' }));
+    handler({ body: 'not-json' } as any);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/partyroom-client/lib/use-superseded-session-listener.hook.tsx
+++ b/src/entities/partyroom-client/lib/use-superseded-session-listener.hook.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { IMessage } from '@stomp/stompjs';
+import { useRemoveCurrentPartyroomCaches } from '@/entities/current-partyroom';
+import { SessionEventType, SessionSupersededEvent } from '@/shared/api/websocket/types/session';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
+import { useStores } from '@/shared/lib/store/stores.context';
+import { useDialog } from '@/shared/ui/components/dialog';
+import { usePartyroomClient } from './partyroom-client.context';
+
+/**
+ * 멀티 디바이스 세션 승계 수신측(#476). 유저 개인 큐(/user/sub/session)를 구독해
+ * SESSION_SUPERSEDED 를 받으면, 이 세션(탭)이 보고 있는 방이 밀려난 방과 일치할 때
+ * 로컬 teardown 후 로비로 이동하고 안내 모달을 띄운다.
+ *
+ * <p>서버가 이미 밀어냄(crew EXIT)을 완결했으므로 **exit API 를 호출하지 않는다**(서버 권위 원칙).
+ * WS 가 죽어 알림을 못 받아도 무방하다 — 재연결 resync 스냅샷(#477)이 정합성을 치유한다.
+ * 같은 유저의 새 세션 B 는 newPartyroomId 에 있어 supersededPartyroomId 와 불일치하므로 무시된다.
+ */
+export function useSupersededSessionListener() {
+  const client = usePartyroomClient();
+  const { useCurrentPartyroom } = useStores();
+  const reset = useCurrentPartyroom((state) => state.reset);
+  const removeCurrentPartyroomCaches = useRemoveCurrentPartyroomCaches();
+  const router = useAppRouter();
+  const { openAlertDialog } = useDialog();
+  const t = useI18n();
+
+  const handlerRef = useRef<(message: IMessage) => void>(() => {});
+  handlerRef.current = (message: IMessage) => {
+    let event: SessionSupersededEvent | undefined;
+    try {
+      event = JSON.parse(message.body);
+    } catch {
+      return;
+    }
+    if (event?.type !== SessionEventType.SESSION_SUPERSEDED) return;
+
+    // 이 세션(탭)이 보고 있는 방이 밀려난 방일 때만 처리한다.
+    const currentRoomId = useCurrentPartyroom.getState().id;
+    if (currentRoomId == null || currentRoomId !== event.supersededPartyroomId) return;
+
+    // 로컬 teardown 만 수행 — 서버가 이미 EXIT 완결했으므로 exit API 미호출.
+    client.unsubscribeCurrentRoom();
+    reset();
+    removeCurrentPartyroomCaches();
+    router.push('/parties');
+    openAlertDialog({ content: t.party.para.superseded });
+  };
+
+  useEffect(() => {
+    const handler = (message: IMessage) => handlerRef.current(message);
+    client.subscribeUserSession(handler);
+    return () => client.unsubscribeUserSession();
+  }, [client]);
+}

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -1,6 +1,8 @@
 vi.mock('@/entities/partyroom-client');
 vi.mock('@/shared/lib/store/stores.context');
 vi.mock('@/shared/lib/router/use-app-router.hook');
+vi.mock('@/shared/ui/components/dialog');
+vi.mock('@/shared/lib/localization/i18n.context');
 vi.mock('../api/use-enter-partyroom.mutation');
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>();
@@ -24,15 +26,19 @@ import {
 } from '@/entities/partyroom-client';
 import { QueryKeys } from '@/shared/api/http/query-keys';
 import { partyroomsService } from '@/shared/api/http/services';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
+import { useDialog } from '@/shared/ui/components/dialog';
 import { useEnterPartyroom } from './use-enter-partyroom';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
 
 const mockOnConnect = vi.fn();
 const mockSetRoomReconnectHandler = vi.fn();
 const mockUnsubscribeCurrentRoom = vi.fn();
+const mockMarkEnteredRoom = vi.fn();
 const mockGetMyActiveRoom = partyroomsService.getMyActiveRoom as Mock;
+const mockOpenConfirmDialog = vi.fn();
 const mockMutate = vi.fn();
 const mockInit = vi.fn();
 const mockPush = vi.fn();
@@ -40,12 +46,20 @@ const mockInvalidateQueries = vi.fn();
 const mockTrackerClear = vi.fn();
 const mockSeedFromSetup = vi.fn();
 
+// 이 탭이 들어갔던 방(#476 사전 컨펌 판별). 기본=미입장(fresh) → 활성 방 있으면 다른 세션으로 취급.
+let myEnteredRoomId: number | undefined;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  myEnteredRoomId = undefined;
   (usePartyroomClient as Mock).mockReturnValue({
     onConnect: mockOnConnect,
     setRoomReconnectHandler: mockSetRoomReconnectHandler,
     unsubscribeCurrentRoom: mockUnsubscribeCurrentRoom,
+    markEnteredRoom: mockMarkEnteredRoom,
+    get myEnteredRoomId() {
+      return myEnteredRoomId;
+    },
     subscribe: vi.fn(),
   });
   (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(vi.fn());
@@ -61,7 +75,20 @@ beforeEach(() => {
   (useEnterPartyroomMutation as Mock).mockReturnValue({ mutate: mockMutate });
   (useAppRouter as Mock).mockReturnValue({ push: mockPush });
   (useQueryClient as Mock).mockReturnValue({ invalidateQueries: mockInvalidateQueries });
+  (useDialog as Mock).mockReturnValue({ openConfirmDialog: mockOpenConfirmDialog });
+  (useI18n as Mock).mockReturnValue({ party: { para: { supersede_confirm: '계속할까요?' } } });
+  // 기본: 다른 활성 방 없음(사전 컨펌 미발동) + 컨펌 시 승인
+  mockGetMyActiveRoom.mockResolvedValue(null);
+  mockOpenConfirmDialog.mockResolvedValue(true);
 });
+
+/** once 핸들러까지 실행(= resync 등록 + 비동기 사전 컨펌/입장 시작). */
+const triggerOnce = (partyroomId: number, opts?: { entrySource?: 'list' }) => {
+  const { result } = renderHook(() => useEnterPartyroom(partyroomId, opts));
+  act(() => result.current());
+  mockOnConnect.mock.calls[0][0]();
+  return result;
+};
 
 describe('useEnterPartyroom', () => {
   test('반환된 함수를 호출하면 client.onConnect를 등록한다', () => {
@@ -74,72 +101,117 @@ describe('useEnterPartyroom', () => {
     expect(mockOnConnect).toHaveBeenCalledWith(expect.any(Function), { once: true });
   });
 
-  test('onConnect 콜백이 실행되면 enter mutation을 호출한다', () => {
-    const { result } = renderHook(() => useEnterPartyroom(42));
+  test('onConnect 콜백이 실행되면 (사전 컨펌 통과 후) enter mutation을 호출한다', async () => {
+    triggerOnce(42);
 
-    act(() => {
-      result.current();
-    });
-
-    // onConnect의 첫 번째 인자인 콜백을 실행
-    const onConnectCallback = mockOnConnect.mock.calls[0][0];
-    onConnectCallback();
-
-    expect(mockMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ partyroomId: 42 }),
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
-      })
+    await vi.waitFor(() =>
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ partyroomId: 42 }),
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      )
     );
   });
 
-  test('enter 실패 시 로비로 이동한다 (백엔드 exit 워크어라운드 없음)', () => {
-    const { result } = renderHook(() => useEnterPartyroom(1));
-
-    act(() => {
-      result.current();
-    });
-
-    const onConnectCallback = mockOnConnect.mock.calls[0][0];
-    onConnectCallback();
+  test('enter 실패 시 로비로 이동한다 (백엔드 exit 워크어라운드 없음)', async () => {
+    triggerOnce(1);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
 
     // enter mutation의 onError 콜백 실행
-    const mutateOptions = mockMutate.mock.calls[0][1];
-    mutateOptions.onError();
+    mockMutate.mock.calls[0][1].onError();
 
-    // enter 자체가 실패했으므로 입장한 룸이 없다. 레이아웃 언마운트는 더 이상
-    // 백엔드 exit을 호출하지 않으므로 별도의 억제 워크어라운드가 필요 없다.
     expect(mockPush).toHaveBeenCalledWith('/parties');
   });
 
-  test('options.entrySource를 받아도 기존 enter 흐름은 변경되지 않는다 (PR-3 시그니처 회귀)', () => {
-    const { result } = renderHook(() => useEnterPartyroom(7, { entrySource: 'list' }));
+  test('enter 성공 시 이 탭의 입장 방을 기록한다 (#476 markEnteredRoom)', async () => {
+    triggerOnce(42);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
 
-    act(() => {
-      result.current();
-    });
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER' });
+    expect(mockMarkEnteredRoom).toHaveBeenCalledWith(42);
+  });
+
+  test('options.entrySource를 받아도 기존 enter 흐름은 변경되지 않는다 (PR-3 시그니처 회귀)', async () => {
+    triggerOnce(7, { entrySource: 'list' });
 
     expect(mockOnConnect).toHaveBeenCalledWith(expect.any(Function), { once: true });
-
-    const onConnectCallback = mockOnConnect.mock.calls[0][0];
-    onConnectCallback();
-
-    expect(mockMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ partyroomId: 7 }),
-      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+    await vi.waitFor(() =>
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ partyroomId: 7 }),
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      )
     );
   });
 });
 
+describe('useEnterPartyroom 사전 컨펌 — 다른 세션(탭/기기) 점유 (#476)', () => {
+  test('다른 활성 방 없음 → 컨펌 없이 바로 입장', async () => {
+    mockGetMyActiveRoom.mockResolvedValue(null);
+    triggerOnce(7);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    expect(mockOpenConfirmDialog).not.toHaveBeenCalled();
+  });
+
+  test('서버 활성 방 == 이 탭이 들어갔던 방 → 같은 세션 방 전환, 컨펌 없이 입장', async () => {
+    myEnteredRoomId = 5; // 이 탭은 방 5에 있었음
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 5, crewId: 1 }); // 서버도 5
+    triggerOnce(7); // 방 7로 전환
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    expect(mockOpenConfirmDialog).not.toHaveBeenCalled();
+  });
+
+  test('서버 활성 방이 다른 세션(이 탭 미입장) → 컨펌 노출, 승인 시 입장', async () => {
+    myEnteredRoomId = undefined; // fresh 탭/기기
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 99, crewId: 2 }); // 다른 세션이 방 99 점유
+    mockOpenConfirmDialog.mockResolvedValue(true);
+    triggerOnce(7);
+    await vi.waitFor(() => expect(mockOpenConfirmDialog).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ partyroomId: 7 }),
+        expect.anything()
+      )
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('다른 세션 점유 + 컨펌 취소 → 입장하지 않고 로비로', async () => {
+    mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 99, crewId: 2 });
+    mockOpenConfirmDialog.mockResolvedValue(false);
+    triggerOnce(7);
+    await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test('이 탭이 같은 방 재입장(myEnteredRoomId===target) → 스냅샷 조회 생략', async () => {
+    myEnteredRoomId = 7;
+    triggerOnce(7);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    expect(mockGetMyActiveRoom).not.toHaveBeenCalled();
+    expect(mockOpenConfirmDialog).not.toHaveBeenCalled();
+  });
+
+  test('스냅샷 조회 실패 → 컨펌 없이 입장(advisory fail-open)', async () => {
+    mockGetMyActiveRoom.mockRejectedValue(new Error('network'));
+    triggerOnce(7);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    expect(mockOpenConfirmDialog).not.toHaveBeenCalled();
+  });
+});
+
 describe('useEnterPartyroom 재연결 resync — 스냅샷 분기 (#477/#469/#402)', () => {
-  // #469: onConnect 는 초기 enter(once) 1회만 등록되고, resync 는 그 once 핸들러 실행 시
-  // setRoomReconnectHandler 로 단일 슬롯 등록된다(방마다 누적 X). 아래는 그 resync 콜백을 꺼내온다.
-  const registerAndGetResync = (partyroomId: number) => {
+  // once 핸들러 실행 시 resync 가 setRoomReconnectHandler 로 동기 등록된다(사전 컨펌/입장은 비동기).
+  // 초기 입장을 settle 시킨 뒤 mockMutate/getMyActiveRoom 을 clear 해 resync 만 격리 관찰한다.
+  const registerAndGetResync = async (partyroomId: number) => {
+    mockGetMyActiveRoom.mockResolvedValue(null); // 초기 입장: 다른 방 없음 → 바로 입장
     const { result } = renderHook(() => useEnterPartyroom(partyroomId));
     act(() => result.current());
-    mockOnConnect.mock.calls[0][0](); // once 핸들러 → 초기 enter + resync 등록
-    mockMutate.mockClear(); // 초기 enter 호출 제거 → 재연결에서 되훔침 여부를 mockMutate 로 검증
+    mockOnConnect.mock.calls[0][0]();
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled()); // 초기 입장 settle
+    mockMutate.mockClear();
+    mockGetMyActiveRoom.mockClear();
     return mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
   };
 
@@ -151,72 +223,70 @@ describe('useEnterPartyroom 재연결 resync — 스냅샷 분기 (#477/#469/#40
     expect(mockOnConnect).toHaveBeenCalledWith(expect.any(Function), { once: true });
     expect(mockSetRoomReconnectHandler).not.toHaveBeenCalled();
 
-    mockOnConnect.mock.calls[0][0](); // once 실행 시 resync 등록
+    mockOnConnect.mock.calls[0][0](); // once 실행 시 resync 동기 등록
     expect(mockSetRoomReconnectHandler).toHaveBeenCalledWith(expect.any(Function));
   });
 
   test('#477 재연결 resync 는 enter(tryEnter) 를 재주장하지 않고 내 활성 방 스냅샷을 조회한다 (되훔침 금지)', async () => {
+    const resync = await registerAndGetResync(7);
     mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 7, crewId: 1 });
-    const resync = registerAndGetResync(7);
     resync();
     await vi.waitFor(() => expect(mockGetMyActiveRoom).toHaveBeenCalledTimes(1));
-    expect(mockMutate).not.toHaveBeenCalled(); // tryEnter 재주장 소멸 (CRW-005 유발 경로 제거)
+    expect(mockMutate).not.toHaveBeenCalled(); // tryEnter 재주장 소멸
   });
 
   test('스냅샷 활성 방 == 현재 방 → 경량 resync (DJ큐 invalidate), 이탈/teardown 없음', async () => {
+    const resync = await registerAndGetResync(7);
+    mockInvalidateQueries.mockClear();
     mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 7, crewId: 1 });
-    const resync = registerAndGetResync(7);
     resync();
     await vi.waitFor(() =>
       expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: [QueryKeys.DjingQueue, 7] })
     );
-    expect(partyroomsService.getSetupInfo).not.toHaveBeenCalled();
     expect(mockUnsubscribeCurrentRoom).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  test('스냅샷 활성 방 != 현재 방(밀려남) → 구독 teardown + 로비, enter/exit 미호출', async () => {
+  test('스냅샷 활성 방 != 현재 방(밀려남) → 구독 teardown + 로비, enter 미호출', async () => {
+    const resync = await registerAndGetResync(7);
     mockGetMyActiveRoom.mockResolvedValue({ partyroomId: 99, crewId: 2 });
-    const resync = registerAndGetResync(7);
     resync();
     await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
     expect(mockUnsubscribeCurrentRoom).toHaveBeenCalledTimes(1);
-    expect(mockMutate).not.toHaveBeenCalled(); // 되훔침 금지
-    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   test('스냅샷 활성 방 없음(null) → 구독 teardown + 로비', async () => {
+    const resync = await registerAndGetResync(7);
     mockGetMyActiveRoom.mockResolvedValue(null);
-    const resync = registerAndGetResync(7);
     resync();
     await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
     expect(mockUnsubscribeCurrentRoom).toHaveBeenCalledTimes(1);
   });
 
   test('스냅샷 조회 실패 → 로비 이동 (fail-safe)', async () => {
+    const resync = await registerAndGetResync(7);
     mockGetMyActiveRoom.mockRejectedValue(new Error('network'));
-    const resync = registerAndGetResync(7);
     resync();
     await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
   });
 });
 
 describe('플레이백 요약 추적기 배선 (#444)', () => {
-  const enterViaOnce = (
+  const enterViaOnce = async (
     partyroomId: number,
     enterResponse = { crewId: 1, gradeType: 'LISTENER' }
   ) => {
-    const { result } = renderHook(() => useEnterPartyroom(partyroomId));
-    act(() => result.current());
-    mockOnConnect.mock.calls[0][0]();
+    triggerOnce(partyroomId);
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled());
     mockMutate.mock.calls[0][1].onSuccess(enterResponse);
   };
 
-  test('L1: setup 시작 시 추적기를 즉시 clear한다 (await 이전)', () => {
+  test('L1: setup 시작 시 추적기를 즉시 clear한다 (setup await 이전)', async () => {
     (partyroomsService.getSetupInfo as Mock).mockReturnValue(new Promise(() => {}));
     (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
 
-    enterViaOnce(7);
+    await enterViaOnce(7);
 
     expect(mockTrackerClear).toHaveBeenCalled();
     expect(mockSeedFromSetup).not.toHaveBeenCalled(); // setup 미완료 — 시드는 아직
@@ -236,9 +306,6 @@ describe('플레이백 요약 추적기 배선 (#444)', () => {
           thumbnailImage: 't.jpg',
           endTime: 1_234_567,
         },
-        // NOTE: motion 미포함 — crewIdToMotionTypeMap의 reduce 초기값이 {} as Map(Map 아님)이라
-        // motion 배열이 존재하면 mock 경로에서 .set/.get 크래시. 선재 버그, #445로 추적.
-        // 시드② 매핑 검증엔 불필요.
         reaction: {
           history: { isLiked: false, isDisliked: false, isGrabbed: false },
           aggregation: { likeCount: 1, dislikeCount: 2, grabCount: 3 },
@@ -248,7 +315,7 @@ describe('플레이백 요약 추적기 배선 (#444)', () => {
     });
     (partyroomsService.getNotice as Mock).mockResolvedValue({ content: '공지' });
 
-    enterViaOnce(7);
+    await enterViaOnce(7);
 
     await vi.waitFor(() => expect(mockSeedFromSetup).toHaveBeenCalled());
     expect(mockSeedFromSetup).toHaveBeenCalledWith({
@@ -271,7 +338,7 @@ describe('플레이백 요약 추적기 배선 (#444)', () => {
     });
     (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
 
-    enterViaOnce(7);
+    await enterViaOnce(7);
 
     await vi.waitFor(() => expect(mockSeedFromSetup).toHaveBeenCalled());
     expect(mockSeedFromSetup).toHaveBeenCalledWith({
@@ -282,13 +349,14 @@ describe('플레이백 요약 추적기 배선 (#444)', () => {
     });
   });
 
-  test('L2: 재연결 resync 발화 시 추적기를 clear한다 (#469 setRoomReconnectHandler)', () => {
+  test('L2: 재연결 resync 발화 시 추적기를 clear한다 (#469 setRoomReconnectHandler)', async () => {
+    mockGetMyActiveRoom.mockResolvedValue(null);
     const { result } = renderHook(() => useEnterPartyroom(7));
     act(() => result.current());
-    mockOnConnect.mock.calls[0][0](); // once 핸들러 → resync 등록
+    mockOnConnect.mock.calls[0][0]();
+    await vi.waitFor(() => expect(mockMutate).toHaveBeenCalled()); // 초기 입장 settle
+    mockTrackerClear.mockClear();
     const resync = mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
-
-    expect(mockTrackerClear).not.toHaveBeenCalled(); // 등록만으론 clear 안 함
 
     resync(); // 재연결 발화
     expect(mockTrackerClear).toHaveBeenCalledTimes(1);

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -10,8 +10,10 @@ import { EnterResponse, PartyroomReaction } from '@/shared/api/http/types/partyr
 import type { EntrySource } from '@/shared/lib/analytics/events';
 import { trackPartyroomEntered } from '@/shared/lib/analytics/room-tracking';
 import silent from '@/shared/lib/functions/silent';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
+import { useDialog } from '@/shared/ui/components/dialog';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
 
 type Options = {
@@ -26,6 +28,8 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   const { mutate: enter } = useEnterPartyroomMutation();
   const queryClient = useQueryClient();
   const router = useAppRouter();
+  const { openConfirmDialog } = useDialog();
+  const t = useI18n();
 
   const entrySource: EntrySource = options.entrySource ?? 'direct';
 
@@ -128,29 +132,67 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
           });
         });
 
-        enter(
-          { partyroomId },
-          {
-            onSuccess: (enterResponse) => {
-              silent(setup(enterResponse), {
-                onSuccess: () => {
-                  client.subscribe(partyroomId, handleEvent);
-                  queryClient.invalidateQueries({
-                    queryKey: [QueryKeys.DjingQueue, partyroomId],
-                  });
-                },
-                onError: () => {
-                  router.push('/parties'); // 에러 발생 시 로비로 이동
-                },
-              });
-            },
-            onError: () => {
-              // enter 자체가 실패해 입장한 룸이 없다. 레이아웃 언마운트는 더 이상
-              // 백엔드 exit을 호출하지 않으므로 별도의 억제 워크어라운드가 필요 없다.
-              router.push('/parties'); // 에러 발생 시 로비로 이동
-            },
-          }
-        );
+        const proceedEnter = () => {
+          enter(
+            { partyroomId },
+            {
+              onSuccess: (enterResponse) => {
+                // #476 이 탭이 입장 성공한 방 기록 — 이후 다른 세션 판별(사전 컨펌)에 쓰인다.
+                client.markEnteredRoom(partyroomId);
+                silent(setup(enterResponse), {
+                  onSuccess: () => {
+                    client.subscribe(partyroomId, handleEvent);
+                    queryClient.invalidateQueries({
+                      queryKey: [QueryKeys.DjingQueue, partyroomId],
+                    });
+                  },
+                  onError: () => {
+                    router.push('/parties'); // 에러 발생 시 로비로 이동
+                  },
+                });
+              },
+              onError: () => {
+                // enter 자체가 실패해 입장한 룸이 없다. 레이아웃 언마운트는 더 이상
+                // 백엔드 exit을 호출하지 않으므로 별도의 억제 워크어라운드가 필요 없다.
+                router.push('/parties'); // 에러 발생 시 로비로 이동
+              },
+            }
+          );
+        };
+
+        // #476 사전 컨펌 — 다른 세션(탭/기기)이 활성 방을 점유 중인데 다른 방으로 입장하려 하면
+        // 확인을 받는다(데스크탑 DJ 세션을 모바일 오조작으로 잃는 사고 방지). check-then-act 레이스는
+        // 허용 — 정합성은 V38 유니크가 보장하는 순수 advisory. 서버 활성 방이 이 탭이 들어갔던
+        // 방(myEnteredRoomId)이면 같은 세션의 방 전환이므로 컨펌하지 않는다. 이 탭이 같은 방을
+        // 재입장(myEnteredRoomId===partyroomId)하는 경우 조회 자체를 생략한다.
+        if (client.myEnteredRoomId === partyroomId) {
+          proceedEnter();
+          return;
+        }
+        silent(partyroomsService.getMyActiveRoom(), {
+          onSuccess: (snapshot) => {
+            const isOtherSessionActive =
+              snapshot != null &&
+              snapshot.partyroomId !== partyroomId &&
+              snapshot.partyroomId !== client.myEnteredRoomId;
+            if (!isOtherSessionActive) {
+              proceedEnter();
+              return;
+            }
+            silent(openConfirmDialog({ content: t.party.para.supersede_confirm }), {
+              onSuccess: (confirmed) => {
+                if (confirmed) {
+                  proceedEnter();
+                } else {
+                  router.push('/parties'); // 취소 → 입장하지 않고 로비로
+                }
+              },
+              onError: () => proceedEnter(),
+            });
+          },
+          // 스냅샷 조회 실패 시 컨펌 없이 입장(advisory, fail-open — 정합성은 서버가 보장).
+          onError: () => proceedEnter(),
+        });
       },
       { once: true }
     );

--- a/src/shared/api/websocket/types/session.ts
+++ b/src/shared/api/websocket/types/session.ts
@@ -1,0 +1,19 @@
+/**
+ * 유저 개인 큐(/user/sub/session) 세션 이벤트 타입 (멀티 디바이스 승계, #476/platform#369).
+ * 룸 브로드캐스트가 아니라 특정 유저의 모든 세션(탭/기기)에 도달하는 user destination 메시지다.
+ */
+export enum SessionEventType {
+  SESSION_SUPERSEDED = 'SESSION_SUPERSEDED',
+}
+
+/**
+ * 같은 유저가 다른 방으로 입장해 기존 활성 crew 가 밀려났음을 알린다.
+ * 수신 세션은 자신의 현재 방이 {@link supersededPartyroomId} 와 일치할 때만 밀려남 처리한다
+ * (같은 유저의 새 세션 B 는 {@link newPartyroomId} 에 있으므로 무시).
+ */
+export type SessionSupersededEvent = {
+  type: SessionEventType.SESSION_SUPERSEDED;
+  newPartyroomId: number;
+  supersededPartyroomId: number;
+  occurredAt: number;
+};

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -220,6 +220,8 @@
       "party_rooms": "Party Rooms",
       "leave_party_confirm": "Your changes won't be saved.\nAre you sure you want to leave the party room?",
       "closed": "The party room has been closed.",
+      "superseded": "This screen was closed because you joined from another device.",
+      "supersede_confirm": "You're using a party room on another device.\nContinue here?",
       "close": "Close",
       "share_x_partyroom": "I'm listening to the {partyroom_name} room. Come hang out!"
     },

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -220,6 +220,8 @@
       "party_rooms": "Party Rooms",
       "leave_party_confirm": "변경 내용이 저장되지 않아요.\n파티룸으로 나가시겠어요?",
       "closed": "파티룸이 폐쇄되었습니다",
+      "superseded": "다른 기기에서 입장하여 이 화면의 이용이 종료되었습니다",
+      "supersede_confirm": "다른 기기에서 파티룸을 이용 중입니다.\n여기서 계속할까요?",
       "close": "폐쇄하기",
       "share_x_partyroom": "I'm listening to the {partyroom_name} room. Come hang out!"
     },


### PR DESCRIPTION
## 개요
멀티 디바이스 세션 승계(new-session-wins) 3종 세트의 **웹 UX**. platform#369(SESSION_SUPERSEDED 발행) + web#477(getMyActiveRoom 스냅샷)과 세트.

> ⚠️ **스택 PR**: base = `feature/477-reconnect-resync-snapshot`(getMyActiveRoom 의존). web#477 머지 후 base 를 `development` 로 재타겟.

## 1) 밀려난 브라우저 (수신측)
- 유저 개인 큐(`/user/sub/session`) 구독. `SESSION_SUPERSEDED` 수신 시, 이 세션(탭)의 현재 방이 `supersededPartyroomId` 와 일치하면 **로컬 teardown + 로비 + 안내 모달**. **exit API 미호출**(서버가 EXIT 완결, 클라는 렌더만). 새 세션 B(`newPartyroomId`)는 무시.
- WS 죽어 알림 미수신 시에도 재연결 resync 스냅샷(#477)이 정합성 치유.

## 2) 새 기기 (송신측 사전 컨펌)
- 입장 직전 `getMyActiveRoom` 조회. 서버 활성 방이 **이 탭이 들어갔던 방(`myEnteredRoomId`)·입장 대상과 모두 다르면 = 다른 세션(탭/기기) 점유** → 확인 다이얼로그. 취소 시 미입장(로비).
- **판별은 세션(탭) 단위**: 같은 탭 방 전환·같은 방 멀티탭은 컨펌 없음. 다른 탭/기기는 실제 밀어냄이라 컨펌.
- check-then-act 레이스 허용 — 정합성은 V38 유니크 보장, 순수 advisory.

## 변경
- `PartyroomClient`: `subscribeUserSession`(멱등)/`unsubscribeUserSession` + `markEnteredRoom`/`myEnteredRoomId`
- `useSupersededSessionListener`(룸 레이아웃 마운트), `useEnterPartyroom` 사전 컨펌 게이트
- i18n ko/en(JSON 직접): `party.para.superseded` / `supersede_confirm`

## 검증
- 단위: 리스너 5 · enter(사전컨펌+재연결) 21 · PartyroomClient 15 · layout 4 · **전체 1769 GREEN** · tsc/lint 클린
- e2e 스펙 추가(사전 컨펌 취소 + 밀려난 모달) — **라이브 실행은 #477+#369 결합 백엔드 필요**

## ⚠️ 머지 보류
- 세트 전체(#477·#369·#476) 검토 후 결정.

관련: #476, #477, platform#369