### PR TITLE
fix(e2e): DJ 등록 CTA 를 testid 로 고정 + 커서 배지 기대값 정정 (#485)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -92,19 +92,38 @@ npx playwright test --debug
 npx playwright show-report
 ```
 
-### 2. 로컬 실행의 한계 (알고 시작할 것)
+### 2. 로컬 실행 세팅 — 여기서 두 번 넘어졌다 (2026-08-01 실측)
 
-로컬 dev 서버로는 **전 스위트 GREEN 을 목표로 삼지 말 것.** 다음은 코드가 아니라 환경 때문에
-깨진다(2026-08-01 실측).
+로컬 풀 스위트는 **정상적으로 GREEN 이 난다**(19~21/21). 다만 아래 두 설정이 틀리면 코드와
+무관하게 무너지고, **둘 다 조용히 실패해서 원인이 엉뚱한 곳으로 보인다.**
 
-| 증상 | 원인 | 대응 |
-|---|---|---|
-| auth setup 전건 실패 + 화면에 `Network Error` | 백엔드 CORS 허용 오리진에 이 포트가 없음(기본 `localhost:3000` 만) | 3000 으로 띄우거나 백엔드 `CORS_ALLOWED_ORIGINS` 에 포트 추가 |
-| `createPartyroom` 의 `waitForURL` 타임아웃 | ① 같은 계정이 이미 방을 보유(활성 방 1개 불변식) ② dev 모드 룸 라우트 컴파일 지연 | 아래 방 정리 → 재실행. 모바일 project 는 dev 모드에서 여전히 실패할 수 있다(CI 프로덕션 빌드에선 통과) |
+#### (1) `E2E_API_BASE` 는 `/api/` 까지 포함해야 한다 ← 가장 악질
 
-**실행 전 잔존 방 정리** — 앞선 실패가 방을 남기면 다음 스펙이 방을 못 만든다. 증상이
-"방 생성 실패" 로 보여 원인 추적이 어렵다. 제목 접두어로 거르면 **놓친다**(데스크탑 `E2E*`,
-모바일 `MAT*` 등 제각각).
+```bash
+E2E_API_BASE=http://localhost:8080/api/   # ✅
+E2E_API_BASE=http://localhost:8080        # ❌ 조용히 망가진다
+```
+
+`cleanupMobileTestPartyrooms` 는 `new URL('v1/partyrooms', API_BASE)` 로 호출한다. 접두어가
+빠지면 404 → `if (!response.ok()) return;` 로 **아무 로그 없이 no-op** 이 된다. 그러면:
+
+1. 앞 스펙이 남긴 방이 정리되지 않고
+2. **계정당 활성 방 1개 불변식**에 걸려 다음 스펙의 방 생성이 거부되고
+3. 증상은 엉뚱하게 `createPartyroom` 의 `waitForURL` 타임아웃으로 나타난다
+
+실제로 이걸 "dev 모드 컴파일 지연" 으로 오진했다. 값을 바로잡자 모바일 11/11 이 통과했다.
+**모바일 spec 은 응답 로깅 계측이 없어 `POST /partyrooms` 성공 여부가 로그에 안 보인다** —
+DB(`partyroom` 테이블)나 trace 를 봐야 한다.
+
+#### (2) 백엔드 CORS 허용 오리진에 웹 포트가 있어야 한다
+
+없으면 **auth setup 전건이 화면의 `Network Error` 와 함께 죽는다.** 백엔드 기본값은
+`localhost:3000`(http/https)·`8080` 뿐이다. 3000 이 이미 점유돼 다른 포트로 띄운다면
+백엔드 `.env.local` 의 `CORS_ALLOWED_ORIGINS` 에 그 포트를 추가하고 app 컨테이너를 재기동한다.
+
+#### 그래도 꼬였다면 — 잔존 방 정리
+
+제목 접두어로 거르면 **놓친다**(데스크탑 `E2E*`, 모바일 `MAT*`/`MDJ*`/`MPM*` 등 제각각).
 
 ```sql
 -- 로컬 전용. Main Stage(id=1) 만 남기고 전부 종료

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -92,7 +92,27 @@ npx playwright test --debug
 npx playwright show-report
 ```
 
-### 2. cold 실행 flake
+### 2. 로컬 실행의 한계 (알고 시작할 것)
+
+로컬 dev 서버로는 **전 스위트 GREEN 을 목표로 삼지 말 것.** 다음은 코드가 아니라 환경 때문에
+깨진다(2026-08-01 실측).
+
+| 증상 | 원인 | 대응 |
+|---|---|---|
+| auth setup 전건 실패 + 화면에 `Network Error` | 백엔드 CORS 허용 오리진에 이 포트가 없음(기본 `localhost:3000` 만) | 3000 으로 띄우거나 백엔드 `CORS_ALLOWED_ORIGINS` 에 포트 추가 |
+| `createPartyroom` 의 `waitForURL` 타임아웃 | ① 같은 계정이 이미 방을 보유(활성 방 1개 불변식) ② dev 모드 룸 라우트 컴파일 지연 | 아래 방 정리 → 재실행. 모바일 project 는 dev 모드에서 여전히 실패할 수 있다(CI 프로덕션 빌드에선 통과) |
+
+**실행 전 잔존 방 정리** — 앞선 실패가 방을 남기면 다음 스펙이 방을 못 만든다. 증상이
+"방 생성 실패" 로 보여 원인 추적이 어렵다. 제목 접두어로 거르면 **놓친다**(데스크탑 `E2E*`,
+모바일 `MAT*` 등 제각각).
+
+```sql
+-- 로컬 전용. Main Stage(id=1) 만 남기고 전부 종료
+UPDATE crew SET is_active=0 WHERE partyroom_id<>1;
+UPDATE partyroom SET status='TERMINATED' WHERE partyroom_id<>1 AND status<>'TERMINATED';
+```
+
+### 3. cold 실행 flake
 
 로컬에서 처음 한 번은 Next 컴파일·백엔드 워밍 때문에 타임아웃이 날 수 있다.
 **동일 조건으로 한 번 더(warm) 돌려보고 판단한다.** 두 번째도 같은 지점에서 실패하면 그때부터
@@ -147,7 +167,24 @@ React Query devtools 오버레이가 클릭을 계속 흡수하면 드로어는 
 (크루 계급 그룹이 기본 접힘 → 기본 펼침으로 바뀌면서 kick/ban 스펙이 깨진 사례).
 **상태를 읽고 조건부로 클릭**하도록 쓴다.
 
-### 4. 백엔드 500 이 프론트 에러로 위장한다
+### 4. 라벨은 상태에 따라 바뀐다 — CTA 는 testid 로 잡는다 (#485)
+
+`getByRole('button', { name: ... })` 는 라벨이 고정일 때만 안전하다. DJ 등록 버튼은 큐 상태에
+따라 **같은 컴포넌트가 다른 라벨**로 렌더된다.
+
+| 상태 | 컴포넌트 | 라벨 |
+|---|---|---|
+| 큐에 DJ 있음 | `Body` | Register for DJ Queue |
+| 큐 비어 있음 | `EmptyBody` | **Choose from my playlist** (+ 별도 CTA `Search a song and be a DJ`) |
+
+`registerAsDj` 는 **갓 만든 방**(항상 빈 큐)에서 호출되므로 이름 매칭은 100% 실패했다.
+`data-testid` 는 양쪽에서 동일하므로 그것을 앵커로 쓴다.
+
+> 이 실패는 6개 스펙을 한꺼번에 무너뜨렸고, 표면 증상은 "방에 못 들어감"처럼 보였다(스냅샷이
+> cleanup 이후 로비였다). **증상이 아니라 trace 의 네트워크 타임라인을 먼저 볼 것** — 당시 API 는
+> 전부 2xx 였다.
+
+### 5. 백엔드 500 이 프론트 에러로 위장한다
 
 백엔드가 500 을 주면 화면에는 Suspense/에러 바운더리 메시지만 뜬다. e2e 실패 메시지도 프론트
 문제처럼 보인다. **네트워크 응답을 먼저 확인**한다(스펙 안에서 `page.on('response')` 계측).

--- a/e2e/e2e-b.playback-summary.spec.ts
+++ b/e2e/e2e-b.playback-summary.spec.ts
@@ -195,7 +195,8 @@ async function closeDjDrawerSafely(page: Page) {
 async function registerAsDjEscapeClose(page: Page, playlistName: string) {
   await openDjQueueDrawer(page);
 
-  const registerButton = page.getByRole('button', { name: /register.*dj queue|dj 대기 등록/i });
+  // #485: 라벨이 큐 상태에 따라 바뀌므로 testid 로 고정 (helpers.registerAsDj 와 동일 규칙)
+  const registerButton = page.getByTestId('register-dj-queue');
   await expect(registerButton).toBeVisible({ timeout: 10_000 });
   await expect(registerButton).toBeEnabled({ timeout: 10_000 });
   await registerButton.click({ force: true });

--- a/e2e/helpers/partyroom.helpers.ts
+++ b/e2e/helpers/partyroom.helpers.ts
@@ -192,7 +192,11 @@ export async function createPartyroom(
 export async function registerAsDj(page: Page, playlistName?: string) {
   await openDjQueueDrawer(page);
 
-  const registerButton = page.getByRole('button', { name: /register.*dj queue|dj 대기 등록/i });
+  // 접근성 이름으로 찾지 않는다. #467 이후 이 버튼의 라벨이 큐 상태에 따라 달라진다:
+  //   - 큐에 DJ 있음(Body)      → "Register for DJ Queue"
+  //   - 큐 비어 있음(EmptyBody) → "Choose from my playlist" (+ 별도 CTA "Search a song and be a DJ")
+  // 갓 만든 방은 항상 후자라 이름 매칭은 100% 실패한다. testid 는 양쪽에서 동일하다.
+  const registerButton = page.getByTestId('register-dj-queue');
   await expect(registerButton).toBeVisible({ timeout: 10_000 });
   await expect(registerButton).toBeEnabled({ timeout: 10_000 });
   await registerButton.click({ force: true });

--- a/e2e/mobile/chunk4.helpers.ts
+++ b/e2e/mobile/chunk4.helpers.ts
@@ -55,8 +55,18 @@ export async function newDesktopUserContext(
  */
 export async function cleanupMobileTestPartyrooms(ctx: BrowserContext): Promise<void> {
   try {
-    const response = await ctx.request.get(new URL('v1/partyrooms', API_BASE).toString());
-    if (!response.ok()) return;
+    const url = new URL('v1/partyrooms', API_BASE).toString();
+    const response = await ctx.request.get(url);
+    if (!response.ok()) {
+      // 무증상 no-op 금지(#485): 여기서 조용히 빠지면 잔존 방이 남고, 다음 spec 이
+      // "계정당 활성 방 1개" 불변식에 걸려 createPartyroom 의 waitForURL 타임아웃으로 죽는다.
+      // 증상이 원인과 멀어 추적이 어렵다. 대표 원인 = E2E_API_BASE 에 `/api/` 누락.
+      console.warn(
+        `[cleanup] 잔존 파티룸 정리 실패 — GET ${url} → ${response.status()}. ` +
+          `E2E_API_BASE 가 '/api/' 까지 포함하는지 확인할 것.`
+      );
+      return;
+    }
     const list = (await response.json()) as Array<{ partyroomId: number; title: string }>;
     const stale = list.filter((p) => E2E_PARTYROOM_TITLE_PATTERN.test(p.title));
     for (const p of stale) {

--- a/e2e/mobile/chunk4.helpers.ts
+++ b/e2e/mobile/chunk4.helpers.ts
@@ -55,18 +55,8 @@ export async function newDesktopUserContext(
  */
 export async function cleanupMobileTestPartyrooms(ctx: BrowserContext): Promise<void> {
   try {
-    const url = new URL('v1/partyrooms', API_BASE).toString();
-    const response = await ctx.request.get(url);
-    if (!response.ok()) {
-      // 무증상 no-op 금지(#485): 여기서 조용히 빠지면 잔존 방이 남고, 다음 spec 이
-      // "계정당 활성 방 1개" 불변식에 걸려 createPartyroom 의 waitForURL 타임아웃으로 죽는다.
-      // 증상이 원인과 멀어 추적이 어렵다. 대표 원인 = E2E_API_BASE 에 `/api/` 누락.
-      console.warn(
-        `[cleanup] 잔존 파티룸 정리 실패 — GET ${url} → ${response.status()}. ` +
-          `E2E_API_BASE 가 '/api/' 까지 포함하는지 확인할 것.`
-      );
-      return;
-    }
+    const response = await ctx.request.get(new URL('v1/partyrooms', API_BASE).toString());
+    if (!response.ok()) return;
     const list = (await response.json()) as Array<{ partyroomId: number; title: string }>;
     const stale = list.filter((p) => E2E_PARTYROOM_TITLE_PATTERN.test(p.title));
     for (const p of stale) {
@@ -87,7 +77,23 @@ export async function cleanupMobileTestPartyrooms(ctx: BrowserContext): Promise<
  * - console.error / console.warn
  * - Next.js dev overlay DOM 주기 스캔
  */
+/** 로깅 대상 API — 방/플리 라이프사이클. 나머지는 실패(4xx/5xx)일 때만 남긴다. */
+const TRACED_ENDPOINT = /\/v1\/(partyrooms|playlists)(\/|\?|$)/;
+
 export function attachErrorTracing(page: Page, log: (m: string) => void) {
+  // #485: 모바일 spec 에는 응답 로깅이 없어 "POST /partyrooms 이 성공했는지" 를 로그로 알 수
+  // 없었다. 그 탓에 방이 실제로 생성됐는데도 "요청 자체가 안 나갔다" 고 오진했다(원인은 잔존
+  // 방 + 정리 헬퍼 no-op). 데스크탑 spec 이 각자 인라인으로 달던 계측을 공용 헬퍼로 올린다.
+  page.on('response', (res) => {
+    const url = res.url();
+    const status = res.status();
+    if (status >= 400 || TRACED_ENDPOINT.test(url)) {
+      log(`response ${status} ${res.request().method()} ${url}`);
+    }
+  });
+  page.on('requestfailed', (req) => {
+    log(`REQ_FAILED ${req.method()} ${req.url()} :: ${req.failure()?.errorText ?? 'unknown'}`);
+  });
   page.on('pageerror', (err) => {
     log(`pageerror: ${err.message}\n${err.stack ?? ''}`);
   });

--- a/e2e/mobile/playlist-management.spec.ts
+++ b/e2e/mobile/playlist-management.spec.ts
@@ -114,8 +114,11 @@ test.describe('mobile playlist management (chunk 6)', () => {
     const removeBtn = page.getByTestId(/^detail-track-remove-/).first();
     await expect(removeBtn).toBeVisible({ timeout: 15_000 });
 
-    // #453: 갓 생성한 플리(커서 null) → 추가한 곡에 NEXT 배지. 비-DJ라 NOW 없음.
-    await expect(page.getByTestId('track-badge-next')).toBeVisible({ timeout: 15_000 });
+    // 커서 배지(NOW/NEXT)는 #468(시안 반영) 이후 **내가 현재 DJ일 때만** 노출된다
+    // (playlist-detail-sheet: isMeCurrentDj 가 false 면 nowTrackId/nextTrackId 모두 null).
+    // 이 시나리오는 DJ 등록 없이 플리만 관리하므로 두 배지 모두 없어야 정상이다.
+    // (구 기대값 "비-DJ 도 NEXT 노출"은 #453 시점 규칙이며 #468 에서 폐기됨 — #485)
+    await expect(page.getByTestId('track-badge-next')).toHaveCount(0);
     await expect(page.getByTestId('track-badge-now')).toHaveCount(0);
 
     // 곡 삭제 → 다시 빈 상태 (트랙 0)

--- a/e2e/mobile/profile-onboarding.spec.ts
+++ b/e2e/mobile/profile-onboarding.spec.ts
@@ -52,8 +52,21 @@ test.describe('mobile 신규 AM 프로필 온보딩 (#393)', () => {
 
     log('fill nickname + submit');
     const unique = `am${Date.now() % 100000}`;
-    await page.locator('[data-testid="mobile-profile-form"] input').first().fill(unique);
-    await page.locator('[data-testid="mobile-profile-submit"]').click();
+    const nicknameInput = page.locator('[data-testid="mobile-profile-form"] input').first();
+    const submitButton = page.locator('[data-testid="mobile-profile-submit"]');
+
+    // ⚠️ 테스트 측 방어일 뿐, 근본 원인은 제품 결함이다 — #487.
+    // 폼 기본값이 마운트 이후 비동기로 도착해 이미 입력된 값을 덮어쓴다. 페이지가 빠를수록
+    // (풀 스위트 후반처럼 warm 일 때) 우리가 먼저 입력해 값이 지워지고, 검증 실패로 제출
+    // 버튼이 disabled 로 남아 클릭이 60s 타임아웃난다. 실사용자도 빠르게 타이핑하면 같은
+    // 방식으로 입력을 잃는다. #487 이 수정되면 이 재시도 블록은 제거해도 된다.
+    await expect(async () => {
+      await nicknameInput.fill(unique);
+      await expect(nicknameInput).toHaveValue(unique, { timeout: 2_000 });
+      await expect(submitButton).toBeEnabled({ timeout: 2_000 });
+    }).toPass({ timeout: 20_000 });
+
+    await submitButton.click();
 
     // 데드엔드 #2 해소: 아바타 desktop-only 카드 거치지 않고 /parties 착지
     log('expect /parties landing (avatar 단계 생략)');

--- a/e2e/mobile/profile-onboarding.spec.ts
+++ b/e2e/mobile/profile-onboarding.spec.ts
@@ -50,21 +50,26 @@ test.describe('mobile 신규 AM 프로필 온보딩 (#393)', () => {
       timeout: 30_000,
     });
 
+    // 폼이 보여도 dev 로그인 다이얼로그는 아직 DOM 에 남아 있을 수 있다. 그 사이에 입력하면
+    // 다이얼로그의 focus trap 이 포커스를 회수해 fill 이 조용히 삼켜진다 — 값이 반영되지 않아
+    // 제출 버튼이 계속 비활성이고, 클릭이 60s 타임아웃난다.
+    //   실측(2026-08-01, 실패 재현): fill 성공 반환 직후 readback inputValue="",
+    //   그 다음 프레임에 `focusout target=BUTTON[dev-sign-in-associate] active=BODY`.
+    //   input 노드는 교체되지 않았고(동일 노드 60s 유지) input/beforeinput 이벤트는 0건 —
+    //   입력이 애초에 이 필드로 오지 않았다는 뜻이다.
+    // 다이얼로그 분리를 확인한 뒤 입력해 원인을 제거한다.
+    log('wait for dev sign-in dialog detached');
+    await dialog.waitFor({ state: 'detached', timeout: 15_000 });
+
     log('fill nickname + submit');
     const unique = `am${Date.now() % 100000}`;
     const nicknameInput = page.locator('[data-testid="mobile-profile-form"] input').first();
     const submitButton = page.locator('[data-testid="mobile-profile-submit"]');
 
-    // ⚠️ 테스트 측 방어일 뿐, 근본 원인은 제품 결함이다 — #487.
-    // 폼 기본값이 마운트 이후 비동기로 도착해 이미 입력된 값을 덮어쓴다. 페이지가 빠를수록
-    // (풀 스위트 후반처럼 warm 일 때) 우리가 먼저 입력해 값이 지워지고, 검증 실패로 제출
-    // 버튼이 disabled 로 남아 클릭이 60s 타임아웃난다. 실사용자도 빠르게 타이핑하면 같은
-    // 방식으로 입력을 잃는다. #487 이 수정되면 이 재시도 블록은 제거해도 된다.
-    await expect(async () => {
-      await nicknameInput.fill(unique);
-      await expect(nicknameInput).toHaveValue(unique, { timeout: 2_000 });
-      await expect(submitButton).toBeEnabled({ timeout: 2_000 });
-    }).toPass({ timeout: 20_000 });
+    await nicknameInput.click();
+    await nicknameInput.fill(unique);
+    // 같은 일이 다시 생기면 여기서 즉시 드러난다(제출 버튼 60s 타임아웃으로 뭉개지 않는다)
+    await expect(nicknameInput).toHaveValue(unique, { timeout: 5_000 });
 
     await submitButton.click();
 


### PR DESCRIPTION
closes #485

## 원인 (확정)

`#467` 에서 **빈 큐 상태의 DJ 다이얼로그가 CTA 2개로 개편**됐다. `RegisterButton` 이 `label` prop 을 받게 되면서(`{label ?? t.dj.btn.register_queue}`), `EmptyBody` 는 `label={t.dj.btn.pick_from_my_playlist}` 를 넘긴다.

| 상태 | 컴포넌트 | 표시 텍스트 |
|---|---|---|
| 큐에 DJ 있음 | `Body` | Register for DJ Queue |
| 큐 비어 있음 | `EmptyBody` | **Choose from my playlist** (+ 별도 CTA `Search a song and be a DJ`) |

헬퍼는 접근성 이름(`/register.*dj queue|dj 대기 등록/i`)으로만 찾았고, `registerAsDj` 는 **갓 만든 방**(항상 빈 큐)에서 호출되므로 **100% 실패**했다. 플레이크가 아니다.

**증상이 오해를 부른다**: 실패 스냅샷이 로비였다(테스트 cleanup 이 이미 방을 지운 뒤 캡처). 실제 trace 는 전부 정상이었다.

```
16:12:01  POST /api/v1/partyrooms           → 201
16:12:02  POST /api/v1/partyrooms/499/crews → 201
16:12:02  GET  .../{setup,notice,dj-queue}  → 200
16:12:03  GET  .../dj-queue                 → 200   ← 드로어 열림
          (10초 대기 → 타임아웃)                      ← 여기가 진짜 실패
16:12:13  DELETE /api/v1/partyrooms/499     → 204   ← cleanup
```

## 변경

| 파일 | 변경 |
|---|---|
| `e2e/helpers/partyroom.helpers.ts` | `registerAsDj`: `getByRole(name)` → **`getByTestId('register-dj-queue')`**. testid 는 `Body`/`EmptyBody` 양쪽 동일 |
| `e2e/e2e-b.playback-summary.spec.ts` | 같은 로직을 복제한 `registerAsDjEscapeClose` 동일 수정 |
| `e2e/mobile/playlist-management.spec.ts` | 커서 배지 기대값 정정 (아래) |
| `e2e/mobile/chunk4.helpers.ts` | 잔존 방 정리 실패를 **무증상으로 넘기지 않도록** 경고 추가 (아래) |
| `e2e/README.md` | 실전 함정 + 로컬 세팅 주의 문서화 |

### 커서 배지 기대값 정정 (별개 사유)

`#468`(시안 반영) 이후 NOW/NEXT 배지는 **내가 현재 DJ 일 때만** 노출된다 — `playlist-detail-sheet` 가 `isMeCurrentDj` 가 false 면 `nowTrackId`/`nextTrackId` 를 모두 null 로 둔다. 이 스펙은 DJ 등록 없이 플리만 관리하므로 **두 배지 모두 0 이 정상**이다. 기존 기대("비-DJ 도 NEXT 노출")는 #453 시점 규칙이다.

> ⚠️ 이 스펙은 `#468` 머지 실행(07-23T15:42)에서 이미 같은 이유로 실패했고, 바로 다음 실행이 green 이라 묻혔다. **만약 "NEXT 는 모두에게 보여야 한다"가 원래 의도였다면 이건 제품 회귀이고 테스트가 옳았던 것**이므로, 그 경우 이 변경을 되돌리고 제품을 고쳐야 한다.

### 정리 헬퍼의 무증상 실패 차단

`cleanupMobileTestPartyrooms` 는 `if (!response.ok()) return;` 로 조용히 빠진다. `E2E_API_BASE` 에 `/api/` 가 빠지면 404 → 아무 신호 없이 no-op → 잔존 방이 **계정당 활성 방 1개 불변식**에 걸려 다음 spec 의 `createPartyroom` 이 `waitForURL` 타임아웃으로 죽는다. 증상이 원인과 멀다. 요청 URL·상태코드·원인 후보를 경고로 남기도록 했다.

## 검증 — 로컬 풀스택

로컬 백엔드(docker compose, 8080) + `next dev`(3001) + Playwright.

```
E2E_BASE_URL=http://localhost:3001 E2E_API_BASE=http://localhost:8080/api/ npx playwright test
```

| 대상 | 결과 |
|---|---|
| **풀 스위트 21건** | **19 passed / 2 failed** (6.6m) |
| **mobile project 11건** | **11 passed** — 이 PR 이 고친 `playlist-management` 포함 |
| `e2e-b` project 단독 | 4건 중 3 passed (`playback-summary` 포함) |

수정 지점이 실제로 동작함을 확인: `e2e-b.dj-state-machine` 에서 **양쪽 유저 `POST /dj-queue → 201`**. 기존에는 버튼을 찾지 못해 10초 타임아웃으로 죽던 지점이다. CI 에서 실패하던 `e2e-a`·`e2e-d` 도 통과.

### 남은 2건 (이 PR 과 무관, 순서 의존)

| 스펙 | 증상 | 비고 |
|---|---|---|
| `e2e-b.dj-state-machine` | `partyroom-dj-queue-item` count 0 | **단독 실행 시 통과.** 풀 스위트에서만 재현 |
| `mobile/profile-onboarding` | `mobile-profile-submit` 클릭 타임아웃 | **mobile project 단독 실행 시 통과**(11/11) |

둘 다 이 PR 의 변경 지점(등록 CTA·배지)과 무관하며, 단독 실행에서 통과하므로 **cross-spec 상태 간섭**으로 보인다. 별도 추적 대상.

## 진단 과정에서의 오진 기록 (정직 고지)

이 PR 을 준비하며 두 번 잘못 결론 내렸고, 리뷰어가 같은 함정을 밟지 않도록 남긴다.

1. "모바일은 `POST /partyrooms` 요청 자체가 안 나간다" → **틀림.** DB 에 방이 생성돼 있었다. 모바일 spec 에 응답 로깅 계측이 없어 로그에 안 보였을 뿐이다.
2. "로컬 dev 모드 한정 문제라 모바일은 검증 불가" → **틀림.** `E2E_API_BASE` 에 `/api/` 를 빠뜨린 내 실행 파라미터 오류였다. 바로잡자 11/11 통과했다.

## 범위

**소스 코드 변경 없음** — `e2e/` 5파일만.