### PR TITLE
fix(profile): 프로필 응답 null 타입 정정 + 입력 유실 복구 (#487)

### DIFF
--- a/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts
+++ b/src/features/edit-profile-bio/lib/use-edit-profile-bio-form.ts
@@ -25,9 +25,13 @@ export const useEditProfileBioForm = () => {
   } = useForm<Form.Model>({
     mode: 'all',
     resolver: zodResolver(Form.getSchema(t)),
+    // #487 (1): 서버는 미설정 값에 null 을 준다. null 을 그대로 넘기면 Input 의
+    // `value = _value ?? localValue` 가 undefined 로 떨어져 필드가 uncontrolled 로
+    // 시작하고, React 가 "value prop should not be null" / "uncontrolled → controlled"
+    // 경고를 낸다. 빈 문자열로 정규화해 처음부터 controlled 로 둔다.
     defaultValues: {
-      nickname: me.nickname,
-      introduction: me.introduction,
+      nickname: me.nickname ?? '',
+      introduction: me.introduction ?? '',
     },
   });
 

--- a/src/features/edit-profile-bio/ui/v2-edit.component.tsx
+++ b/src/features/edit-profile-bio/ui/v2-edit.component.tsx
@@ -29,9 +29,10 @@ const V2EditMode = ({ changeToViewMode }: V2EditModeProps) => {
   } = useForm<Form.Model>({
     mode: 'all',
     resolver: zodResolver(Form.getSchema(t)),
+    // #487: 서버가 null 을 주는 필드 — 빈 문자열로 정규화(v1·모바일 폼과 동일 규칙)
     defaultValues: {
-      nickname: me.nickname,
-      introduction: me.introduction,
+      nickname: me.nickname ?? '',
+      introduction: me.introduction ?? '',
     },
   });
   const btnDisabled = Object.keys(errors).length > 0 || !isValid;

--- a/src/features/partyroom/create/ui/form.component.tsx
+++ b/src/features/partyroom/create/ui/form.component.tsx
@@ -55,7 +55,7 @@ export default function PartyroomCreateForm({ onSuccess }: Props) {
           }
           classNames={{ label: 'text-gray-200' }}
         >
-          <DjListItem userConfig={{ username: me.nickname, src: me.avatarIconUri }} />
+          <DjListItem userConfig={{ username: me.nickname ?? '', src: me.avatarIconUri }} />
         </FormItem>
       }
     />

