### PR TITLE
ci: 문서만 변경된 머지가 배포·e2e 를 유발하지 않도록 paths-ignore 도입 (#483)

### DIFF
--- a/.github/workflows/vercel-preview-e2e.yml
+++ b/.github/workflows/vercel-preview-e2e.yml
@@ -3,6 +3,10 @@ name: preview deploy and e2e
 on:
   push:
     branches: [development]
+    # 문서만 바뀐 머지는 배포·e2e 를 돌리지 않는다 (#483).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 # 동시 run들이 공유 stg.pfplay.xyz 별칭을 레이스하지 않도록 파이프라인 직렬화 (이슈 #348).

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -3,6 +3,10 @@ name: vercel production
 on:
   push:
     branches: [main]
+    # 문서만 바뀐 push 는 배포하지 않는다 (#483).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
closes #483

## 문제

배포 워크플로에 `paths`/`paths-ignore` 필터가 **전혀 없었다.** 마크다운만 바뀐 머지에도 `development` push → **preview 배포 + Playwright 풀 스위트**가 돈다. 문서와 무관한 플레이크(#443 등)로 빨간불이 뜨면 "문서 PR 이 CI 를 깼다"처럼 보이고, 실행 시간도 길다.

## 변경

| 파일 | 트리거 | 추가 |
|---|---|---|
| `vercel-preview-e2e.yml` | `push → development` | `paths-ignore: ['**.md', 'docs/**']` |
| `vercel-production.yml` | `push → main` | 동일 |

`e2e/README.md` 처럼 `docs/` 밖에 있는 문서도 `**.md` 로 덮인다.

## 의도적으로 하지 않은 것

**`lint-check.yml` / `vercel-build-check.yml` 에는 걸지 않았다.** PR 검증은 싸고 스킵해서 얻는 게 없다. 더 중요한 이유: 현재 브랜치 보호가 없지만(확인함) 나중에 required status check 로 등록되면 **`paths` 로 스킵된 체크가 "대기 중"으로 남아 PR 이 영구 머지 불가**가 되는 알려진 함정이 있다.

## 검증

- 네 워크플로 YAML 파싱 확인 — 두 배포 워크플로만 `paths-ignore` 획득, `lint-check`/`vercel-build-check` 무변경
- 실동작은 머지 후 확인: 이 PR 자체는 워크플로 변경이라 **정상적으로 preview+e2e 가 돈다**. 이어서 머지할 문서 PR #482 가 **skipped** 로 표시되면 의도대로 동작하는 것

## 참고

소스 코드 변경 없음. 커밋은 별도 worktree 작업(`node_modules`/husky 부재)으로 `--no-verify` 사용.