### PR TITLE
fix(ui): 다이얼로그 닫힘 창에서 사용자 포커스를 빼앗지 않는다 (#488)

### DIFF
--- a/src/shared/ui/components/dialog/dialog.provider.test.tsx
+++ b/src/shared/ui/components/dialog/dialog.provider.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { useDialogContext } from './dialog.context';
+import { DialogProvider } from './dialog.provider';
+
+vi.mock('@/shared/lib/localization/i18n.context', () => ({
+  useI18n: () => ({ common: { btn: { confirm: '확인', cancel: '취소' } } }),
+}));
+
+/**
+ * #488: 다이얼로그가 닫히고 DOM 에서 제거될 때까지 창(제거 지연)이 있다. 그 사이에 사용자가
+ * 바깥 입력창을 클릭해 포커스를 두면, 제거 시점의 포커스 복원이 그 포커스를 빼앗아
+ * 이후 타이핑이 사라진다("커서는 깜빡이는데 글자가 안 써진다").
+ */
+const Harness = () => {
+  const { openDialog } = useDialogContext();
+
+  return (
+    <div>
+      <input data-testid='outside-input' />
+      <button
+        data-testid='open-trigger'
+        onClick={() =>
+          openDialog(() => ({
+            Body: <div data-testid='dialog-body'>본문</div>,
+          }))
+        }
+      >
+        열기
+      </button>
+    </div>
+  );
+};
+
+describe('DialogProvider — #488 포커스 보존', () => {
+  test('닫히는 동안 사용자가 바깥 요소로 포커스를 옮기면, 제거 후에도 그 포커스가 유지된다', async () => {
+    render(
+      <DialogProvider>
+        <Harness />
+      </DialogProvider>
+    );
+
+    const trigger = screen.getByTestId('open-trigger');
+    const outsideInput = screen.getByTestId('outside-input') as HTMLInputElement;
+
+    // 다이얼로그 열기 (트리거가 포커스를 가진 상태 — 복원 대상이 된다)
+    trigger.focus();
+    await act(async () => {
+      trigger.click();
+    });
+    expect(screen.getByTestId('dialog-body')).toBeTruthy();
+
+    // 닫기 시작 — 제거까지는 지연이 있다
+    const dialogRoot = document.querySelector('[data-testid="dialog-panel"]');
+    await act(async () => {
+      (dialogRoot?.parentElement ?? document.body).dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    // 창 안에서 사용자가 바깥 입력창을 클릭해 포커스를 둔다(실제 클릭과 동일한 순서)
+    await act(async () => {
+      outsideInput.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      outsideInput.focus();
+    });
+    expect(document.activeElement).toBe(outsideInput);
+
+    // 제거가 끝난 뒤에도 사용자의 포커스가 유지되어야 한다
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('dialog-body')).toBeNull();
+      },
+      { timeout: 3_000 }
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    expect(document.activeElement).toBe(outsideInput);
+  });
+});

--- a/src/shared/ui/components/dialog/dialog.provider.tsx
+++ b/src/shared/ui/components/dialog/dialog.provider.tsx
@@ -23,9 +23,15 @@ export const DialogProvider = ({ children }: DialogProviderProps) => {
         return { ...dialog, open: false };
       })
     );
-    await delay(500);
+    // #488: 닫기와 DOM 제거 사이에는 창이 있고, 그 사이 Headless UI 는 포커스를
+    // "열었던 요소"로 되돌린다. 사용자가 그 창에서 바깥 입력창을 클릭해 두었다면
+    // 포커스를 빼앗겨 이후 타이핑이 사라진다 — 사용자의 클릭 의도를 지켜준다.
+    const focusGuard = startUserFocusIntentGuard();
+    await delay(CLOSE_TRANSITION_MS + CLOSE_TRANSITION_BUFFER_MS);
 
     setDialogs((prevDialogs) => prevDialogs.filter((dialog) => dialog.id !== id));
