### PR TITLE
release: development→main(prod) 승격 — 디제잉 빈 상태 진입 개선·플레이리스트 커서 시안 반영 (2커밋)

### DIFF
--- a/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.integration.test.ts
+++ b/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.integration.test.ts
@@ -1,0 +1,52 @@
+import { waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/shared/api/__test__/msw-server';
+import { renderWithClient } from '@/shared/api/__test__/test-utils';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { useQuickRegisterMeToQueue } from './use-quick-register-me-to-queue.mutation';
+
+const TRACK = {
+  name: "BLACKPINK - 'Shut Down' M/V",
+  linkId: 'POe9SOEKotk',
+  duration: '03:01',
+  thumbnailImage: 'https://i.ytimg.com/vi/POe9SOEKotk/mqdefault.jpg',
+};
+
+describe('useQuickRegisterMeToQueue integration (hook → service → MSW)', () => {
+  it('partyroomId 를 뺀 트랙 4개 필드만 body 로 보낸다', async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(
+        'http://localhost:8080/api/v1/partyrooms/:id/dj-queue/quick',
+        async ({ request }) => {
+          requestBody = await request.json();
+          return new HttpResponse(null, { status: 201 });
+        }
+      )
+    );
+
+    const { result } = renderWithClient(() => useQuickRegisterMeToQueue());
+
+    result.current.mutate({ partyroomId: 1, ...TRACK });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requestBody).toEqual(TRACK);
+  });
+
+  it('성공 시 DjingQueue 와 Playlist 캐시를 무효화한다', async () => {
+    const { result, queryClient } = renderWithClient(() => useQuickRegisterMeToQueue());
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    result.current.mutate({ partyroomId: 1, ...TRACK });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [QueryKeys.DjingQueue, 1] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [QueryKeys.Playlist] })
+    );
+  });
+});

--- a/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
+++ b/src/features/partyroom/register-dj-with-track/api/use-quick-register-me-to-queue.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { QueryKeys } from '@/shared/api/http/query-keys';
+import { djsService } from '@/shared/api/http/services';
+import { APIError } from '@/shared/api/http/types/@shared';
+import { QuickRegisterMeToQueuePayload } from '@/shared/api/http/types/djs';
+import { track } from '@/shared/lib/analytics';
+
+export const useQuickRegisterMeToQueue = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, AxiosError<APIError>, QuickRegisterMeToQueuePayload>({
+    mutationFn: (request) => djsService.quickRegisterMeToQueue(request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.DjingQueue, variables.partyroomId],
+      });
+      // 서버가 플레이리스트를 대신 만들어 담으므로 목록·곡 수가 함께 바뀐다
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.Playlist],
+      });
+      track('DJ Registered', { partyroom_id: variables.partyroomId });
+    },
+  });
+};

--- a/src/features/partyroom/register-dj-with-track/index.ts
+++ b/src/features/partyroom/register-dj-with-track/index.ts
@@ -1,0 +1,1 @@
+export { default as useRegisterDjWithTrack } from './ui/use-register-dj-with-track.hook';

