### PR TITLE
fix(partyroom): 동시 입장 시 상대 크루가 안 보이는 입장 이벤트 유실 차단 + 보정 (#491)

### DIFF
--- a/src/features/partyroom/enter/lib/subscription-event-buffer.test.ts
+++ b/src/features/partyroom/enter/lib/subscription-event-buffer.test.ts
@@ -1,0 +1,75 @@
+import { IMessage } from '@stomp/stompjs';
+import { createSubscriptionEventBuffer } from './subscription-event-buffer';
+
+const message = (body: string) => ({ body }) as IMessage;
+
+describe('createSubscriptionEventBuffer (#491)', () => {
+  test('생성 직후는 보류 상태 — release 전엔 전달하지 않는다', () => {
+    const dispatch = vi.fn();
+    const buffer = createSubscriptionEventBuffer(() => dispatch);
+
+    buffer.handle(message('a'));
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test('release 시 보류분을 도착 순서대로 재생한다', () => {
+    const dispatch = vi.fn();
+    const buffer = createSubscriptionEventBuffer(() => dispatch);
+
+    buffer.handle(message('a'));
+    buffer.handle(message('b'));
+    buffer.release();
+
+    expect(dispatch.mock.calls.map(([m]) => (m as IMessage).body)).toEqual(['a', 'b']);
+  });
+
+  test('release 이후 도착분은 즉시 전달한다', () => {
+    const dispatch = vi.fn();
+    const buffer = createSubscriptionEventBuffer(() => dispatch);
+
+    buffer.release();
+    buffer.handle(message('a'));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('재생된 이벤트는 버퍼에서 비워져 두 번 재생되지 않는다', () => {
+    const dispatch = vi.fn();
+    const buffer = createSubscriptionEventBuffer(() => dispatch);
+
+    buffer.handle(message('a'));
+    buffer.release();
+    buffer.hold();
+    buffer.release();
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('hold 로 다시 보류할 수 있다 (재수화 구간)', () => {
+    const dispatch = vi.fn();
+    const buffer = createSubscriptionEventBuffer(() => dispatch);
+
+    buffer.release();
+    buffer.hold();
+    buffer.handle(message('a'));
+    expect(dispatch).not.toHaveBeenCalled();
+
+    buffer.release();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('dispatch 는 매번 게터로 조회한다 — 핸들러가 교체돼도 최신본으로 전달', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    let current = first;
+    const buffer = createSubscriptionEventBuffer(() => current);
+
+    buffer.handle(message('a')); // 보류 시점의 핸들러는 first
+    current = second; // 재렌더로 핸들러 교체
+    buffer.release();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/partyroom/enter/lib/subscription-event-buffer.ts
+++ b/src/features/partyroom/enter/lib/subscription-event-buffer.ts
@@ -1,0 +1,60 @@
+import { IMessage } from '@stomp/stompjs';
+
+/**
+ * #491 스냅샷-구독 유실 구간 차단.
+ *
+ * 룸 입장은 "스냅샷(GET /setup) + 이후 이벤트 구독"으로 상태를 만든다. 이 둘의 경계에는
+ * 두 방향의 유실 구간이 있다.
+ *
+ *  1. 구독을 스냅샷 *뒤에* 걸면 — 스냅샷 생성 시점부터 브로커에 구독이 등록되기까지 발생한
+ *     이벤트가 아무에게도 전달되지 않는다. `CREW_ENTERED` 처럼 전체 상태가 아닌 델타를
+ *     1회만 싣는 이벤트는 이때 영구 유실된다(재조회·reconcile 경로가 없음).
+ *  2. 구독을 스냅샷 *앞에* 걸어도 — 스냅샷이 만들어진 뒤 그것이 적용(initPartyroom)되기
+ *     전에 도착한 이벤트는, 뒤이어 적용되는 (더 낡은) 스냅샷에 덮여 사라진다.
+ *
+ * 그래서 "구독 먼저, 스냅샷 적용까지 보류, 적용 후 재생" 순서가 필요하다. 이 버퍼가 (2)를
+ * 담당하고, 호출부의 구독-먼저 배치가 (1)을 담당한다.
+ *
+ * 재생은 at-least-once 다 — 보류 중 모은 이벤트에는 스냅샷에 이미 반영된 것도 섞여 있다.
+ * 룸 이벤트 핸들러들이 멱등이라 안전하다: `CREW_ENTERED` 는 upsert,
+ * `DJ_QUEUE_CHANGED` 는 큐 전체를 싣고, `PLAYBACK_STARTED` 는 `eventId` 로 중복 방출을 막는다.
+ */
+export type SubscriptionEventBuffer = {
+  /** 구독에 등록할 핸들러. 보류 중이면 모아두고, 아니면 즉시 전달한다. */
+  handle: (message: IMessage) => void;
+  /** 재수화(스냅샷 재적용) 시작 — 이후 도착분을 다시 모은다. */
+  hold: () => void;
+  /** 스냅샷 적용 완료 — 모아둔 순서 그대로 재생하고 버퍼를 비운다. */
+  release: () => void;
+};
+
+/**
+ * @param dispatch 최신 이벤트 핸들러를 돌려주는 게터. 구독 핸들러는 한 번만 등록되는 반면
+ *   핸들러는 렌더마다 새로 만들어지므로, 값이 아니라 게터로 받아 stale closure 를 피한다.
+ */
+export function createSubscriptionEventBuffer(
+  dispatch: () => (message: IMessage) => void
+): SubscriptionEventBuffer {
+  let held = true;
+  let pending: IMessage[] = [];
+
+  return {
+    handle(message) {
+      if (held) {
+        pending.push(message);
+        return;
+      }
+
+      dispatch()(message);
+    },
+    hold() {
+      held = true;
+    },
+    release() {
+      held = false;
+      const replaying = pending;
+      pending = [];
+      replaying.forEach((message) => dispatch()(message));
+    },
+  };
+}

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -37,15 +37,19 @@ const mockPush = vi.fn();
 const mockInvalidateQueries = vi.fn();
 const mockTrackerClear = vi.fn();
 const mockSeedFromSetup = vi.fn();
+const mockSubscribe = vi.fn();
+const mockUnsubscribeCurrentRoom = vi.fn();
+const mockHandleEvent = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
   (usePartyroomClient as Mock).mockReturnValue({
     onConnect: mockOnConnect,
     setRoomReconnectHandler: mockSetRoomReconnectHandler,
-    subscribe: vi.fn(),
+    subscribe: mockSubscribe,
+    unsubscribeCurrentRoom: mockUnsubscribeCurrentRoom,
   });
-  (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(vi.fn());
+  (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(mockHandleEvent);
   const state = {
     init: mockInit,
     playbackSummaryTracker: { clear: mockTrackerClear, seedFromSetup: mockSeedFromSetup },
@@ -183,6 +187,121 @@ describe('useEnterPartyroom 재연결 resync (#402/#469)', () => {
     resync();
     mockMutate.mock.calls[0][1].onError();
     expect(mockPush).toHaveBeenCalledWith('/parties');
+  });
+});
+
+describe('스냅샷-구독 유실 구간 차단 (#491)', () => {
+  const SETUP_RESPONSE = {
+    stageType: 'GENERAL',
+    crews: [{ crewId: 1, nickname: '나', gradeType: 'CLUBBER' }],
+    display: { playbackActivated: false },
+  };
+
+  const enterAndGetSubscribedHandler = (partyroomId = 7) => {
+    const { result } = renderHook(() => useEnterPartyroom(partyroomId));
+    act(() => result.current());
+    mockOnConnect.mock.calls[0][0]();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER' });
+    return mockSubscribe.mock.calls[0]?.[1] as (message: unknown) => void;
+  };
+
+  test('구독은 setup 스냅샷 조회보다 먼저 등록된다', () => {
+    (partyroomsService.getSetupInfo as Mock).mockReturnValue(new Promise(() => {}));
+    (partyroomsService.getNotice as Mock).mockReturnValue(new Promise(() => {}));
+
+    enterAndGetSubscribedHandler(7);
+
+    expect(mockSubscribe).toHaveBeenCalledWith(7, expect.any(Function));
+    // 스냅샷이 구독보다 먼저 만들어지면 그 사이 이벤트(CREW_ENTERED 등)가 영구 유실된다.
+    expect(mockSubscribe.mock.invocationCallOrder[0]).toBeLessThan(
+      (partyroomsService.getSetupInfo as Mock).mock.invocationCallOrder[0]
+    );
+  });
+
+  test('setup 적용 전 도착한 이벤트는 버퍼링됐다가 init 이후 재생된다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const handler = enterAndGetSubscribedHandler(7);
+    const message = { body: '{"eventType":"CREW_ENTERED"}' };
+    handler(message);
+
+    // 스냅샷 적용 전 — 아직 전달하지 않는다 (init이 덮어써 유실되는 것을 막기 위해)
+    expect(mockHandleEvent).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(mockHandleEvent).toHaveBeenCalledWith(message));
+    // 재생은 반드시 initPartyroom 이후 — 그래야 스냅샷이 이벤트를 덮어쓰지 않는다
+    expect(mockInit.mock.invocationCallOrder[0]).toBeLessThan(
+      mockHandleEvent.mock.invocationCallOrder[0]
+    );
+  });
+
+  test('setup 적용 후 도착한 이벤트는 즉시 전달된다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const handler = enterAndGetSubscribedHandler(7);
+    await vi.waitFor(() => expect(mockInit).toHaveBeenCalled());
+
+    const message = { body: '{"eventType":"CHAT_MESSAGE_SENT"}' };
+    handler(message);
+
+    expect(mockHandleEvent).toHaveBeenCalledWith(message);
+  });
+
+  test('버퍼는 재생 후 비워진다 (같은 이벤트 중복 재생 없음)', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const handler = enterAndGetSubscribedHandler(7);
+    const buffered = { body: '{"eventType":"CREW_ENTERED"}' };
+    handler(buffered);
+
+    await vi.waitFor(() => expect(mockHandleEvent).toHaveBeenCalledWith(buffered));
+
+    handler({ body: '{"eventType":"CHAT_MESSAGE_SENT"}' });
+    expect(mockHandleEvent).toHaveBeenCalledTimes(2);
+  });
+
+  test('setup 실패 시 구독을 해제하고 로비로 이동한다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockRejectedValue(new Error('setup failed'));
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    enterAndGetSubscribedHandler(7);
+
+    await vi.waitFor(() => expect(mockPush).toHaveBeenCalledWith('/parties'));
+    // 입장 실패한 방의 구독이 남으면 유령 구독이 된다
+    expect(mockUnsubscribeCurrentRoom).toHaveBeenCalled();
+  });
+
+  test('재연결 재수화(reactivated) 중 도착한 이벤트도 스냅샷에 덮이지 않는다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const { result } = renderHook(() => useEnterPartyroom(7));
+    act(() => result.current());
+    mockOnConnect.mock.calls[0][0]();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER' });
+    const handler = mockSubscribe.mock.calls[0][1] as (message: unknown) => void;
+
+    await vi.waitFor(() => expect(mockInit).toHaveBeenCalled());
+    mockHandleEvent.mockClear();
+    mockInit.mockClear();
+
+    // 재연결 → reactivated 재수화 시작
+    const resync = mockSetRoomReconnectHandler.mock.calls[0][0] as () => void;
+    mockMutate.mockClear();
+    resync();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER', reactivated: true });
+
+    const message = { body: '{"eventType":"CREW_ENTERED"}' };
+    handler(message);
+    expect(mockHandleEvent).not.toHaveBeenCalled(); // 재수화 중 — 보류
+
+    await vi.waitFor(() => expect(mockHandleEvent).toHaveBeenCalledWith(message));
+    expect(mockInit.mock.invocationCallOrder[0]).toBeLessThan(
+      mockHandleEvent.mock.invocationCallOrder[0]
+    );
   });
 });
 

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.test.ts
@@ -38,6 +38,12 @@ const mockInvalidateQueries = vi.fn();
 const mockTrackerClear = vi.fn();
 const mockSeedFromSetup = vi.fn();
 const mockSubscribe = vi.fn();
+const mockUpdateCrews = vi.fn();
+let storeRoomId = 7;
+let storeCrews: { crewId: number }[] = [];
+const setStoreRoomId = (id: number) => {
+  storeRoomId = id;
+};
 const mockUnsubscribeCurrentRoom = vi.fn();
 const mockHandleEvent = vi.fn();
 
@@ -50,8 +56,17 @@ beforeEach(() => {
     unsubscribeCurrentRoom: mockUnsubscribeCurrentRoom,
   });
   (useHandlePartyroomSubscriptionEvent as Mock).mockReturnValue(mockHandleEvent);
+  storeRoomId = 7;
+  storeCrews = [];
   const state = {
+    get id() {
+      return storeRoomId;
+    },
     init: mockInit,
+    get crews() {
+      return storeCrews;
+    },
+    updateCrews: mockUpdateCrews,
     playbackSummaryTracker: { clear: mockTrackerClear, seedFromSetup: mockSeedFromSetup },
   };
   (useStores as Mock).mockReturnValue({
@@ -302,6 +317,149 @@ describe('스냅샷-구독 유실 구간 차단 (#491)', () => {
     expect(mockInit.mock.invocationCallOrder[0]).toBeLessThan(
       mockHandleEvent.mock.invocationCallOrder[0]
     );
+  });
+});
+
+describe('구독 등록 지연 보정 (#491 self-heal)', () => {
+  const SETUP_RESPONSE = {
+    stageType: 'GENERAL',
+    crews: [{ crewId: 1, nickname: '나', gradeType: 'CLUBBER' }],
+    display: { playbackActivated: false },
+  };
+  const RECONCILE_TIMEOUT = { timeout: 4_000 };
+
+  // 보정은 실시간 타이머로 예약되므로 앞선 테스트의 예약분이 뒤 테스트 도중 발화한다.
+  // 테스트마다 방 번호를 다르게 쓰고 스토어 id 를 거기에 맞추면, 흘러온 보정은
+  // "다른 방" 가드에 걸려 조기 return 하므로 서로를 오염시키지 않는다.
+  const enterRoom = (partyroomId: number) => {
+    setStoreRoomId(partyroomId);
+    const { result } = renderHook(() => useEnterPartyroom(partyroomId));
+    act(() => result.current());
+    mockOnConnect.mock.calls[0][0]();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER' });
+    return mockSubscribe.mock.calls[0][1] as (message: unknown) => void;
+  };
+
+  test('초기 스냅샷 적용 후 crews 스냅샷을 한 번 다시 맞춘다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue({
+      ...SETUP_RESPONSE,
+      crews: [
+        { crewId: 1, nickname: '나', gradeType: 'CLUBBER' },
+        { crewId: 2, nickname: '늦게 반영된 크루', gradeType: 'CLUBBER' },
+      ],
+    });
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    enterRoom(1101);
+
+    // 초기 setup 1회 → 보정으로 1회 더
+    await vi.waitFor(
+      () => expect(partyroomsService.getSetupInfo).toHaveBeenCalledTimes(2),
+      RECONCILE_TIMEOUT
+    );
+    await vi.waitFor(() => expect(mockUpdateCrews).toHaveBeenCalled(), RECONCILE_TIMEOUT);
+    expect(mockUpdateCrews.mock.calls[0][0]()).toEqual([
+      expect.objectContaining({ crewId: 1 }),
+      expect.objectContaining({ crewId: 2 }),
+    ]);
+  });
+
+  test('어긋난 게 없으면 스토어를 건드리지 않는다 (불필요한 리렌더 방지)', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    enterRoom(1105);
+    storeCrews = [{ crewId: 1 }]; // 스냅샷과 동일한 멤버십
+
+    await vi.waitFor(
+      () => expect(partyroomsService.getSetupInfo).toHaveBeenCalledTimes(2),
+      RECONCILE_TIMEOUT
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockUpdateCrews).not.toHaveBeenCalled();
+  });
+
+  test('이미 있는 크루의 라이브 상태는 보정이 되돌리지 않는다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue({
+      ...SETUP_RESPONSE,
+      crews: [
+        { crewId: 1, nickname: '나', gradeType: 'CLUBBER' },
+        { crewId: 2, nickname: '놓쳤던 크루', gradeType: 'CLUBBER' },
+      ],
+    });
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    enterRoom(1106);
+    const liveCrew = { crewId: 1, reactionType: 'LIKE', motionType: 'DANCE' };
+    storeCrews = [liveCrew];
+
+    await vi.waitFor(() => expect(mockUpdateCrews).toHaveBeenCalled(), RECONCILE_TIMEOUT);
+
+    const next = mockUpdateCrews.mock.calls[0][0]();
+    expect(next[0]).toBe(liveCrew); // 동일 참조 — 반응/모션이 스냅샷으로 덮이지 않는다
+    expect(next[1]).toEqual(expect.objectContaining({ crewId: 2 }));
+  });
+
+  test('보정 중 도착한 이벤트는 보류됐다가 보정 후 재생된다', async () => {
+    let resolveReconcile: ((value: unknown) => void) | undefined;
+    (partyroomsService.getSetupInfo as Mock)
+      .mockResolvedValueOnce(SETUP_RESPONSE)
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveReconcile = resolve)));
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const handler = enterRoom(1102);
+    await vi.waitFor(() => expect(resolveReconcile).toBeDefined(), RECONCILE_TIMEOUT);
+    mockHandleEvent.mockClear();
+
+    const message = { body: '{"eventType":"CREW_ENTERED"}' };
+    handler(message);
+    expect(mockHandleEvent).not.toHaveBeenCalled(); // 보정 중 — 보류
+
+    resolveReconcile?.(SETUP_RESPONSE);
+    await vi.waitFor(() => expect(mockHandleEvent).toHaveBeenCalledWith(message), RECONCILE_TIMEOUT);
+  });
+
+  test('보정 요청이 실패해도 버퍼는 풀린다', async () => {
+    (partyroomsService.getSetupInfo as Mock)
+      .mockResolvedValueOnce(SETUP_RESPONSE)
+      .mockRejectedValueOnce(new Error('reconcile failed'));
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    const handler = enterRoom(1103);
+    await vi.waitFor(
+      () => expect(partyroomsService.getSetupInfo).toHaveBeenCalledTimes(2),
+      RECONCILE_TIMEOUT
+    );
+    mockHandleEvent.mockClear();
+
+    const message = { body: '{"eventType":"CHAT_MESSAGE_SENT"}' };
+    await vi.waitFor(() => {
+      handler(message);
+      expect(mockHandleEvent).toHaveBeenCalled();
+    }, RECONCILE_TIMEOUT);
+  });
+
+  test('보정 시점에 다른 방으로 옮겼으면 crews 를 덮지 않는다', async () => {
+    (partyroomsService.getSetupInfo as Mock).mockResolvedValue(SETUP_RESPONSE);
+    (partyroomsService.getNotice as Mock).mockResolvedValue({ content: null });
+
+    setStoreRoomId(1104);
+    const { result } = renderHook(() => useEnterPartyroom(999)); // 스토어 id(1104)와 다른 방
+    act(() => result.current());
+    mockOnConnect.mock.calls[0][0]();
+    mockMutate.mock.calls[0][1].onSuccess({ crewId: 1, gradeType: 'LISTENER' });
+
+    await vi.waitFor(() => expect(mockInit).toHaveBeenCalled(), RECONCILE_TIMEOUT);
+    mockUpdateCrews.mockClear();
+    const setupCallsBeforeReconcile = (partyroomsService.getSetupInfo as Mock).mock.calls.length;
+
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    expect((partyroomsService.getSetupInfo as Mock).mock.calls.length).toBe(
+      setupCallsBeforeReconcile
+    );
+    expect(mockUpdateCrews).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -23,6 +23,12 @@ type Options = {
   entrySource?: EntrySource;
 };
 
+/**
+ * 구독 등록 지연을 넉넉히 덮는 보정 시점. 측정된 지연은 수십 ms 수준이라 1s 면 충분한 여유가 있고,
+ * 초기 렌더 이후에 도는 보정이라 늦어도 사용자 체감엔 영향이 없다.
+ */
+const CREWS_RECONCILE_DELAY_MS = 1_000;
+
 export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   const client = usePartyroomClient();
   const handleEvent = useHandlePartyroomSubscriptionEvent();
@@ -43,6 +49,56 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
     eventBufferRef.current = createSubscriptionEventBuffer(() => handleEventRef.current);
   }
   const eventBuffer = eventBufferRef.current;
+
+  /**
+   * #491 구독 등록 지연 보정 (self-heal).
+   *
+   * `SUBSCRIBE` 프레임을 보낸 시각과 브로커가 실제로 구독을 등록하는 시각 사이에는 간격이 있고,
+   * STOMP 는 SUBSCRIBE 에 ack 가 없어(Spring `enableSimpleBroker` 는 DISCONNECT 에만 RECEIPT 를
+   * 보낸다) 클라이언트가 등록 완료를 알 방법이 없다. 그래서 구독을 스냅샷보다 먼저 보내도
+   * "프레임 전송 ~ 등록 완료" 사이의 `CREW_ENTERED` 는 여전히 유실될 수 있다
+   * (측정: 유실률 37.5% → 8%, 구독-스냅샷 사이에 500ms 를 강제로 넣으면 0%).
+   *
+   * 등록이 확실히 끝났을 시점에 crews 스냅샷을 한 번 다시 맞춰 그 잔여분을 복구한다. 초기 렌더는
+   * 이미 첫 스냅샷으로 끝났으므로 사용자 체감 지연은 없다. 재조회 중 도착분은 버퍼가 보류했다가
+   * 재생하므로, 뒤늦게 적용되는 스냅샷이 그 사이 이벤트를 덮지 않는다.
+   */
+  const scheduleCrewsReconcile = () => {
+    setTimeout(async () => {
+      // 방을 떠났거나 다른 방으로 옮겼으면 낡은 방의 crews 로 덮지 않는다.
+      if (useCurrentPartyroom.getState().id !== partyroomId) return;
+
+      eventBuffer.hold();
+      try {
+        const setUpInfo = await partyroomsService.getSetupInfo({ partyroomId });
+        if (useCurrentPartyroom.getState().id !== partyroomId) return;
+
+        const motionTypeMap = crewIdToMotionTypeMap(setUpInfo.display.reaction?.motion);
+        const { crews: currentCrews, updateCrews } = useCurrentPartyroom.getState();
+        const currentById = new Map(currentCrews.map((crew) => [crew.crewId, crew]));
+        const membershipMatches =
+          currentCrews.length === setUpInfo.crews.length &&
+          setUpInfo.crews.every((crew) => currentById.has(crew.crewId));
+
+        // 어긋난 게 없으면 스토어를 건드리지 않는다. 대부분의 입장은 이 경로로,
+        // 불필요한 리렌더나 라이브 상태 손실이 생기지 않는다.
+        if (membershipMatches) return;
+
+        updateCrews(() =>
+          setUpInfo.crews.map((crew) => {
+            // 이미 있는 크루는 스토어 객체를 그대로 둔다 — 스냅샷에 없는 라이브 필드
+            // (모션·반응·마지막 채팅)를 보정이 되돌리지 않도록.
+            const existing = currentById.get(crew.crewId);
+            return existing ?? { ...crew, motionType: motionTypeMap.get(crew.crewId) ?? MotionType.NONE };
+          })
+        );
+      } catch {
+        // 보정 실패는 조용히 넘긴다 — 원래 상태를 유지할 뿐 악화시키지 않는다.
+      } finally {
+        eventBuffer.release();
+      }
+    }, CREWS_RECONCILE_DELAY_MS);
+  };
 
   const setup = async (enterResponse: EnterResponse) => {
     // L1: 방 enter/재수화 시작 시 무조건 clear — 이전 방 스냅샷이 새 방 채팅에 방출되는 누출 방지
@@ -167,6 +223,7 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
                   queryClient.invalidateQueries({
                     queryKey: [QueryKeys.DjingQueue, partyroomId],
                   });
+                  scheduleCrewsReconcile();
                 },
                 onError: () => {
                   client.unsubscribeCurrentRoom(); // 입장 실패한 방의 유령 구독을 남기지 않는다

--- a/src/features/partyroom/enter/lib/use-enter-partyroom.ts
+++ b/src/features/partyroom/enter/lib/use-enter-partyroom.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   useHandlePartyroomSubscriptionEvent,
@@ -12,6 +13,10 @@ import { trackPartyroomEntered } from '@/shared/lib/analytics/room-tracking';
 import silent from '@/shared/lib/functions/silent';
 import { useAppRouter } from '@/shared/lib/router/use-app-router.hook';
 import { useStores } from '@/shared/lib/store/stores.context';
+import {
+  createSubscriptionEventBuffer,
+  type SubscriptionEventBuffer,
+} from './subscription-event-buffer';
 import { useEnterPartyroom as useEnterPartyroomMutation } from '../api/use-enter-partyroom.mutation';
 
 type Options = {
@@ -28,6 +33,16 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
   const router = useAppRouter();
 
   const entrySource: EntrySource = options.entrySource ?? 'direct';
+
+  // #491 구독 핸들러는 방마다 1회만 등록되지만 handleEvent 는 렌더마다 새로 만들어진다.
+  // ref 로 최신 핸들러를 가리켜 버퍼가 stale closure 를 잡지 않게 한다.
+  const handleEventRef = useRef(handleEvent);
+  handleEventRef.current = handleEvent;
+  const eventBufferRef = useRef<SubscriptionEventBuffer>();
+  if (!eventBufferRef.current) {
+    eventBufferRef.current = createSubscriptionEventBuffer(() => handleEventRef.current);
+  }
+  const eventBuffer = eventBufferRef.current;
 
   const setup = async (enterResponse: EnterResponse) => {
     // L1: 방 enter/재수화 시작 시 무조건 clear — 이전 방 스냅샷이 새 방 채팅에 방출되는 누출 방지
@@ -115,8 +130,14 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
                   queryClient.invalidateQueries({ queryKey: [QueryKeys.DjingQueue, partyroomId] });
                 if (enterResponse.reactivated) {
                   // 멤버십 상실 → 풀 재수화(검정 해소). 룸 재구독은 추가하지 않음(handleConnect 가 이미 reconcile).
+                  // #491 재수화도 스냅샷 경계를 다시 지난다 — 적용 전 도착분을 보류했다가 재생한다.
+                  // 실패 경로에선 보류를 풀지 않는다(로비로 나가므로 낡은 이벤트를 재생할 이유가 없다).
+                  eventBuffer.hold();
                   silent(setup(enterResponse), {
-                    onSuccess: invalidateDjQueue,
+                    onSuccess: () => {
+                      eventBuffer.release();
+                      invalidateDjQueue();
+                    },
                     onError: () => router.push('/parties'),
                   });
                 } else {
@@ -133,14 +154,22 @@ export function useEnterPartyroom(partyroomId: number, options: Options = {}) {
           { partyroomId },
           {
             onSuccess: (enterResponse) => {
+              // #491 스냅샷(GET /setup)보다 **먼저** 구독한다. 반대 순서였을 때는 스냅샷 생성 시점부터
+              // 구독이 브로커에 등록되기까지의 이벤트가 통째로 유실됐고(동시 입장 시 상대 크루가
+              // 영원히 안 보임), 자가치유 경로가 없어 새로고침 전까지 복구되지 않았다.
+              // 스냅샷 적용 전 도착분은 버퍼가 보류했다가 initPartyroom 이후 재생한다.
+              eventBuffer.hold();
+              client.subscribe(partyroomId, eventBuffer.handle);
+
               silent(setup(enterResponse), {
                 onSuccess: () => {
-                  client.subscribe(partyroomId, handleEvent);
+                  eventBuffer.release();
                   queryClient.invalidateQueries({
                     queryKey: [QueryKeys.DjingQueue, partyroomId],
                   });
                 },
                 onError: () => {
+                  client.unsubscribeCurrentRoom(); // 입장 실패한 방의 유령 구독을 남기지 않는다
                   router.push('/parties'); // 에러 발생 시 로비로 이동
                 },
               });


### PR DESCRIPTION
Close #491

## 원인 — 이슈 본문의 전제를 정정한다

이슈는 "다른 사용자의 DJ 큐 등록이 전파되지 않는다"로 적혀 있지만, **DJ 큐 이벤트는 정상 도착하고 있었다.** 유실되는 것은 `CREW_ENTERED` 다.

실패를 재현해 계측한 결과(계측은 테스트 프로세스 측에만 — 앱에 인페이지 로깅을 심으면 관측자 효과로 플래키가 사라진다):

```
server GET /dj-queue : djs=[909(order1), 910(order2)]        ← 서버 정상
user1 수신 WS 이벤트  : DJ_QUEUE_CHANGED ×3, PLAYBACK_STARTED ×1, CREW_ENTERED ×0
user1 DOM            : currentDj=[909], queueItems=[], crewItems=[]   ← 910 이 어디에도 없음
user2 DOM            : currentDj=[909], queueItems=[910]              ← 정상
```

user1 은 user2 의 큐 등록 이벤트를 **받았고** react-query 캐시의 `djs` 에도 910 이 들어갔다. 그럼에도 0 인 이유는 대기열 아바타가 두 데이터의 **교집합**으로 렌더되기 때문이다 — `avatars.component.tsx` 의 `crews.filter((c) => djQueueIdSet.has(c.crewId))`. `crews`(zustand)에 910 이 없으니 큐 데이터가 맞아도 아바타는 0 명이다.

즉 `[data-testid="partyroom-dj-queue-item"]` 는 DJ 큐 지표가 아니라 **크루 목록 ∩ DJ 큐** 지표였다. 이슈에 적힌 "user1 이 `/dj-queue` 를 재조회하지 않는다"는 관찰도 결함의 근거가 아니다 — 캐시가 warm 이면 `use-dj-queue-changed-callback` 이 `setQueryData` 로 제자리 갱신하므로 **재조회가 없는 것이 정상 동작**이다.

**e2e 전용 문제가 아니다.** 프로덕션에서도 동시 입장 시 서로의 아바타가 안 보이는 형태로 발생하고, `crews` 에는 자가치유 경로가 없어 새로고침 전까지 유지된다.

## 유실 구간은 두 겹이었다

### 1. 스냅샷 → 구독 (커밋 1)

입장 절차가 `enter → setup 스냅샷 적용 → 구독` 순서였다.

```
10255ms  user1 ENTER 201
~10290ms user1 /setup 스냅샷 생성 → crews=[909]      ← user2 아직 없음
10301ms  user1 SUBSCRIBE /sub/partyrooms/489
10314ms  user2 ENTER 201 (crew 910) → CREW_ENTERED 발행
```

스냅샷 생성부터 구독 등록까지의 이벤트는 아무에게도 전달되지 않는다. `DJ_QUEUE_CHANGED` 는 큐 전체를 싣고 반복 도착해 살아남지만, `CREW_ENTERED` 는 델타를 1 회만 싣기 때문에 이 구간에 걸리면 영구 유실된다.

구독을 스냅샷보다 **먼저** 건다. 다만 그것만으로는 부족하다 — 스냅샷 생성 후 적용(initPartyroom) 전에 도착한 이벤트는 뒤이어 적용되는 **더 낡은** 스냅샷에 덮인다. 그래서 적용 전까지는 버퍼가 보류했다가 적용 직후 도착 순서대로 재생한다.

재생은 at-least-once 다. 룸 이벤트 핸들러가 멱등이라 안전하다 — `CREW_ENTERED` 는 upsert, `DJ_QUEUE_CHANGED` 는 큐 전체를 싣고, `PLAYBACK_STARTED` 는 `eventId` 로 중복 방출을 막는다(`playback-summary-tracker`).

### 2. 구독 프레임 전송 → 브로커 등록 (커밋 2)

구독을 먼저 걸어도 재현율이 0 이 되지 않았다. `SUBSCRIBE` 프레임을 보낸 시각과 브로커가 실제로 등록하는 시각 사이가 남는데, STOMP 는 SUBSCRIBE 에 ack 가 없고 Spring `enableSimpleBroker` 는 **DISCONNECT 에만 RECEIPT** 를 보내므로 클라이언트가 등록 완료를 알 방법이 없다.

구독과 setup 사이에 500ms 를 강제로 넣은 빌드로 이 가설을 확인했다(아래 표).

초기 조회를 지연시키면 첫 화면이 늦어지므로, 대신 **등록이 확실히 끝났을 시점에 crews 스냅샷을 한 번 다시 맞춘다.** 초기 렌더는 첫 스냅샷으로 이미 끝나 있어 사용자 체감 지연은 없다.

- 멤버십이 일치하면 스토어를 건드리지 않는다. 대부분의 입장이 이 경로라 불필요한 리렌더가 없다.
- 어긋났을 때도 이미 있는 크루는 스토어 객체를 그대로 재사용한다. setup 스냅샷에는 모션·반응·마지막 채팅 같은 라이브 필드가 없어, 통째로 교체하면 보정이 이들을 되돌려 버린다.
- 보정 중 도착분은 버퍼가 보류했다가 재생한다.
- 방을 옮겼으면 낡은 방의 crews 로 덮지 않는다. 보정 실패는 조용히 넘긴다.

## 검증

로컬 프로덕션 빌드 + docker 백엔드에서 `e2e-b.dj-state-machine` 반복. 실패는 **시그니처로 분류**했다(같은 테스트가 #443 으로도 깨지므로).

| 빌드 | #491 시그니처 | #443(`closeDjQueueDrawer`) |
|---|---|---|
| 수정 전 | 6/16 (37.5%) | — |
| ① 구독 먼저 + 버퍼 재생 | 2/24 → 5/30 | 1/24, 3/30 |
| ① + 구독·스냅샷 사이 500ms (진단용) | **0/25** | 1/25 |
| ② ① + crews 보정 (이 PR) | **0/30** | 6/30 |

①과 ②는 같은 머신·같은 세션에서 보정만 켜고 끈 A/B 다 — **5/30 → 0/30**. #443 은 3/30 vs 6/30 으로 통계적으로 구분되지 않는다(p≈0.47). #443 은 이 PR 범위 밖의 기존 이슈다.

단위 테스트 전체 GREEN. 회귀 방어 추가 — 구독이 setup 보다 먼저인지, 보류분이 init 이후 재생되는지, 버퍼가 재생 후 비워지는지, setup 실패 시 구독 해제, 재수화 경로 보류-재생, 보정 수행/미수행 조건, 라이브 필드 보존, 방 이동 시 미적용.

## 남는 것 (이 PR 범위 밖)

`crews` 에 자가치유가 아예 없던 것을 이 보정이 메우지만, 근본적으로는 **구독 시점에 서버가 스냅샷을 밀어주는 쪽**이 옳다(등록 이후에 생성되므로 레이스가 원천 소멸). platform 레포 변경이라 별건으로 다루는 것이 맞다.