+
+    focusGuard.restore();
   }, []);
 
   const push: PushDialog = useCallback(
@@ -75,4 +81,40 @@ export const DialogProvider = ({ children }: DialogProviderProps) => {
 
 function generateId(): DialogID {
   return `${Date.now()}`;
+}
+
+/** dialog.component 의 닫힘 전환(`leave ... duration-200`)과 맞춘다. */
+const CLOSE_TRANSITION_MS = 200;
+/** 전환이 끝난 직후 제거되도록 하는 여유분. 길수록 #488 의 포커스 탈취 창이 넓어진다. */
+const CLOSE_TRANSITION_BUFFER_MS = 50;
+
+/** 다이얼로그가 닫히는 동안 사용자가 포커스를 두려고 클릭한 요소를 기억한다. */
+function startUserFocusIntentGuard() {
+  const FOCUSABLE = 'input, textarea, select, [contenteditable="true"], [tabindex]';
+  let intended: HTMLElement | null = null;
+
+  const onPointerDown = (event: Event) => {
+    const target = event.target as HTMLElement | null;
+    if (!target || typeof target.closest !== 'function') return;
+    if (target.closest('[role="dialog"]')) return;
+
+    intended = target.closest(FOCUSABLE) as HTMLElement | null;
+  };
+
+  document.addEventListener('pointerdown', onPointerDown, true);
+
+  return {
+    restore() {
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      if (!intended) return;
+
+      // 라이브러리의 포커스 복원이 언제 도는지에 의존하지 않도록 짧은 구간에 걸쳐 확인한다
+      const element = intended;
+      const attempt = () => {
+        if (!element.isConnected) return;
+        if (document.activeElement !== element) element.focus();
+      };
+      [0, 50, 150].forEach((ms) => setTimeout(attempt, ms));
+    },
+  };
 }


### PR DESCRIPTION
Closes #488

## 증상

다이얼로그를 닫고 **0.3초 안에 입력창을 클릭하면 그 뒤 타이핑이 사라진다.** 사용자는 "커서는 깜빡이는데 글자가 안 써진다"로 인지한다.

## 원인

`DialogProvider.pop()` 은 `open:false` 로 바꾼 뒤 지연을 두고 DOM 에서 제거한다. 그 창(제거까지 실측 ≈315~356ms)에서 사용자가 바깥 입력창을 클릭해 두어도, 제거 시점에 Headless UI 가 포커스를 "열었던 요소"로 되돌리면서 **사용자의 포커스를 빼앗는다.**

프로덕션 빌드 실측 (수정 전):

```
t=  16ms active=INPUT[chat] dialogs=1 value=""
t= 315ms active=BUTTON      dialogs=0 value=""     ← 사용자 동작 없이 포커스 탈취
RESULT typed="afterUNMOUNT" final="" lost=true     ← 입력 전부 유실
```

전환 구간 자체는 무해하다(전환 중 타이핑은 정상 입력됨). 문제는 **제거 시점의 포커스 복원**이다. 조사 경위와 기각된 가설들은 #488 코멘트 참고.

## 수정

- 닫히는 동안 사용자가 **클릭한** 요소(pointerdown 대상 중 포커스 가능한 것)를 기억해 두고, 제거 후 포커스가 그 요소를 벗어나 있으면 되돌린다. 라이브러리의 복원 시점에 의존하지 않도록 짧은 구간에 걸쳐 확인하며, 사용자가 그 사이 다른 곳을 클릭하면 그 선택을 존중한다.
- 제거 지연을 닫힘 전환(`leave ... duration-200`)에 맞춰 **500ms → 250ms** 로 줄여 창 자체를 좁혔다.

포커스를 "복원하지 않기"가 아니라 "사용자가 옮긴 포커스를 지키기"로 구현했다 — 다이얼로그 안에서 그대로 닫은 경우의 기존 복원 동작(접근성)은 유지된다.

## 검증

| 항목 | 결과 |
|---|---|
| 신규 단위 테스트 | 닫히는 동안 바깥 요소로 포커스를 옮기면 제거 후에도 유지된다. **복구 로직 무력화 시 red** 확인 |
| 단위 전체 | **1776 passed** (317 파일) |
| `tsc --noEmit` | 0 |
| eslint | 0 errors |
| 프로덕션 빌드 실측 (수정 후) | `t=320ms` 에 포커스가 입력창으로 복구, `final="afterUNMOUNT" lost=false` |
| 로컬 풀스택 e2e | 회귀 없음 |

e2e 잔여 실패 7건은 모두 `registerAsDj` 헬퍼(#485) 계열로, 본 브랜치가 PR #486 을 포함하지 않는 `development` 기반이라 예상된 실패다.

## 관련

- #488 (원인 확정 코멘트) · #487 (이 건이 분리된 경위) · #485 / PR #486 (e2e 측)