--- a/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/search-track-for-djing.component.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { useCallback, useState } from 'react';
+import { useSearchMusics } from '@/features/playlist/add-tracks/api/use-search-musics.query';
+import SearchInput from '@/features/playlist/add-tracks/ui/search-input.component';
+import SearchListItem from '@/features/playlist/add-tracks/ui/search-list-item.component';
+import { Music } from '@/shared/api/http/types/playlists';
+import { track } from '@/shared/lib/analytics';
+import { cn } from '@/shared/lib/functions/cn';
+import { safeDecodeURI } from '@/shared/lib/functions/safe-decode-uri';
+import { useI18n } from '@/shared/lib/localization/i18n.context';
+import { Button } from '@/shared/ui/components/button';
+import LoadingPanel from '@/shared/ui/components/loading/loading-panel.component';
+import { TextButton } from '@/shared/ui/components/text-button';
+import { Typography } from '@/shared/ui/components/typography';
+import { PFArrowLeft, PFClose } from '@/shared/ui/icons';
+
+type Props = {
+  onSelectTrack: (music: Music) => void;
+  onBackToDjingDialog: () => void;
+  onCloseAll: () => void;
+};
+
+export default function SearchTrackForDjing({
+  onSelectTrack,
+  onBackToDjingDialog,
+  onCloseAll,
+}: Props) {
+  const t = useI18n();
+  const [search, setSearch] = useState('');
+  const [selectedTrack, setSelectedTrack] = useState<Music>();
+  const { data: musics, isFetching } = useSearchMusics(search);
+
+  const handleSearch = useCallback((value: string) => {
+    setSearch(value);
+    setSelectedTrack(undefined);
+    if (value) {
+      track('Music Searched', { query: value });
+    }
+  }, []);
+
+  const hasNoResult = !isFetching && !musics?.length;
+
+  return (
+    <div className='flexCol text-start'>
+      <header className='flex items-center gap-7 px-[40px] pt-[36px] pb-[24px]'>
+        <TextButton
+          onClick={onBackToDjingDialog}
+          Icon={<PFArrowLeft width={24} height={24} />}
+          data-testid='djing-track-search-back'
+        />
+        <Typography type='title2'>{t.playlist.btn.add_song}</Typography>
+        <SearchInput onSearch={handleSearch} />
+        <TextButton
+          onClick={onCloseAll}
+          Icon={<PFClose width={24} height={24} />}
+          data-testid='djing-track-search-close'
+        />
+      </header>
+
+      <div className='h-[420px] overflow-y-auto px-[40px]'>
+        {isFetching && <LoadingPanel />}
+
+        {hasNoResult && (
+          <div className='h-full flexRowCenter'>
+            <Typography type='body2' className='text-gray-300'>
+              {t.dj.para.search_song_to_dj}
+            </Typography>
+          </div>
+        )}
+
+        {!isFetching &&
+          musics?.map((music) => {
+            const isSelected = selectedTrack?.videoId === music.videoId;
+
+            return (
+              <div
+                key={music.videoId}
+                role='button'
+                tabIndex={0}
+                aria-pressed={isSelected}
+                onClick={() => setSelectedTrack(music)}
+                className={cn(
+                  'my-1 rounded border px-[12px] py-[12px] cursor-pointer transition-colors',
+                  isSelected
+                    ? 'border-red-300 bg-red-500/40'
+                    : 'border-transparent hover:bg-gray-800'
+                )}
+                data-testid='djing-track-item'
+              >
+                <SearchListItem music={music} Suffix={null} />
+              </div>
+            );
+          })}
+      </div>
+
+      <footer className='flex items-center justify-between gap-4 border-t border-gray-700 px-[40px] py-[24px]'>
+        {selectedTrack ? (
+          <div className='flexCol gap-1 min-w-0'>
+            <Typography type='body1' overflow='ellipsis'>
+              {safeDecodeURI(selectedTrack.videoTitle)}
+            </Typography>
+            <Typography type='detail1' className='text-gray-300'>
+              {t.dj.para.start_djing_with_this_song}
+            </Typography>
+          </div>
+        ) : (
+          <Typography type='body2' className='text-gray-300'>
+            {t.dj.para.select_song_to_dj}
+          </Typography>
+        )}
+
+        <Button
+          size='lg'
+          disabled={!selectedTrack}
+          onClick={() => selectedTrack && onSelectTrack(selectedTrack)}
+          data-testid='djing-track-confirm'
+        >
+          {t.dj.btn.register_with_this_song}
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
+++ b/src/features/partyroom/register-dj-with-track/ui/use-register-dj-with-track.hook.tsx
@@ -1,0 +1,47 @@
+import { Music } from '@/shared/api/http/types/playlists';
+import { useDialog } from '@/shared/ui/components/dialog';
+import theme from '@/shared/ui/foundation/theme';
+import SearchTrackForDjing from './search-track-for-djing.component';
+import { useQuickRegisterMeToQueue } from '../api/use-quick-register-me-to-queue.mutation';
+
+type RegisterDjWithTrackParams = {
+  partyroomId: number;
+  closeDjingDialog?: () => void;
+};
+
+export default function useRegisterDjWithTrack() {
+  const { openDialog } = useDialog();
+  const { mutate: quickRegisterMeToQueue } = useQuickRegisterMeToQueue();
+
+  const openTrackSearchDialog = (closeDjingDialog?: () => void) =>
+    openDialog<Music>((onSelect, onCancel) => ({
+      zIndex: theme.zIndex.dialog + 1,
+      closeWhenOverlayClicked: false,
+      classNames: { container: '!p-[unset] w-[1000px] bg-black border border-gray-700' },
+      Body: (
+        <SearchTrackForDjing
+          onSelectTrack={onSelect}
+          onBackToDjingDialog={() => onCancel?.()}
+          onCloseAll={() => {
+            onCancel?.();
+            closeDjingDialog?.();
+          }}
+        />
+      ),
+    }));
+
+  return async ({ partyroomId, closeDjingDialog }: RegisterDjWithTrackParams) => {
+    const selectedTrack = await openTrackSearchDialog(closeDjingDialog);
+    if (!selectedTrack) return;
+
+    quickRegisterMeToQueue({
+      partyroomId,
+      name: selectedTrack.videoTitle,
+      linkId: selectedTrack.videoId,
+      duration: selectedTrack.runningTime,
+      thumbnailImage: selectedTrack.thumbnailUrl,
+    });
+
+    closeDjingDialog?.();
+  };
+}

--- a/src/features/playlist/list-tracks/ui/track.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.test.tsx
@@ -18,6 +18,11 @@ vi.mock('@/entities/music-preview/index.ui', () => ({
 vi.mock('@/shared/ui/components/icon-menu', () => ({
   IconMenu: () => <div data-testid='icon-menu' />,
 }));
+vi.mock('react-fast-marquee', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='marquee'>{children}</div>
+  ),
+}));
 
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -27,8 +32,8 @@ import { useStores } from '@/shared/lib/store/stores.context';
 import Track from './track.component';
 
 const NOT_PLAYABLE = 'Not playable here (exceeds this room limit)';
-const NOW_LABEL = 'Now';
-const NEXT_LABEL = 'Next';
+const NOW_LABEL = 'NOW';
+const NEXT_LABEL = 'NEXT';
 
 const track = {
   linkId: 'l1',
@@ -95,5 +100,42 @@ describe('Track NOW/NEXT 배지', () => {
     render(<Track track={track} menuItems={[]} />);
     expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
     expect(screen.queryByTestId('track-badge-next')).not.toBeInTheDocument();
+  });
+});
+
+describe('Track NOW/NEXT 배치 (#462)', () => {
+  test('isNow=true 여도 ⋮ 메뉴는 그대로 두고 배지를 왼쪽에 붙인다', () => {
+    render(<Track track={track} menuItems={[]} isNow />);
+    expect(screen.getByTestId('track-badge-now')).toBeInTheDocument();
+    expect(screen.getByTestId('icon-menu')).toBeInTheDocument();
+  });
+
+  test('isNext=true 여도 ⋮ 메뉴는 그대로 두고 배지를 왼쪽에 붙인다', () => {
+    render(<Track track={track} menuItems={[]} isNext />);
+    expect(screen.getByTestId('track-badge-next')).toBeInTheDocument();
+    expect(screen.getByTestId('icon-menu')).toBeInTheDocument();
+  });
+
+  test('일반 곡은 배지 없이 ⋮ 메뉴만 보여준다', () => {
+    render(<Track track={track} menuItems={[]} />);
+    expect(screen.getByTestId('icon-menu')).toBeInTheDocument();
+  });
+
+  test('isNow=true 면 타이틀이 마퀴로 흐르고 이퀄라이저가 뜬다', () => {
+    render(<Track track={track} menuItems={[]} isNow />);
+    expect(screen.getByTestId('marquee')).toBeInTheDocument();
+    expect(screen.getByTestId('playing-bars')).toBeInTheDocument();
+  });
+
+  test('isNext=true 면 마퀴도 이퀄라이저도 없다 — NOW 전용 모션', () => {
+    render(<Track track={track} menuItems={[]} isNext />);
+    expect(screen.queryByTestId('marquee')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('playing-bars')).not.toBeInTheDocument();
+  });
+
+  test('일반 곡은 마퀴 없이 제목을 그대로 렌더한다', () => {
+    render(<Track track={track} menuItems={[]} />);
+    expect(screen.queryByTestId('marquee')).not.toBeInTheDocument();
+    expect(screen.getByText('My Song')).toBeInTheDocument();
   });
 });

--- a/src/features/playlist/list-tracks/ui/track.component.tsx
+++ b/src/features/playlist/list-tracks/ui/track.component.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { IconMenu } from '@/shared/ui/components/icon-menu';
 import { MenuItem } from '@/shared/ui/components/menu';
+import { CursorBadge, CursorTitle, PlayingBars } from '@/shared/ui/components/track-cursor';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFDragAndDrop, PFMoreVert } from '@/shared/ui/icons';
 