--- a/src/shared/api/http/types/users.ts
+++ b/src/shared/api/http/types/users.ts
@@ -23,8 +23,10 @@ export interface ActivitySummary {
 }
 
 export interface GetMyProfileSummaryResponse {
-  nickname: string;
-  introduction?: string;
+  /** 프로필 미설정 신규 가입자는 서버가 null 을 준다 (#487). */
+  nickname: string | null;
+  /** 미입력 시 서버가 null 을 준다 — `?: string` 은 사실과 달랐다 (#487). */
+  introduction: string | null;
   avatarCompositionType: AvatarCompositionType;
   avatarBodyUri: string;
   avatarFaceUri: string;

--- a/src/shared/ui/components/input/input.component.test.tsx
+++ b/src/shared/ui/components/input/input.component.test.tsx
@@ -1,3 +1,6 @@
+import { act, useState } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Input from './input.component';
 
@@ -70,6 +73,48 @@ describe('Input', () => {
     expect(screen.getByText('접미사')).toBeTruthy();
   });
 
+  // #487: 서버 마크업이 하이드레이션되기 전에 사용자가 친 값은 DOM 에만 존재한다.
+  // React 가 마운트하며 상태값으로 덮으면 그 입력은 조용히 사라진다("글자가 안 써진다").
+  // 차단(비활성)이 아니라 복구 — 마운트 시점의 DOM 값을 상태로 흡수해야 한다.
+  test('#487: 하이드레이션 이전에 입력된 값이 마운트 후에도 남고 onChange 로 전파된다', async () => {
+    // RHF 처럼 값을 되돌려주는 제어 부모 (onChange 를 무시하면 제어 컴포넌트 특성상
+    // DOM 값이 부모 값으로 덮이는 게 정상이라, 실제 폼과 같은 구조로 확인한다)
+    const ControlledHost = ({ onValue }: { onValue: (v: string) => void }) => {
+      const [value, setValue] = useState('');
+      return (
+        <Input
+          value={value}
+          onChange={(e) => {
+            onValue(e.target.value);
+            setValue(e.target.value);
+          }}
+          placeholder='입력'
+        />
+      );
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(<ControlledHost onValue={() => {}} />);
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    // 하이드레이션 전 사용자 타이핑 (React 는 이 입력을 모른다)
+    input.value = '하이드레이션전입력';
+
+    const onChange = vi.fn();
+    await act(async () => {
+      hydrateRoot(container, <ControlledHost onValue={onChange} />);
+    });
+
+    try {
+      expect(input.value).toBe('하이드레이션전입력');
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith('하이드레이션전입력');
+    } finally {
+      container.remove();
+    }
+  });
+
   test('wrapper 클릭 시 input이 포커스된다', () => {
     const { container } = render(<Input placeholder='입력' />);
 
@@ -81,5 +126,37 @@ describe('Input', () => {
 
     expect(focusSpy).toHaveBeenCalled();
     focusSpy.mockRestore();
+  });
+
+  // #487 (b): value 를 직접 대입한 뒤 input 이벤트가 오면 React 의 value tracker 가
+  // "변경 없음" 으로 판단해 onChange 를 건너뛴다(Playwright fill 이 실제로 이 모양이다).
+  // 그 결과 DOM 에는 글자가 있는데 폼 상태는 비어 제출 버튼이 계속 비활성이 된다.
+  test('#487: value 직접 대입 + input 이벤트도 상태로 흡수된다(onChange 유실 복구)', async () => {
+    const onValue = vi.fn();
+    const ControlledHost = () => {
+      const [value, setValue] = useState('');
+      return (
+        <Input
+          value={value}
+          onChange={(e) => {
+            onValue(e.target.value);
+            setValue(e.target.value);
+          }}
+          placeholder='입력'
+        />
+      );
+    };
+
+    render(<ControlledHost />);
+    const input = screen.getByPlaceholderText('입력') as HTMLInputElement;
+
+    await act(async () => {
+      input.value = 'fill주입값'; // React 합성 이벤트를 우회한 값 주입
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(onValue).toHaveBeenCalledWith('fill주입값');
+    expect(input.value).toBe('fill주입값');
   });
 });

--- a/src/shared/ui/components/input/input.component.tsx
+++ b/src/shared/ui/components/input/input.component.tsx
@@ -3,11 +3,13 @@ import {
   ComponentProps,
   ReactNode,
   MouseEventHandler,
+  ChangeEvent,
   ChangeEventHandler,
   forwardRef,
   useState,
   KeyboardEventHandler,
   useRef,
+  useEffect,
 } from 'react';
 import { cn } from '@/shared/lib/functions/cn';
 import { combineRef } from '@/shared/lib/functions/combine-ref';
@@ -54,6 +56,56 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     const [localValue, setLocalValue] = useState(defaultValue);
     const value = _value ?? localValue;
     const valueLength = value?.length ?? 0;
+
+    // 아래 복구 로직이 항상 최신 값·핸들러를 보도록 동기화한다(네이티브 이벤트는
+    // 렌더 사이에 도착하므로 클로저 캡처로는 스테일해진다).
+    const onChangeRef = useRef(onChange);
+    const valueRef = useRef(value);
+    useEffect(() => {
+      onChangeRef.current = onChange;
+      valueRef.current = value;
+    });
+
+    /**
+     * #487: 입력값은 React 합성 onChange 를 거쳐야만 상태에 남는다. 그 경로를 타지 못한
+     * 입력은 DOM 에만 존재하고 상태·폼(RHF)은 빈 값이라, 글자수 카운터는 00 이고 제출
+     * 버튼은 계속 비활성이다 — 사용자 눈에는 "글자가 안 써진다".
+     * 확인된 경로 2가지:
+     *   (a) 하이드레이션 이전 타이핑 — React 가 마운트하기 전이라 핸들러가 없다.
+     *   (b) value 를 직접 대입한 뒤 input 이벤트가 오는 경우 — React 의 value tracker 가
+     *       "변경 없음"으로 보고 건너뛴다. 자동화 도구의 fill 이 이 모양이고, 값을 직접
+     *       채우는 확장·자동완성도 같은 경로가 될 수 있다.
+     * 입력을 막는 대신(막으면 사용자만 손해다) 유실을 감지해 상태로 흡수한다.
+     */
+    useEffect(() => {
+      const el = inputRef.current;
+      if (!el) return;
+
+      const adopt = (event?: Event) => {
+        const domValue = el.value;
+        if (domValue === (valueRef.current ?? '')) return;
+        setLocalValue(domValue);
+        onChangeRef.current?.(
+          (event ?? { target: el, currentTarget: el }) as unknown as ChangeEvent<HTMLInputElement>
+        );
+      };
+
+      // (a) 마운트 시점에 이미 들어와 있던 값. "DOM 에 값이 있는데 상태가 빈" 방향만
+      // 흡수한다 — 반대 방향(defaultValue 가 상태에만 있는 정상 상태)은 건드리지 않는다.
+      if (el.value) adopt();
+
+      // (b) React 가 처리했는지 다음 매크로태스크에 확인하고, 놓친 경우에만 흡수한다
+      const handleNativeInput = () => {
+        const domValue = el.value;
+        window.setTimeout(() => {
+          if (el.value === domValue && domValue !== (valueRef.current ?? '')) adopt();
+        }, 0);
+      };
+
+      el.addEventListener('input', handleNativeInput);
+      return () => el.removeEventListener('input', handleNativeInput);
+       
+    }, []);
 
     const handleClickWrapper: MouseEventHandler<HTMLDivElement> = (e) => {
       if (!(e.target as HTMLElement).closest('button')) {

--- a/src/shared/ui/components/textarea/textarea.component.test.tsx
+++ b/src/shared/ui/components/textarea/textarea.component.test.tsx
@@ -1,4 +1,6 @@
-import { createRef } from 'react';
+import { act, createRef, useState } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 import { render, screen, fireEvent } from '@testing-library/react';
 import TextArea from './textarea.component';
 
@@ -68,5 +70,71 @@ describe('TextArea', () => {
 
     expect(ref.current).not.toBeNull();
     expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+  });
+
+  // #487: 하이드레이션 이전 입력이 상태에 반영되지 않아 사라지는 결함의 복구 확인
+  test('#487: 하이드레이션 이전에 입력된 값이 마운트 후에도 남고 onChange 로 전파된다', async () => {
+    const ControlledHost = ({ onValue }: { onValue: (v: string) => void }) => {
+      const [value, setValue] = useState('');
+      return (
+        <TextArea
+          value={value}
+          onChange={(e) => {
+            onValue(e.target.value);
+            setValue(e.target.value);
+          }}
+          placeholder='소개'
+        />
+      );
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(<ControlledHost onValue={() => {}} />);
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = '하이드레이션전소개';
+
+    const onChange = vi.fn();
+    await act(async () => {
+      hydrateRoot(container, <ControlledHost onValue={onChange} />);
+    });
+
+    try {
+      expect(textarea.value).toBe('하이드레이션전소개');
+      expect(onChange).toHaveBeenCalledWith('하이드레이션전소개');
+    } finally {
+      container.remove();
+    }
+  });
+
+  // #487 (b): value 직접 대입 + input 이벤트 → React 가 onChange 를 건너뛰는 경로
+  test('#487: value 직접 대입 + input 이벤트도 상태로 흡수된다(onChange 유실 복구)', async () => {
+    const onValue = vi.fn();
+    const ControlledHost = () => {
+      const [value, setValue] = useState('');
+      return (
+        <TextArea
+          value={value}
+          onChange={(e) => {
+            onValue(e.target.value);
+            setValue(e.target.value);
+          }}
+          placeholder='소개'
+        />
+      );
+    };
+
+    render(<ControlledHost />);
+    const textarea = screen.getByPlaceholderText('소개') as HTMLTextAreaElement;
+
+    await act(async () => {
+      textarea.value = 'fill주입소개';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(onValue).toHaveBeenCalledWith('fill주입소개');
+    expect(textarea.value).toBe('fill주입소개');
   });
 });

--- a/src/shared/ui/components/textarea/textarea.component.tsx
+++ b/src/shared/ui/components/textarea/textarea.component.tsx
@@ -1,5 +1,13 @@
 'use client';
-import { ComponentProps, ChangeEventHandler, useState, forwardRef, useRef } from 'react';
+import {
+  ComponentProps,
+  ChangeEvent,
+  ChangeEventHandler,
+  useState,
+  forwardRef,
+  useRef,
+  useEffect,
+} from 'react';
 import { cn } from '@/shared/lib/functions/cn';
 import { combineRef } from '@/shared/lib/functions/combine-ref';
 import { Typography } from '../typography';
@@ -27,6 +35,50 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const [localValue, setLocalValue] = useState<string>(initialValue);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const combinedRef = combineRef([ref, textareaRef]);
+
+    const onChangeRef = useRef(onChange);
+    const valueRef = useRef(localValue);
+    useEffect(() => {
+      onChangeRef.current = onChange;
+      valueRef.current = localValue;
+    });
+
+    /**
+     * #487: Input 과 동일 — React 합성 onChange 를 거치지 못한 입력은 DOM 에만 남고
+     * 상태·폼에는 반영되지 않아 조용히 사라진다. (a) 하이드레이션 이전 타이핑,
+     * (b) value 직접 대입 후 input 이벤트(fill 등, React value tracker 가 건너뜀).
+     */
+    useEffect(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+
+      const adopt = (event?: Event) => {
+        const domValue = el.value;
+        if (domValue === (valueRef.current ?? '')) return;
+        setLocalValue(domValue);
+        onChangeRef.current?.(
+          (event ?? {
+            target: el,
+            currentTarget: el,
+          }) as unknown as ChangeEvent<HTMLTextAreaElement>
+        );
+      };
+
+      // 마운트 흡수는 "DOM 에 값이 있는데 상태가 비어 있는" 방향만 — 반대 방향(초기값이
+      // 상태에만 있는 정상 상태)까지 삼키면 initialValue 가 지워진다.
+      if (el.value) adopt();
+
+      const handleNativeInput = () => {
+        const domValue = el.value;
+        window.setTimeout(() => {
+          if (el.value === domValue && domValue !== (valueRef.current ?? '')) adopt();
+        }, 0);
+      };
+
+      el.addEventListener('input', handleNativeInput);
+      return () => el.removeEventListener('input', handleNativeInput);
+       
+    }, []);
 
     const handleChangeTextArea: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
       setLocalValue(e.target.value);


### PR DESCRIPTION
## 배경

#487 조사 과정에서 확인된 **두 개의 실재 결함**을 고친다. 이슈 본문의 가설(기본값 덮어쓰기)과 후속 가설(준비 전 입력 차단)은 각각 기각·무효 확인됐고, e2e 간헐 실패의 실제 원인은 별개(#488)로 밝혀졌다. 본 PR 은 그와 무관하게 확인된 것만 담는다. 상세 조사 기록은 #487 코멘트 2건 참고.

## 1. 타입·기본값 정규화

`GetMyProfileSummaryResponse` 는 `nickname: string` / `introduction?: string` 로 선언돼 있었으나 **서버는 미설정 값에 `null` 을 준다**(신규 AM 은 두 필드 모두 NULL). 타입이 런타임과 어긋나 있었다.

null 이 그대로 폼 기본값으로 들어가면 `Input` 의 `value = _value ?? localValue` 가 `undefined` 로 떨어져 필드가 uncontrolled 로 시작하고, 다음 두 경고가 상시 발생한다.

- `Warning: value prop on textarea should not be null`
- `Warning: A component is changing an uncontrolled input to be controlled`

**수정**: 타입을 `string | null` 로 바로잡고, 폼 기본값을 `?? ''` 로 정규화해 처음부터 controlled 로 둔다. 타입 변경에 따라 파티룸 생성 폼의 닉네임 사용처도 정규화했다.

## 2. 입력 유실 복구 — 차단이 아니라 흡수

입력값은 **React 합성 `onChange` 를 거쳐야만 상태에 남는다.** 그 경로를 타지 못한 입력은 DOM 에만 존재하고 폼 상태(RHF)는 빈 값이라, 글자수 카운터는 `00` 이고 제출 버튼은 계속 비활성이다 — 사용자 눈에는 "글자가 안 써진다".

공유 `Input` / `TextArea` 에 유실 감지·흡수를 넣었다.

- **(a) 하이드레이션 이전 입력** — 마운트 시점 DOM 값이 상태와 다르면 흡수한다. 단 **"DOM 에 값이 있는데 상태가 빈" 방향만** 처리한다(반대 방향까지 삼켰다가 `initialValue` 가 지워지는 회귀를 냈고, 테스트로 잡아 좁혔다).
- **(b) `value` 직접 대입 후 `input` 이벤트** — React 의 value tracker 가 "변경 없음" 으로 보고 `onChange` 를 건너뛴다. 네이티브 `input` 리스너로 감지해 **다음 매크로태스크에 React 가 처리했는지 확인하고, 놓친 경우에만** 흡수한다(정상 경로에서는 중복 호출하지 않는다).

입력을 막는 방식(필드 비활성화)은 채택하지 않았다. 이 렌더 경로에서 무효임을 실측으로 확인했다(#487 코멘트).

## 테스트

`Input` · `TextArea` 각 2건, 총 **4건 추가**.

- 하이드레이션 이전 입력이 마운트 후에도 남고 `onChange` 로 전파되는지 — `renderToString` → DOM 값 주입 → `hydrateRoot`
- `value` 직접 대입 + `input` 이벤트가 상태로 흡수되는지

**두 테스트 모두 복구 로직을 무력화하면 실패(red)하는 것까지 확인**했다.

## 검증

| 게이트 | 결과 |
|---|---|
| 단위 | **1779 passed** (316 파일) |
| `tsc --noEmit` | 0 |
| eslint | 0 errors |
| 로컬 풀스택 e2e | 회귀 없음 |

e2e 잔여 실패는 본 변경과 무관함을 각각 확인했다 — `registerAsDj` 헬퍼 계열은 #485(PR #486 에서 수정), `playlist-management` 는 수정을 stash 한 베이스라인에서도 동일 실패하는 기존 결함(역시 #486 에서 기대값 정정).

## 이 PR 이 하지 않는 것

- **#487 을 닫지 않는다.** 이슈 본문의 사용자 영향 주장("빠르게 타이핑하면 입력이 사라진다")은 조사 전 구간에서 **실측 재현되지 않았다**(CPU 6× 스로틀링, 폼 등장 전부터 키 210개 연발, 삽입 즉시 포커스 탈취 — 수정 전후 모두 유실 0). 본문 주장의 사실 여부는 열어둔 채, 확인된 결함만 고친다.
- 다이얼로그 focus trap 건은 #488 로 분리했다.

## 관련

- #487 (조사 기록 코멘트 2건) · #488 (분리된 Dialog focus trap) · #485 / PR #486 (e2e 측)