@@ -17,9 +18,9 @@ type TrackProps = {
   track: PlaylistTrack;
   menuItems: MenuItem[];
   isOverRoomLimit?: boolean;
-  /** 지금 재생 중(CurrentDJ 본인 한정, 방 안). NOW 배지. */
+  /** 지금 재생 중(CurrentDJ 본인 한정, 방 안). */
   isNow?: boolean;
-  /** 내가 다음에 디제잉하면 시작될 곡. NEXT 배지. */
+  /** 내가 다음에 디제잉하면 시작될 곡. */
   isNext?: boolean;
 };
 
@@ -46,11 +47,13 @@ const Track = ({
   // 미리보기용 트랙 데이터 변환
   const previewTrack = convertPlaylistTrackToPreview(track);
 
+  const hasCursor = isNow || isNext;
+
   return (
     <div
       ref={setNodeRef}
       className={cn(
-        'relative grid grid-cols-[24px_1fr_32px] items-center gap-2 cursor-default',
+        'relative grid grid-cols-[24px_1fr_auto] items-center gap-2 cursor-default',
         isOverRoomLimit && 'opacity-50'
       )}
       style={style}
@@ -62,7 +65,7 @@ const Track = ({
 
       <div className='relative w-full flexRow justify-start rounded gap-[12px] overflow-hidden select-none'>
         {/* 미리보기 기능이 통합된 썸네일 */}
-        <div className='shrink-0 pointer-events-auto'>
+        <div className='relative shrink-0 pointer-events-auto'>
           <ThumbnailWithPreview
             previewTrack={previewTrack}
             thumbnailSrc={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
@@ -72,23 +75,11 @@ const Track = ({
             className='w-[80px] h-[44px] bg-gray-600'
             imageClassName={cn('w-full h-full object-contain select-none')}
           />
+          {isNow && <PlayingBars className='absolute inset-0 pointer-events-none' />}
         </div>
 
         <div className='flex-1 min-w-0 select-none flexCol overflow-hidden pointer-events-none'>
-          {(isNow || isNext) && (
-            <span
-              data-testid={isNow ? 'track-badge-now' : 'track-badge-next'}
-              className={cn(
-                'mb-0.5 inline-flex w-fit items-center rounded-[3px] px-1.5 py-[1px] text-[10px] font-bold leading-[14px]',
-                isNow ? 'bg-red-300 text-white' : 'bg-gray-600 text-gray-100'
-              )}
-            >
-              {isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
-            </span>
-          )}
-          <Typography type='caption1' overflow='ellipsis' className='text-gray-50'>
-            {track.name}
-          </Typography>
+          <CursorTitle name={track.name} scrolling={isNow} faded={hasCursor} />
           <Typography type='caption1' className='text-gray-400'>
             {track.duration}
           </Typography>
@@ -100,7 +91,13 @@ const Track = ({
         </div>
       </div>
 
-      <div className='shrink-0'>
+      <div className='shrink-0 flexRow items-center gap-2'>
+        {hasCursor && (
+          <CursorBadge
+            variant={isNow ? 'now' : 'next'}
+            label={isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
+          />
+        )}
         <IconMenu
           MenuButtonIcon={<PFMoreVert />}
           menuItemConfig={menuItems}

--- a/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.test.tsx
@@ -178,7 +178,16 @@ describe('TracksInPlaylist NOW/NEXT 배지', () => {
     return found;
   };
 
-  test('커서 null: NEXT는 첫 트랙, NOW 없음(비-DJ)', () => {
+  test('비-DJ + 커서 null: NOW/NEXT 모두 없음', () => {
+    setTracks([t10(), t20(), t30()], null);
+    render(<TracksInPlaylist playlist={playlist} />);
+
+    expect(lastTrackProps.every((p) => !p.isNow)).toBe(true);
+    expect(lastTrackProps.every((p) => !p.isNext)).toBe(true);
+  });
+
+  test('내가 CurrentDJ + 커서 null: NEXT는 첫 트랙', () => {
+    setStore({ me: { crewId: 5 }, currentDj: { crewId: 5 } });
     setTracks([t10(), t20(), t30()], null);
     render(<TracksInPlaylist playlist={playlist} />);
 
@@ -198,13 +207,13 @@ describe('TracksInPlaylist NOW/NEXT 배지', () => {
     expect(byId(10).isNow).toBe(false);
   });
 
-  test('내가 CurrentDJ 아님 + 커서=20: NOW 없음, NEXT=30만', () => {
+  test('내가 CurrentDJ 아님 + 커서=20: NOW/NEXT 모두 없음', () => {
     setStore({ me: { crewId: 5 }, currentDj: { crewId: 9 } });
     setTracks([t10(), t20(), t30()], 20);
     render(<TracksInPlaylist playlist={playlist} />);
 
     expect(lastTrackProps.every((p) => !p.isNow)).toBe(true);
-    expect(byId(30).isNext).toBe(true);
+    expect(lastTrackProps.every((p) => !p.isNext)).toBe(true);
   });
 
   test('커서=마지막(30): NEXT는 wrap 하여 첫 트랙(10)', () => {

--- a/src/features/playlist/list-tracks/ui/tracks.component.tsx
+++ b/src/features/playlist/list-tracks/ui/tracks.component.tsx
@@ -49,12 +49,14 @@ const TracksInPlaylist = ({ playlist }: TracksInPlaylistProps) => {
 
   // 재생 커서(NOW 앵커). NEXT는 커서 + 현재(낙관적 재정렬 반영) 순서로부터 파생 → refetch 불필요.
   const cursor = data?.lastPlayedTrackId ?? null;
+  // 방 밖에선 currentDj가 없어 자연히 비활성.
   const isMeCurrentDj = me?.crewId != null && me.crewId === currentDj?.crewId;
-  const nextTrackId = resolveNextTrackId(
-    items.map((track) => track.trackId),
-    cursor
-  );
-  // NOW는 내가 CurrentDJ일 때(방 안)만. 방 밖에선 currentDj가 없어 자연히 비활성.
+  const nextTrackId = isMeCurrentDj
+    ? resolveNextTrackId(
+        items.map((track) => track.trackId),
+        cursor
+      )
+    : null;
   const nowTrackId = isMeCurrentDj ? cursor : null;
 
   useEffect(() => {

--- a/src/shared/api/__test__/handlers.ts
+++ b/src/shared/api/__test__/handlers.ts
@@ -248,6 +248,11 @@ export const handlers = [
     return new HttpResponse(null, { status: 201 });
   }),
 
+  // POST /v1/partyrooms/:id/dj-queue/quick — quickRegisterMeToQueue
+  http.post(`${BASE_URL}/v1/partyrooms/:id/dj-queue/quick`, () => {
+    return new HttpResponse(null, { status: 201 });
+  }),
+
   // DELETE /v1/partyrooms/:id/dj-queue/me — unregisterMeFromQueue
   http.delete(`${BASE_URL}/v1/partyrooms/:id/dj-queue/me`, () => {
     return new HttpResponse(null, { status: 204 });

--- a/src/shared/api/http/services/djs.ts
+++ b/src/shared/api/http/services/djs.ts
@@ -1,5 +1,6 @@
 import {
   RegisterMeToQueuePayload,
+  QuickRegisterMeToQueuePayload,
   ChangeMyPlaylistPayload,
   UnregisterMeFromQueuePayload,
   UnregisterDjFromQueuePayload,
@@ -17,6 +18,10 @@ export default class DjsService extends HTTPClient implements DjsClient {
 
   public registerMeToQueue({ partyroomId, ...body }: RegisterMeToQueuePayload) {
     return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue`, body);
+  }
+
+  public quickRegisterMeToQueue({ partyroomId, ...body }: QuickRegisterMeToQueuePayload) {
+    return this.post<void>(`${this.ROUTE_V1}/${partyroomId}/dj-queue/quick`, body);
   }
 
   public changeMyPlaylist({ partyroomId, ...body }: ChangeMyPlaylistPayload) {

--- a/src/shared/api/http/types/djs.ts
+++ b/src/shared/api/http/types/djs.ts
@@ -5,6 +5,14 @@ export type RegisterMeToQueuePayload = {
   playlistId: Playlist['id'];
 };
 
+export type QuickRegisterMeToQueuePayload = {
+  partyroomId: number;
+  name: string;
+  linkId: string;
+  duration: string;
+  thumbnailImage: string;
+};
+
 export type ChangeMyPlaylistPayload = {
   partyroomId: number;
   playlistId: Playlist['id'];
@@ -35,6 +43,7 @@ export type SkipPlaybackPayload = {
 
 export interface DjsClient {
   registerMeToQueue: (payload: RegisterMeToQueuePayload) => Promise<void>;
+  quickRegisterMeToQueue: (payload: QuickRegisterMeToQueuePayload) => Promise<void>;
   changeMyPlaylist: (payload: ChangeMyPlaylistPayload) => Promise<void>;
   unregisterMeFromQueue: (payload: UnregisterMeFromQueuePayload) => Promise<void>;
   unregisterDjFromQueue: (payload: UnregisterDjFromQueuePayload) => Promise<void>;

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -63,7 +63,8 @@ export type EventPropertyMap = {
   };
   'DJ Registered': {
     partyroom_id: number;
-    playlist_id: number;
+    // 곡 검색 즉시 등록은 서버가 플레이리스트를 만들어 담아 클라이언트가 id 를 모른다
+    playlist_id?: number;
   };
   'DJ Playlist Changed': {
     partyroom_id: number;

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -308,8 +308,8 @@
       "up_to_10_if_connect_wallet": "If you connect your wallet, you can create up to 10!",
       "no_other_playlist": "There are no other playlists to move this song to",
       "select_for_move": "Please select the playlist to move the selected song to",
-      "now_playing": "Now",
-      "next_up": "Next"
+      "now_playing": "NOW",
+      "next_up": "NEXT"
     },
     "ec": {
       "exceeded_list_connect_wallet": "You have already exceeded the number of lists that can be created. ",

--- a/src/shared/lib/localization/dictionaries/en.json
+++ b/src/shared/lib/localization/dictionaries/en.json
@@ -240,10 +240,13 @@
       "register_queue": "Register for DJ Queue",
       "add_dj": "Add DJ",
       "selection_completed": "Selection Complete",
-      "select_dj_playlist": "Select DJ Playlist"
+      "select_dj_playlist": "Select DJ Playlist",
+      "search_and_register_dj": "Search a song and be a DJ",
+      "pick_from_my_playlist": "Choose from my playlist",
+      "register_with_this_song": "Be a DJ"
     },
     "para": {
-      "no_dj_crew": "No one is DJing now.\nWhy not become the DJ and make some noise!",
+      "no_dj_crew": "No one is DJing right now.\nPlay the first song!",
       "create_playlist_song": "Before you join the queue, please create a playlist with at least one song.",
       "cancel_dj_queue": "Cancel DJ queue registration",
       "cancel_dj_queue_confirm": "Do you want to remove yourself from the DJ queue?",
@@ -261,7 +264,10 @@
       "queue_lock_detail": "Locking prevents new DJ registrations and keeps the current queue as-is.",
       "playback_stopped_time_limit": "Playback stopped: a track exceeds this room's time limit ({{minutes}} min).",
       "playback_stopped_no_limit": "Playback stopped: no playable track.",
-      "not_playable_in_room": "Not playable here (exceeds this room's time limit)"
+      "not_playable_in_room": "Not playable here (exceeds this room's time limit)",
+      "search_song_to_dj": "Search for a song to DJ",
+      "select_song_to_dj": "Choose a song to DJ",
+      "start_djing_with_this_song": "Let's start DJing with this song"
     }
   },
   "db": {

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -308,8 +308,8 @@
       "up_to_10_if_connect_wallet": "지갑을 연동하시면 10개까지 생성할 수 있어요!",
       "no_other_playlist": "이동할 수 있는 다른 플레이리스트가 없어요",
       "select_for_move": "선택한 곡을 이동할 재생목록을 선택해 주세요",
-      "now_playing": "재생 중",
-      "next_up": "다음 곡"
+      "now_playing": "NOW",
+      "next_up": "NEXT"
     },
     "ec": {
       "exceeded_list_connect_wallet": "이미 생성 가능한 리스트 수를 초과했어요.\n",

--- a/src/shared/lib/localization/dictionaries/ko.json
+++ b/src/shared/lib/localization/dictionaries/ko.json
@@ -231,7 +231,7 @@
   },
   "dj": {
     "title": {
-      "current_dj": "현재 디제잉",
+      "current_dj": "Now DJing",
       "dj_queue": "DJ 대기열",
       "time_limit": "디제잉 1회당 제한시간 : **{{minutes}}**분",
       "rule_guide": "디제잉 규칙 안내"
@@ -240,10 +240,13 @@
       "register_queue": "DJ 대기 등록",
       "add_dj": "DJ 추가",
       "selection_completed": "선택완료",
-      "select_dj_playlist": "디제잉 플레이리스트 선택"
+      "select_dj_playlist": "디제잉 플레이리스트 선택",
+      "search_and_register_dj": "곡 검색하고 DJ 등록",
+      "pick_from_my_playlist": "내 플레이리스트에서 고르기",
+      "register_with_this_song": "이 곡으로 DJ 등록"
     },
     "para": {
-      "no_dj_crew": "현재 디제잉 인원이 없어요\n파티의 흥을 책임질 DJ가 되어보세요!",
+      "no_dj_crew": "현재 디제잉하는 사람이 없어요.\n첫 곡을 틀어보세요!",
       "create_playlist_song": "대기 등록을 위해 최소 1곡이 담긴 플레이리스트가 필요해요",
       "cancel_dj_queue": "DJ 대기 등록 취소",
       "cancel_dj_queue_confirm": "DJ 대기 등록을 취소하시겠습니까?",
@@ -261,7 +264,10 @@
       "queue_lock_detail": "잠그면 새 DJ 등록이 막히고, 현재 대기열만 유지돼요.",
       "playback_stopped_time_limit": "재생 시간 제한({{minutes}}분)을 초과하는 곡으로 재생이 중단되었습니다",
       "playback_stopped_no_limit": "재생 가능한 곡이 없어 재생이 중단되었습니다",
-      "not_playable_in_room": "이 방에선 재생 안 돼요 (재생 시간 제한 초과)"
+      "not_playable_in_room": "이 방에선 재생 안 돼요 (재생 시간 제한 초과)",
+      "search_song_to_dj": "디제잉할 곡을 검색하세요.",
+      "select_song_to_dj": "디제잉할 곡을 선택해 주세요",
+      "start_djing_with_this_song": "이 곡으로 디제잉을 시작해요"
     }
   },
   "db": {

--- a/src/shared/ui/components/track-cursor/cursor-badge.component.test.tsx
+++ b/src/shared/ui/components/track-cursor/cursor-badge.component.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import CursorBadge from './cursor-badge.component';
+
+describe('CursorBadge', () => {
+  test('variant=now 면 now testid 로 렌더하고 라벨을 표시한다', () => {
+    render(<CursorBadge variant='now' label='NOW' />);
+    const badge = screen.getByTestId('track-badge-now');
+    expect(badge).toHaveTextContent('NOW');
+    expect(screen.queryByTestId('track-badge-next')).not.toBeInTheDocument();
+  });
+
+  test('variant=next 면 next testid 로 렌더한다', () => {
+    render(<CursorBadge variant='next' label='NEXT' />);
+    expect(screen.getByTestId('track-badge-next')).toHaveTextContent('NEXT');
+    expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
+  });
+
+  test('now 와 next 의 배경색이 다르다', () => {
+    const { unmount } = render(<CursorBadge variant='now' label='NOW' />);
+    expect(screen.getByTestId('track-badge-now').className).toContain('bg-red-300');
+    unmount();
+
+    render(<CursorBadge variant='next' label='NEXT' />);
+    expect(screen.getByTestId('track-badge-next').className).toContain('bg-gray-600');
+  });
+
+  test('className 을 덧붙일 수 있다', () => {
+    render(<CursorBadge variant='now' label='NOW' className='ml-2' />);
+    expect(screen.getByTestId('track-badge-now').className).toContain('ml-2');
+  });
+});

--- a/src/shared/ui/components/track-cursor/cursor-badge.component.tsx
+++ b/src/shared/ui/components/track-cursor/cursor-badge.component.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/shared/lib/functions/cn';
+
+type Props = {
+  variant: 'now' | 'next';
+  label: string;
+  className?: string;
+};
+
+/** 데스크탑·시네마는 ⋮ 왼쪽, 모바일 시트는 ✕ 왼쪽에 붙는다. 기존 버튼은 그대로 둔다. */
+const CursorBadge = ({ variant, label, className }: Props) => (
+  <span
+    data-testid={variant === 'now' ? 'track-badge-now' : 'track-badge-next'}
+    className={cn(
+      'inline-flex shrink-0 items-center rounded-full px-2 py-[3px] text-[11px] font-bold leading-[14px]',
+      variant === 'now' ? 'bg-red-300 text-white' : 'bg-gray-600 text-gray-100',
+      className
+    )}
+  >
+    {label}
+  </span>
+);
+
+export default CursorBadge;

--- a/src/shared/ui/components/track-cursor/cursor-title.component.tsx
+++ b/src/shared/ui/components/track-cursor/cursor-title.component.tsx
@@ -1,0 +1,36 @@
+import Marquee from 'react-fast-marquee';
+import { cn } from '@/shared/lib/functions/cn';
+import { Typography } from '@/shared/ui/components/typography';
+
+type Props = {
+  name: string;
+  /** 제목 길이와 무관하게 항상 흐른다. */
+  scrolling: boolean;
+  /** 흐르는 제목이 우측 배지 아래로 지나가므로 페이드로 가린다. */
+  faded: boolean;
+};
+
+/** 전광판용 TrackTitle 은 Galmuri 폰트를 강제하고 항상 흐르므로 별개다. */
+const CursorTitle = ({ name, scrolling, faded }: Props) => (
+  <div
+    className={cn(
+      'min-w-0',
+      faded && '[mask-image:linear-gradient(to_right,black_70%,transparent)]'
+    )}
+  >
+    {scrolling ? (
+      <Marquee delay={2} speed={20} gradientWidth={0}>
+        {/* 반복 사이 간격 — 없으면 제목 끝과 시작이 붙어 읽힌다. */}
+        <Typography type='caption1' className='text-gray-50 pr-8'>
+          {name}
+        </Typography>
+      </Marquee>
+    ) : (
+      <Typography type='caption1' overflow='ellipsis' className='text-gray-50'>
+        {name}
+      </Typography>
+    )}
+  </div>
+);
+
+export default CursorTitle;

--- a/src/shared/ui/components/track-cursor/index.ts
+++ b/src/shared/ui/components/track-cursor/index.ts
@@ -1,0 +1,3 @@
+export { default as CursorBadge } from './cursor-badge.component';
+export { default as CursorTitle } from './cursor-title.component';
+export { default as PlayingBars } from './playing-bars.component';

--- a/src/shared/ui/components/track-cursor/playing-bars.component.test.tsx
+++ b/src/shared/ui/components/track-cursor/playing-bars.component.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import PlayingBars from './playing-bars.component';
+
+describe('PlayingBars', () => {
+  test('막대 4개를 렌더한다', () => {
+    render(<PlayingBars />);
+    expect(screen.getByTestId('playing-bars').children).toHaveLength(4);
+  });
+
+  test('스크린리더에서 감춘다 — 상태는 배지 텍스트가 전달한다', () => {
+    render(<PlayingBars />);
+    expect(screen.getByTestId('playing-bars')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('각 막대의 애니메이션 지연이 서로 달라 파형이 어긋난다', () => {
+    render(<PlayingBars />);
+    const delays = Array.from(screen.getByTestId('playing-bars').children).map(
+      (bar) => (bar as HTMLElement).style.animationDelay
+    );
+    expect(new Set(delays).size).toBe(4);
+  });
+
+  test('reduced-motion 에서 애니메이션이 꺼지도록 motion-reduce 유틸을 단다', () => {
+    render(<PlayingBars />);
+    const firstBar = screen.getByTestId('playing-bars').children[0] as HTMLElement;
+    expect(firstBar.className).toContain('motion-reduce:animate-none');
+  });
+});

--- a/src/shared/ui/components/track-cursor/playing-bars.component.tsx
+++ b/src/shared/ui/components/track-cursor/playing-bars.component.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/shared/lib/functions/cn';
+
+const BAR_DELAYS = ['0ms', '150ms', '300ms', '450ms'];
+
+type Props = {
+  className?: string;
+};
+
+/** 재생 중 상태는 CursorBadge 텍스트가 전달하므로 여기선 aria-hidden. */
+const PlayingBars = ({ className }: Props) => (
+  <div
+    data-testid='playing-bars'
+    aria-hidden='true'
+    className={cn('flexRowCenter gap-[3px] bg-black/50', className)}
+  >
+    {BAR_DELAYS.map((delay) => (
+      <span
+        key={delay}
+        style={{ animationDelay: delay }}
+        className='w-[3px] h-3 origin-center rounded-full bg-white animate-equalizer motion-reduce:animate-none'
+      />
+    ))}
+  </div>
+);
+
+export default PlayingBars;

--- a/src/shared/ui/foundation/globals.css
+++ b/src/shared/ui/foundation/globals.css
@@ -93,3 +93,10 @@
     clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
   }
 }
+
+/* .rfm-marquee 는 react-fast-marquee 내부 클래스라 라이브러리 업데이트 시 깨질 수 있다. */
+@media (prefers-reduced-motion: reduce) {
+  .rfm-marquee {
+    animation: none !important;
+  }
+}

--- a/src/shared/ui/foundation/theme.ts
+++ b/src/shared/ui/foundation/theme.ts
@@ -59,12 +59,17 @@ const theme = {
   },
   animation: {
     loading: 'loading 2s infinite',
+    equalizer: 'equalizer 0.9s ease-in-out infinite alternate',
   },
   keyframes: {
     loading: {
       '0%': { transform: 'rotateZ(0deg)' },
       '50%': { transform: 'rotateZ(480deg)' },
       '100%': { transform: 'rotateZ(1080deg)' },
+    },
+    equalizer: {
+      '0%': { transform: 'scaleY(0.3)' },
+      '100%': { transform: 'scaleY(1)' },
     },
   },
   aspectRatio: {

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/shared/lib/localization/i18n.context', () => ({
         sheet_add_tracks_title: '곡 추가',
       },
     },
-    playlist: { para: { now_playing: '재생 중', next_up: '다음 곡' } },
+    playlist: { para: { now_playing: 'NOW', next_up: 'NEXT' } },
   }),
 }));
 
@@ -38,6 +38,11 @@ vi.mock('@/widgets-mobile/partyroom-djing-sheet', () => ({
 }));
 // AddTracksSheet 는 push node 로만 쓰이므로 stub
 vi.mock('./add-tracks-sheet.component', () => ({ default: () => null }));
+vi.mock('react-fast-marquee', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='marquee'>{children}</div>
+  ),
+}));
 
 const PL = { id: 7, name: 'A', musicCount: 2, type: PlaylistType.PLAYLIST, orderNumber: 1 };
 const TRACK = {
@@ -48,6 +53,7 @@ const TRACK = {
   duration: '3:00',
   thumbnailImage: 'https://t',
 };
+const TRACK2 = { ...TRACK, trackId: 12, linkId: 'v2', name: '곡2', orderNumber: 2 };
 
 describe('PlaylistDetailSheet', () => {
   beforeEach(() => {
@@ -97,16 +103,66 @@ describe('PlaylistDetailSheet', () => {
       data: { content: [TRACK], lastPlayedTrackId: 11 },
     });
     render(<PlaylistDetailSheet playlist={PL as never} />);
-    expect(screen.getByTestId('track-badge-now')).toHaveTextContent('재생 중');
+    expect(screen.getByTestId('track-badge-now')).toHaveTextContent('NOW');
   });
 
-  test('커서=11 + 내가 CurrentDJ 아님 → NOW 없음, NEXT(wrap=11)만', () => {
+  test('커서=11 + 내가 CurrentDJ 아님 → NOW/NEXT 모두 없음', () => {
     storeState = { me: { crewId: 5 }, currentDj: { crewId: 9 } };
     useFetchPlaylistTracksMock.mockReturnValue({
       data: { content: [TRACK], lastPlayedTrackId: 11 },
     });
     render(<PlaylistDetailSheet playlist={PL as never} />);
     expect(screen.queryByTestId('track-badge-now')).not.toBeInTheDocument();
-    expect(screen.getByTestId('track-badge-next')).toHaveTextContent('다음 곡');
+    expect(screen.queryByTestId('track-badge-next')).not.toBeInTheDocument();
+  });
+
+  test('커서=11 + 내가 CurrentDJ + 2곡 → NEXT 는 다음 곡(12)', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 5 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK, TRACK2], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+    expect(screen.getByTestId('track-badge-now')).toHaveTextContent('NOW');
+    expect(screen.getByTestId('track-badge-next')).toHaveTextContent('NEXT');
+  });
+});
+
+describe('모바일 시트 커서 배치 (#462)', () => {
+  beforeEach(() => {
+    storeState = {};
+  });
+
+  test('NOW 곡도 삭제 버튼을 유지한다 — 배지가 ✕ 를 밀어내지 않는다', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 5 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+
+    expect(screen.getByTestId('track-badge-now')).toBeInTheDocument();
+    expect(screen.getByTestId('detail-track-remove-11')).toBeInTheDocument();
+  });
+
+  test('NOW 곡에 마퀴와 이퀄라이저가 붙는다', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 5 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+
+    expect(screen.getByTestId('marquee')).toBeInTheDocument();
+    expect(screen.getByTestId('playing-bars')).toBeInTheDocument();
+  });
+
+  test('NEXT 곡에는 모션이 없다 — NOW 곡에만 마퀴·이퀄라이저', () => {
+    storeState = { me: { crewId: 5 }, currentDj: { crewId: 5 } };
+    useFetchPlaylistTracksMock.mockReturnValue({
+      data: { content: [TRACK, TRACK2], lastPlayedTrackId: 11 },
+    });
+    render(<PlaylistDetailSheet playlist={PL as never} />);
+
+    expect(screen.getByTestId('track-badge-next')).toBeInTheDocument();
+    expect(screen.getAllByTestId('playing-bars')).toHaveLength(1);
+    expect(screen.getAllByTestId('marquee')).toHaveLength(1);
   });
 });

--- a/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
+++ b/src/widgets-mobile/partyroom-djing-sheet/ui/playlist-detail-sheet.component.tsx
@@ -3,11 +3,11 @@ import { FC } from 'react';
 import { useFetchPlaylistTracks } from '@/features/playlist/list-tracks/api/use-fetch-playlist-tracks.query';
 import { useRemovePlaylistTrack } from '@/features/playlist/remove-track/api/use-remove-playlist-track.mutation';
 import { Playlist } from '@/shared/api/http/types/playlists';
-import { cn } from '@/shared/lib/functions/cn';
 import { resolveNextTrackId } from '@/shared/lib/functions/resolve-next-track';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { useStores } from '@/shared/lib/store/stores.context';
 import { Button } from '@/shared/ui/components/button';
+import { CursorBadge, CursorTitle, PlayingBars } from '@/shared/ui/components/track-cursor';
 import { Typography } from '@/shared/ui/components/typography';
 import { PFClose } from '@/shared/ui/icons';
 import { useFullscreenSheet } from '@/widgets-mobile/partyroom-djing-sheet';
@@ -28,10 +28,12 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
   // 재생 커서 기반 NOW/NEXT (데스크톱 TracksInPlaylist와 동일 규칙).
   const cursor = data?.lastPlayedTrackId ?? null;
   const isMeCurrentDj = me?.crewId != null && me.crewId === currentDj?.crewId;
-  const nextTrackId = resolveNextTrackId(
-    tracks.map((track) => track.trackId),
-    cursor
-  );
+  const nextTrackId = isMeCurrentDj
+    ? resolveNextTrackId(
+        tracks.map((track) => track.trackId),
+        cursor
+      )
+    : null;
   const nowTrackId = isMeCurrentDj ? cursor : null;
 
   const openAddTracks = () =>
@@ -57,27 +59,23 @@ const PlaylistDetailSheet: FC<Props> = ({ playlist }) => {
               const isNext = !isNow && nextTrackId !== null && track.trackId === nextTrackId;
               return (
                 <li key={track.trackId} className='flex items-center gap-3 px-5 py-3'>
-                  <img
-                    src={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
-                    alt={track.name}
-                    className='w-[64px] h-[36px] shrink-0 rounded object-cover bg-gray-700'
-                  />
-                  <div className='flex-1 min-w-0 flex flex-col'>
-                    {(isNow || isNext) && (
-                      <span
-                        data-testid={isNow ? 'track-badge-now' : 'track-badge-next'}
-                        className={cn(
-                          'mb-0.5 inline-flex w-fit items-center rounded-[3px] px-1.5 py-[1px] text-[10px] font-bold leading-[14px]',
-                          isNow ? 'bg-red-300 text-white' : 'bg-gray-600 text-gray-100'
-                        )}
-                      >
-                        {isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
-                      </span>
-                    )}
-                    <Typography type='caption1' className='min-w-0 truncate text-gray-50'>
-                      {track.name}
-                    </Typography>
+                  <div className='relative shrink-0'>
+                    <img
+                      src={track.thumbnailImage ?? '/images/ETC/PlaylistThumbnail.png'}
+                      alt={track.name}
+                      className='w-[64px] h-[36px] rounded object-cover bg-gray-700'
+                    />
+                    {isNow && <PlayingBars className='absolute inset-0 rounded' />}
                   </div>
+                  <div className='flex-1 min-w-0 flex flex-col'>
+                    <CursorTitle name={track.name} scrolling={isNow} faded={isNow || isNext} />
+                  </div>
+                  {(isNow || isNext) && (
+                    <CursorBadge
+                      variant={isNow ? 'now' : 'next'}
+                      label={isNow ? t.playlist.para.now_playing : t.playlist.para.next_up}
+                    />
+                  )}
                   <button
                     type='button'
                     data-testid={`detail-track-remove-${track.trackId}`}

--- a/src/widgets/partyroom-djing-dialog/ui/dialog.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/dialog.component.tsx
@@ -16,15 +16,21 @@ export default function DjingDialog({ partyroomId, open, close }: Props) {
 
   if (!djingQueue) return;
 
+  const hasDj = !!djingQueue.djs.length;
+
   return (
     <Dialog
       open={open}
       onClose={close}
-      classNames={{ container: 'w-[800px] py-[36px] px-[40px] bg-black' }}
+      classNames={{
+        container: hasDj
+          ? 'w-[800px] py-[36px] px-[40px] bg-black'
+          : 'w-[520px] py-[36px] px-[40px]',
+      }}
       Body={
         <PartyroomIdContext.Provider value={partyroomId}>
           <DjingQueueContext.Provider value={djingQueue}>
-            {djingQueue.djs.length ? <Body onCancel={close} /> : <EmptyBody onCancel={close} />}
+            {hasDj ? <Body onCancel={close} /> : <EmptyBody onCancel={close} />}
           </DjingQueueContext.Provider>
         </PartyroomIdContext.Provider>
       }

--- a/src/widgets/partyroom-djing-dialog/ui/empty-body.component.test.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/empty-body.component.test.tsx
@@ -4,10 +4,20 @@ vi.mock('@/shared/lib/localization/renderer/index.ui', () => ({
 }));
 vi.mock('@/shared/ui/icons', () => ({
   PFClose: (props: any) => <svg data-testid='close-icon' {...props} />,
+  PFSearch: (props: any) => <svg data-testid='search-icon' {...props} />,
+  PFAddPlaylist: (props: any) => <svg data-testid='add-playlist-icon' {...props} />,
 }));
 vi.mock('./register-button.component', () => ({
   __esModule: true,
   default: () => <button data-testid='register-btn'>Register</button>,
+}));
+vi.mock('../lib/partyroom-id.context', () => ({
+  usePartyroomId: () => 1,
+}));
+
+const registerDjWithTrack = vi.fn();
+vi.mock('@/features/partyroom/register-dj-with-track', () => ({
+  useRegisterDjWithTrack: () => registerDjWithTrack,
 }));
 
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -16,7 +26,13 @@ import EmptyBody from './empty-body.component';
 
 beforeEach(() => {
   (useI18n as Mock).mockReturnValue({
-    dj: { title: { current_dj: 'Current DJ' } },
+    dj: {
+      title: { current_dj: 'Current DJ' },
+      btn: {
+        search_and_register_dj: 'Search a song and be a DJ',
+        pick_from_my_playlist: 'Choose from my playlist',
+      },
+    },
   });
 });
 
@@ -34,6 +50,16 @@ describe('EmptyBody', () => {
   test('RegisterButton을 렌더링한다', () => {
     render(<EmptyBody onCancel={vi.fn()} />);
     expect(screen.getByTestId('register-btn')).toBeTruthy();
+  });
+
+  test('곡 검색하고 DJ 등록 클릭 시 검색 등록 플로우를 연다', () => {
+    const onCancel = vi.fn();
+    render(<EmptyBody onCancel={onCancel} />);
+    fireEvent.click(screen.getByTestId('search-and-register-dj'));
+    expect(registerDjWithTrack).toHaveBeenCalledWith({
+      partyroomId: 1,
+      closeDjingDialog: onCancel,
+    });
   });
 
   test('닫기 아이콘 클릭 시 onCancel을 호출한다', () => {

--- a/src/widgets/partyroom-djing-dialog/ui/empty-body.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/empty-body.component.tsx
@@ -1,17 +1,22 @@
+import { useRegisterDjWithTrack } from '@/features/partyroom/register-dj-with-track';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
 import { LineBreakProcessor } from '@/shared/lib/localization/renderer';
 import { Trans } from '@/shared/lib/localization/renderer/index.ui';
+import { Button } from '@/shared/ui/components/button';
 import { TextButton } from '@/shared/ui/components/text-button';
 import { Typography } from '@/shared/ui/components/typography';
-import { PFClose } from '@/shared/ui/icons';
+import { PFAddPlaylist, PFClose, PFSearch } from '@/shared/ui/icons';
 import RegisterButton from './register-button.component';
+import { usePartyroomId } from '../lib/partyroom-id.context';
 
 export default function EmptyBody({ onCancel }: { onCancel: () => void | undefined }) {
   const t = useI18n();
+  const partyroomId = usePartyroomId();
+  const registerDjWithTrack = useRegisterDjWithTrack();
 
   return (
     <>
-      <header className='flex justify-between items-center h-[48px] pt-[12px]'>
+      <header className='flex justify-between items-center'>
         <Typography type='title2' className='text-start'>
           {t.dj.title.current_dj}
         </Typography>
@@ -23,14 +28,28 @@ export default function EmptyBody({ onCancel }: { onCancel: () => void | undefin
         />
       </header>
 
-      <div className='h-[388px] flexRowCenter'>
-        <div className='flexColCenter gap-[24px]'>
-          <Typography type='body2' className='text-center'>
-            <Trans i18nKey='dj.para.no_dj_crew' processors={[new LineBreakProcessor()]} />
-          </Typography>
+      <Typography type='body2' className='my-[40px] text-center text-gray-300'>
+        <Trans i18nKey='dj.para.no_dj_crew' processors={[new LineBreakProcessor()]} />
+      </Typography>
 
-          <RegisterButton />
-        </div>
+      <div className='flexCol gap-[12px]'>
+        <Button
+          size='xl'
+          className='w-full'
+          Icon={<PFSearch />}
+          onClick={() => registerDjWithTrack({ partyroomId, closeDjingDialog: onCancel })}
+          data-testid='search-and-register-dj'
+        >
+          {t.dj.btn.search_and_register_dj}
+        </Button>
+
+        <RegisterButton
+          size='xl'
+          color='secondary'
+          className='w-full'
+          Icon={<PFAddPlaylist />}
+          label={t.dj.btn.pick_from_my_playlist}
+        />
       </div>
     </>
   );

--- a/src/widgets/partyroom-djing-dialog/ui/register-button.component.tsx
+++ b/src/widgets/partyroom-djing-dialog/ui/register-button.component.tsx
@@ -4,13 +4,15 @@ import useDjingGuide from '@/features/playlist/djing-guide/ui/use-djing-guide.ho
 import { useFetchPlaylists } from '@/features/playlist/list';
 import { QueueStatus } from '@/shared/api/http/types/@enums';
 import { useI18n } from '@/shared/lib/localization/i18n.context';
-import { Button } from '@/shared/ui/components/button';
+import { Button, ButtonProps } from '@/shared/ui/components/button';
 import { useDialog } from '@/shared/ui/components/dialog';
 import { TooltipTrigger } from '@/shared/ui/components/tooltip';
 import { useDjingQueue } from '../lib/djing-queue.context';
 import { usePartyroomId } from '../lib/partyroom-id.context';
 
-export default function RegisterButton() {
+type Props = Omit<ButtonProps, 'onClick' | 'children'> & { label?: string };
+
+export default function RegisterButton({ label, ...buttonProps }: Props) {
   const t = useI18n();
   const { data: playlists = [] } = useFetchPlaylists();
   const { openAlertDialog } = useDialog();
@@ -40,8 +42,13 @@ export default function RegisterButton() {
 
   return (
     <TooltipTrigger title={isLocked ? t.dj.para.queue_lock_detail : undefined}>
-      <Button size='lg' onClick={registerMeToDjQueue} data-testid='register-dj-queue'>
-        {t.dj.btn.register_queue}
+      <Button
+        size='lg'
+        onClick={registerMeToDjQueue}
+        data-testid='register-dj-queue'
+        {...buttonProps}
+      >
+        {label ?? t.dj.btn.register_queue}
       </Button>
     </TooltipTrigger>
   );


### PR DESCRIPTION
## development→main(prod) 승격 — 2커밋

- **#467 (#464)**: 디제잉 중인 사람이 없을 때 뜨는 모달을 신규 시안대로 개편. `곡 검색하고 DJ 등록` 경로를 추가해 플레이리스트가 없어도 안내창에 막히지 않고 첫 DJ가 될 수 있다.
- **#468 (#462)**: 현재곡·다음곡 커서를 시안대로 변경하고, 재생 중인 곡에 이퀄라이저·제목 흐름 모션을 넣었다. 디제잉과 무관한 플레이리스트 첫 곡에도 NEXT 배지가 붙던 문제를 함께 고쳤다.

## 승격 시 확인할 것

- `DJ Registered` 이벤트의 `playlist_id`가 optional로 바뀌었다 — 대시보드가 이 필드를 필수로 가정하면 영향.
- 곡 검색 quick 등록은 실서버 연동 확인 전이다. prod 반영 후 빈 방 첫 DJ 등록 실기 확인 필요.

## 검증

- 로컬 게이트: `yarn test` 1733 passed(312 files) · `yarn test:type` · `yarn lint` 통과
- e2e: 로컬 env 미비로 미실행 — CI e2e 결과로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UH5Nto7Tzxwu4cfqbisZxQ
